### PR TITLE
No more symbols

### DIFF
--- a/src/ksc/Prim.hs
+++ b/src/ksc/Prim.hs
@@ -7,7 +7,6 @@ module Prim where
 import Lang
 import GHC.Stack
 import Control.Monad( zipWithM )
-import Data.Tuple( swap )
 
 --------------------------------------------
 --  Simple call construction
@@ -74,7 +73,7 @@ mk_fun f = case find_dollar f of
              Just ("get", s) -> Fun     (mk_sel_fun s)
              _               -> Fun     (mk_fun_id f)
   where
-    mk_fun_id f | isPrimFun_ f = PrimFun (translate_fun f)
+    mk_fun_id f | isPrimFun f = PrimFun f
                 | otherwise   = UserFun f
     find_dollar f = case break (== '$') f of
                        (_, [])  -> Nothing  -- No $
@@ -83,12 +82,6 @@ mk_fun f = case find_dollar f of
     mk_sel_fun s = case break (== '$') s of
                      (i,_:n) -> SelFun (read i :: Int) (read n :: Int)
                      _ -> error $ "'get' should have form 'get$i$n', not [get$" ++ s ++ "]"
-    isPrimFun_ f = (f `elem` (map fst translation)) || isPrimFun f
-    translation = map swap $
-                  []
-    translate_fun f = case lookup f translation of
-      Just s  -> s
-      Nothing -> f
 
 
 --------------------------------------------


### PR DESCRIPTION
Until now, symbolic operators were translated to alphabetic ones when a `.ks` file was parsed.  This was to allow a transitionary period during which old code would still work, allowing some breathing room to convert to the new format.  I think the time has come to definitively switch over to the alphabetic operators.