### PR TITLE
Fix logsumexp test

### DIFF
--- a/src/ksc/Main.hs
+++ b/src/ksc/Main.hs
@@ -252,11 +252,7 @@ ksTestFiles :: String -> IO [String]
 ksTestFiles testDir = do
   let last n xs = drop (length xs - n) xs
 
-      naughtyTestsThatDon'tWorkButShouldBeFixedAndRemovedFromThisList
-        = ["logsumexp.ks"]
-
     in fmap (map (testDir ++)
-             . filter (not . (`elem` naughtyTestsThatDon'tWorkButShouldBeFixedAndRemovedFromThisList))
              . filter ((== ".ks") . last 3))
             (System.Directory.listDirectory testDir)
 
@@ -286,6 +282,7 @@ futharkCompileKscPrograms ksFiles = do
           "test/ksc/edef.ks"
           -- Doesn't handle dummy variables
         , "test/ksc/fold.ks"
+        , "test/ksc/logsumexp.ks"
         , "test/ksc/vprod.ks"
           -- Doesn't handle recursion
         , "test/ksc/power.ks"

--- a/test/ksc/logsumexp.ks
+++ b/test/ksc/logsumexp.ks
@@ -1,15 +1,31 @@
 ; Copyright (c) Microsoft Corporation.
 ; Licensed under the MIT license.
-(def exp. (Vec Float) (v : Vec Float)
-    (build (size v) (lam (i : Integer) (exp (index i v)))))
+(def exp$Vec (Vec n Float) (v : Vec n Float)
+     (build n (lam (i : Integer) (exp (index i v)))))
 
-(def logsumexp Float (v : Vec Float)
-    (log (sum (exp. v))))
+(def logsumexp Float (v : Vec n Float)
+    (log (sum (exp$Vec v))))
 
-(def logsumexp_inlined Float (v : Vec Float)
-    (log (sum (build (size v) (lam (i : Integer) (exp (index i v)))))))
+(def logsumexp_inlined Float (v : Vec n Float)
+    (log (sum (build n (lam (i : Integer) (exp (index i v)))))))
 
-(def logsumexp_safe Float ( a : Vec Float)
-  (let (mx (max a))
-    (let (sum_exp_minus_x (sum (exp$Vec (sub$Vec<R>$R a mx))))
+(def sub$VecR$R (Vec n Float) ((v : Vec n Float) (x : Float))
+     (build n (lam (ni : Integer) (- (index ni v) x))))
+
+(def max_ Float ((x : Float) (y : Float)) (if (> x y) x y))
+
+(def max$VecR Float (v : Vec n Float)
+     (let ; We can't write -inf in a .ks file so use something very
+          ; small instead
+          (neg_infinity -1e38)
+       (fold (lam (max_so_far_x : Tuple Float Float)
+                  (let ((max_so_far (get$1$2 max_so_far_x))
+                        (x (get$2$2 max_so_far_x)))
+                    (max_ max_so_far x)))
+             neg_infinity
+             v)))
+
+(def logsumexp_safe Float (a : Vec n Float)
+  (let (mx (max$VecR a))
+    (let (sum_exp_minus_x (sum (exp$Vec (sub$VecR$R a mx))))
         (+ (log sum_exp_minus_x) mx))))


### PR DESCRIPTION
that had never previously worked

It would be nice to get this in because there's currently a special case that excludes it from being tested.  The other alternative would be to just remove it.