### PR TITLE
Support 'or' and 'and' builtins in Futhark code generator.

### DIFF
--- a/src/ksc/Ksc/Futhark.hs
+++ b/src/ksc/Ksc/Futhark.hs
@@ -325,6 +325,12 @@ callPrimFun "index" _ [i, arr] =
     arr' ->
       Index arr' [toFutharkExp i]
 
+callPrimFun "or" _ [x, y] =
+  BinOp "||" (toFutharkExp x) (toFutharkExp y)
+
+callPrimFun "and" _ [x, y] =
+  BinOp "&&" (toFutharkExp x) (toFutharkExp y)
+
 callPrimFun "pr" _ es =
   ExpTuple $ map toFutharkExp es
 


### PR DESCRIPTION
The semantics are strictly not the same, since I am mapping them to short-circuiting operators, but I doubt it will matter.