### PR TITLE
Only use to_float if the body is not an integer.

### DIFF
--- a/src/ksc/Opt.hs
+++ b/src/ksc/Opt.hs
@@ -467,7 +467,10 @@ optSumBuild n i (Tuple es)
 optSumBuild sz i e
   | TVar TypeInteger _ <- i
   , i `notFreeIn` e
-  = Just $ pMul (mkPrimCall1 "to_float" sz) e
+  = Just $ pMul sz' e
+    where sz' = case typeof e of
+                  TypeInteger -> sz
+                  _ -> mkPrimCall1 "to_float" sz
 
 -- RULE: sumbuild n (\i. delta i ej e)    where i is not free in ej
 --       = let i = ej in e


### PR DESCRIPTION
I'm not completely sure this is right.  What if the body is an array of integers?  Is that allowed?  However, in that case the old rule was wrong too, unless `to_float` is overloaded to also operate on arrays.