### PR TITLE
Implement fwd$gamma at dx == 0

### DIFF
--- a/src/runtime/knossos-prelude.h
+++ b/src/runtime/knossos-prelude.h
@@ -88,7 +88,11 @@ double rev$lgamma(double x, double dr)
 }
 double fwd$lgamma(double x, double dx)
 {
-	throw "fwd$gamma unimp!\n";
+  if (dx == 0.0) {
+    return 0.0;
+  } else {
+    throw "fwd$gamma unimp except at dx == 0!\n";
+  }
 }
 
 double pow$aFloat(double x, double e)


### PR DESCRIPTION
because it is needed to merge the no-vector-sizes PR.  With vector sizes,
certain optimisations trigger that see that the call to fwd$lgamma with dx
== 0 would return 0.  Therefore the call can be removed.  Without vector
size we do (as of the current PR) need to call that function.  Therefore we
just special case the call we need (because I can't work out how to fully
implement its derivative right now).

no-vector-sizes: https://github.com/microsoft/knossos-ksc/pull/133