### PR TITLE
Handle gradE of a sumbuild

### DIFF
--- a/src/ksc/AD.hs
+++ b/src/ksc/AD.hs
@@ -91,6 +91,13 @@ gradE s (Call f [n, Lam ti body])
     mkLet (gradTVar s ti) (lmZero s (typeof  ti)) $
     gradE s body
 
+-- AD does not currently have rules for handling primitive sumbuild.
+-- Instead we deoptimize by just treating it as though it were a sum
+-- and a build.  It can be optimized again by a later stage of the
+-- pipeline.
+  | f `isThePrimFun` "sumbuild"
+  = gradE s (pSum (pBuild n (Lam ti body)))
+
 -- Currently ignoring $inline when gradding.  Perhaps we should
 -- perform the inlining before gradding.
 gradE s (Call f [arg])


### PR DESCRIPTION
Previously it failed because it encountered the lambda in the sumbuild and complained that it didn't know what to do.

Perhaps later we can handle this in a more intelligent way.  This PR is a bandaid so I can implement tests for the `demoF` pipeline.

This did lead to problems in practice because it meant that the `demoF` pipeline was incapable of running any of our examples where `sum` occurred next to `build`.
