### PR TITLE
Specify cabal 2.4.1.0 on Windows

### DIFF
--- a/test/builds/install_windows.bat
+++ b/test/builds/install_windows.bat
@@ -4,6 +4,7 @@ echo ----- test g++ installation -----
 g++ --version
 where g++
 echo ----- install ghc -----
+choco install cabal --version 2.4.1.0 -y || exit /b
 choco install ghc --version 8.4.4 -y || exit /b
 echo ----- cabal install -----
 refreshenv && cabal new-update && cabal install hspec parsec mtl hashable || exit /b


### PR DESCRIPTION
because 3.0.0.0 was causing a build failure.

https://msrcambridge.visualstudio.com/Knossos/_build/results?buildId=37436

"Cannot build the executables in the package parsec because it does not contain
any executables. Check the .cabal file for the package and make sure that it
properly declares the components that you expect."

Maybe we should be switching to new-build and not installing packages
manually, but we'll do this for now.