### PR TITLE
An empty vector is zero

### DIFF
--- a/src/runtime/knossos.h
+++ b/src/runtime/knossos.h
@@ -418,7 +418,7 @@ namespace ks
 		vec() :
 			size_{ 0 },
 			data_{ nullptr },
-			is_zero_{ false },
+			is_zero_{ true },
 			z_{T{}}
 		{
 		}


### PR DESCRIPTION
A vector of zero length is always zero.  This change is needed for my forthcoming fold PR.  In its absence I have some difficulty creating zero vectors.