### PR TITLE
Toelli/throw

### DIFF
--- a/src/runtime/knossos-prelude.h
+++ b/src/runtime/knossos-prelude.h
@@ -79,19 +79,16 @@ vec<double> rev$maximum(vec<double> const& v, double dr)
 
 double digamma(double x)
 {
-	std::cerr << "digamma unimp!\n";
-	return 1.0;
+	throw "digamma unimp!\n";
 }
 
 double rev$lgamma(double x, double dr)
 {
-	std::cerr << "rev$gamma unimp!\n";
-	return 1.0;
+	throw "rev$gamma unimp!\n";
 }
 double fwd$lgamma(double x, double dx)
 {
-	std::cerr << "fwd$gamma unimp!\n";
-	return 1.0;
+	throw "fwd$gamma unimp!\n";
 }
 
 double pow$aFloat(double x, double e)
@@ -101,14 +98,12 @@ double pow$aFloat(double x, double e)
 
 double fwd$pow$aFloat(double x, double e, double dx, double de)
 {
-	std::cerr << "fwd$pow unimp!\n";
-	return 1.0;
+	throw "fwd$pow unimp!\n";
 }
 
 tuple<double,double> rev$pow$aFloat(double x, double e, double dr)
 {
-	std::cerr << "rev$pow unimp!\n";
-	return std::make_tuple(1.0, 1.0);
+	throw "rev$pow unimp!\n";
 }
 
 tuple<> fwd$gt(double a,double b,double d$a,double d$b)
@@ -118,8 +113,7 @@ tuple<> fwd$gt(double a,double b,double d$a,double d$b)
 
 tuple<double,double> rev$gt(double a,double b, tuple<> d$r)
 {
-	std::cerr << "rev$gt unimp!\n";
-    return std::make_tuple(0.0,0.0);
+	throw "rev$gt unimp!\n";
 }
 
 }


### PR DESCRIPTION
Can we terminate noisily rather than returning a result for unimplemented functions?  This is part of the reason that https://github.com/microsoft/knossos-ksc/pull/133 is failing.

(Calls to `fwd$lgamma` are no longer being erased.  More on that later.)

(/cc @simonpj: FYI)