### PR TITLE
Ensure that we don't incorrectly capture variables when performing ANF

### DIFF
--- a/src/ksc/ANF.hs
+++ b/src/ksc/ANF.hs
@@ -7,7 +7,7 @@
 module ANF where
 
 import Lang
-import OptLet( Subst, extendSubstInScope, lookupSubst, mkEmptySubst )
+import OptLet( Subst, extendSubstInScope, mkEmptySubst, substVar )
 import Prim( isThePrimFun )
 import KMonad
 import Control.Monad( ap )
@@ -42,10 +42,7 @@ anfExpr subst e = wrapLets (anfE subst e)
 anfE :: Subst -> TExpr -> AnfM Typed TExpr
 anfE subst (Tuple es)    = Tuple <$> mapM (anfE1 subst) es
 anfE _ (Konst k)         = return (Konst k)
-anfE subst (Var tv)      = return (case lookupSubst v subst of
-                                      Just e  -> e
-                                      Nothing -> Var tv)
-  where TVar _ v = tv
+anfE subst (Var tv)      = return (substVar subst tv)
 anfE subst (Call fun es)
  | fun `isThePrimFun` "build"   -- See Note [Do not ANF first arg of build]
  , [e1,e2] <- es


### PR DESCRIPTION
Before

```
----------------------------
Typechecked declarations
----------------------------

def tiny Float (r : Float, x : Float)
  = (let { v = (let { r = x + x }
                r * r) }
     v + r)
Linted Typechecked declarations

----------------------------
Anf-ised original definition
----------------------------

def tiny Float (r : Float, x : Float)
  = (let { r = x + x }
     (let { v = r * r }
      v + r))
Linted Anf-ised original definition
```

After

```
----------------------------
Typechecked declarations
----------------------------

def tiny Float (r : Float, x : Float)
  = (let { v = (let { r = x + x }
                r * r) }
     v + r)
Linted Typechecked declarations

----------------------------
Anf-ised original definition
----------------------------

def tiny Float (r : Float, x : Float)
  = (let { r_1 = x + x }
     (let { v = r_1 * r_1 }
      v + r))
Linted Anf-ised original definition
```