### PR TITLE
Toelli/tweaks

### DIFF
--- a/src/runtime/knossos.h
+++ b/src/runtime/knossos.h
@@ -504,7 +504,12 @@ namespace ks
 		vec& operator=(const vec<T>& that)
 		{
 			this->size_ = that.size_;
-			this->data_ = that.data_; // Yes, this will alias, but there is no mutation, and no deletion.
+			// Yes, this will alias, but there is no
+			// deletion, and mutation only happens under
+			// controlled circumstances (inplace_add used
+			// in mutating sumbuild) where we promise to
+			// be careful.
+			this->data_ = that.data_;
 			this->is_zero_ = that.is_zero_;
 			this->z_ = that.z_;
 			return *this;


### PR DESCRIPTION
Small tweaks to the runtime in light of https://github.com/microsoft/knossos-ksc/issues/141

In particular I think it's important to remove the constructor of vecs from vecs of different type.  It's never used but causes confusion because its presence suggests it *might* be used.  In fact I think we should be really explicit if we ever decide to construct vecs that way (which we probably won't).