### PR TITLE
Added rules to reorder if expressions

### DIFF
--- a/doc/rules.md
+++ b/doc/rules.md
@@ -25,7 +25,19 @@ sum (build k (lam ki e))
 
 sumbuild k (lam ki (deltaVec o i e))
   = deltaVec o i (sumbuild k (lam ki e))
+# ki should not appear free in o or i
 
 sumbuild k (lam ki (deltaVec k ki e))
   = build k (lam ki e)
+
+sumbuild k (lam ki (if c t f))
+  = if c (sumbuild k (lam ki t)) (sumbuild k (lam ki f))
+# ki should not appear free in c
+
+build k (lam ki (if c t f))
+  = if c (build k (lam ki t)) (build k (lam ki f))
+# ki should not appear free in c
+
+op (if c t f)
+  = if c (op t) (op f)
 ```


### PR DESCRIPTION
Added three rules to better optimize the machine learning codes.
We need these to optimize conv1d in particular to remove deltaVecs nested inside if expressions.

The condition c in the if expression should be independent to the bound variable li (How do I represent it in the rule?).