### PR TITLE
Bump a dependency

### DIFF
--- a/knossos.cabal
+++ b/knossos.cabal
@@ -24,7 +24,7 @@ executable ksc
   build-depends: base >= 4.9,
                  pretty >= 1.1,
                  filepath >= 1.4.1.1,
-                 hspec >= 2.5,
+                 hspec >= 2.6.1,
                  hashable >= 1.2,
                  mtl >= 2.2,
                  parsec >= 3.1,


### PR DESCRIPTION
We use runSpec which requires hspec >= 2.6.1         

http://hackage.haskell.org/package/hspec-2.6.0/docs/doc-index-R.html

http://hackage.haskell.org/package/hspec-2.6.1/docs/doc-index-R.html
