### PR TITLE
Simplify the configuration of warnings and errors in build

### DIFF
--- a/.ghci
+++ b/.ghci
@@ -1,2 +1,2 @@
-:set -isrc/ksc -Wmissing-monadfail-instances -Wincomplete-patterns -Wunused-local-binds -Wunused-matches -Wunused-imports -Wunused-top-binds -Wmissing-signatures -Wincomplete-patterns
+:set -isrc/ksc -Wall -Wno-name-shadowing -Wno-unticked-promoted-constructors -Wno-type-defaults -Wno-unused-do-bind -Wincomplete-uni-patterns -Wincomplete-record-updates
 

--- a/knossos.cabal
+++ b/knossos.cabal
@@ -31,4 +31,4 @@ executable ksc
                  containers >= 0.5,
                  process >= 1.4,
                  directory >= 1.3
-  ghc-options: -Werror -Wmissing-monadfail-instances -Wincomplete-patterns -Wunused-local-binds -Wunused-matches -Wunused-imports -Wunused-top-binds -Wmissing-signatures
+  ghc-options: -Werror -Wall -Wno-name-shadowing -Wno-unticked-promoted-constructors -Wno-type-defaults -Wno-unused-do-bind -Wincomplete-uni-patterns -Wincomplete-record-updates

--- a/src/ksc/Cgen.hs
+++ b/src/ksc/Cgen.hs
@@ -533,7 +533,9 @@ cgenAnyFun :: HasCallStack => TFun -> CType -> String
 cgenAnyFun tf cftype = case tf of
   TFun _ (Fun (PrimFun "lmApply")) -> "lmApply"
   TFun ty (Fun (PrimFun "build")) ->
-    let TypeVec t = ty in "build<" ++ cgenType (mkCType t) ++ ">"
+    case ty of
+      TypeVec t -> "build<" ++ cgenType (mkCType t) ++ ">"
+      _         -> error ("Unexpected type for build: " ++ show ty)
   TFun ty (Fun (PrimFun "sumbuild")) ->
     "sumbuild<" ++ cgenType (mkCType ty) ++ ">"
   -- This is one of the LM subtypes, e.g. HCat<...>  Name is just HCat<...>::mk
@@ -617,7 +619,9 @@ ctypeofPrimFun ty s arg_types = case (s, map stripTypeDef arg_types) of
       )
     _ -> mkCType ty
 
+pattern RR :: TypeX p
 pattern RR = TypeFloat
+pattern VecR :: TypeX p
 pattern VecR <- TypeVec TypeFloat
 
 ctypeofGradBuiltin :: HasCallStack => FunId -> [CType] -> CType

--- a/src/ksc/KMonad.hs
+++ b/src/ksc/KMonad.hs
@@ -1,6 +1,5 @@
 -- Copyright (c) Microsoft Corporation.
 -- Licensed under the MIT license.
-{-# OPTIONS_GHC -Wno-unused-matches #-}
 
 module KMonad where
 

--- a/src/ksc/Lang.hs
+++ b/src/ksc/Lang.hs
@@ -195,6 +195,7 @@ deriving instance Show (RuleX Parsed)
 -- TypeSize is used to document when an integer represents a Size.
 -- It's too viral to use a separate Integer type because most integer operations
 -- need to be supported, e.g. the size of a lower-triangular matrix is d*(d+1)/2
+pattern TypeSize :: TypeX p
 pattern TypeSize = TypeInteger
 
 isScalar :: Type -> Bool

--- a/src/ksc/LangUtils.hs
+++ b/src/ksc/LangUtils.hs
@@ -1,6 +1,7 @@
 -- Copyright (c) Microsoft Corporation.
 -- Licensed under the MIT license.
 {-# OPTIONS_GHC -Wno-unused-matches #-}
+{-# OPTIONS_GHC -Wno-orphans        #-}
 {-# LANGUAGE TypeFamilies, DataKinds, FlexibleInstances, LambdaCase,
              PatternSynonyms, StandaloneDeriving, AllowAmbiguousTypes,
 	     ScopedTypeVariables, TypeApplications #-}

--- a/src/ksc/Main.hs
+++ b/src/ksc/Main.hs
@@ -367,12 +367,17 @@ demoFOnTestPrograms ksTests = do
   testOn ksTestsInModes $ \(ksTest, adp) -> do
         demoFFilter Nothing ignoreMain adp ksTest
 
+-- Drop items from the list while the condition is satisfied, and also
+-- drop the first element satisfying the condition, if any.
+dropWhile1 :: (a -> Bool) -> [a] -> [a]
+dropWhile1 f = tail . dropWhile f
+
 testRunKS :: String -> String -> IO ()
 testRunKS compiler ksFile = do
   let ksTest = System.FilePath.dropExtension ksFile
   output <- displayCppGenCompileAndRun compiler Nothing ksTest
 
-  let "TESTS FOLLOW":testResults = dropWhile (/= "TESTS FOLLOW") (lines output)
+  let testResults = dropWhile1 (/= "TESTS FOLLOW") (lines output)
 
       groupedTestResults = group testResults
         where group = \case

--- a/src/ksc/Opt.hs
+++ b/src/ksc/Opt.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+
 -- Copyright (c) Microsoft Corporation.
 -- Licensed under the MIT license.
 {-# LANGUAGE TypeFamilies, DataKinds, FlexibleInstances, LambdaCase,

--- a/test/builds/build_linux.sh
+++ b/test/builds/build_linux.sh
@@ -2,7 +2,7 @@ set -e
 
 GHC=$1
 
-ERRORS="-Wmissing-monadfail-instances -Wincomplete-patterns -Wunused-local-binds -Wunused-matches -Wunused-imports -Wunused-top-binds -Wmissing-signatures"
+ERRORS="-Wall -Wno-name-shadowing -Wno-unticked-promoted-constructors -Wno-type-defaults -Wno-unused-do-bind -Wincomplete-uni-patterns -Wincomplete-record-updates"
 
 $GHC -main-is test -isrc/ksc -Werror $ERRORS src/ksc/Main.hs
 $GHC -main-is profile -o profile -isrc/ksc -Werror $ERRORS src/ksc/Main.hs


### PR DESCRIPTION
by disabling the warnings we don't want rather than trying to enable all the
warnings that we do want.  Also, fix or silence the warnings that are thus
triggered.

I'd like to enable most of GHC's default warnings as helpful lint checks.  Our code is almost completely compliant already.