### PR TITLE
Update .NET installation task

### DIFF
--- a/test/builds/build_and_test.yml
+++ b/test/builds/build_and_test.yml
@@ -15,7 +15,7 @@ jobs:
       versionSpec: '3.6'
       architecture: 'x64'
 
-  - task: DotNetCoreInstaller@0
+  - task: UseDotNet@2
     inputs:
       version: 2.2.300
 


### PR DESCRIPTION
because Azure DevOps told us that the older one was outdated