### PR TITLE
Make tests more generalizable

### DIFF
--- a/test/ksc/gmm.ks
+++ b/test/ksc/gmm.ks
@@ -259,8 +259,13 @@
 
           (tuple "Checked, should be small:" checked)
 
+          "TESTS FOLLOW"
+          "Golden test GMM objective"
           golden_test_gmm_objective
+          "Reverse mode as expected"
           everything_works_as_expected_reverse
+          "Forward mode as expected"
           everything_works_as_expected
+          "Not impossibly good"
           (not_ impossibly_good)
           )))


### PR DESCRIPTION
Currently our GMM test code is hardcoded with a list of things it tests.  I'd like to make our test code more flexible, in particular so it's easier to add new tests to GMM and other `.ks` files.

See the following line onwards for the new test format.

https://github.com/microsoft/knossos-ksc/compare/toelli/test?expand=1#diff-ddab5f4c5653e44124328f10423de615R262

@awf is probably the best reviewer but if @simonpj or @acl33 can give it a once over before him then that's fine too.