### PR TITLE
Remove old, disabled, test

### DIFF
--- a/src/ksc/AD.hs
+++ b/src/ksc/AD.hs
@@ -313,22 +313,3 @@ applyD _ def = def
 
 applyDefs :: ADDir -> [TDef] -> [TDef]
 applyDefs dir = map (applyD dir)
-
-
-----------------------------------
---- Unit test
-
-{-
-
--- TODO make this work
-test_AD =
-  hspec $ do
-    let e1 = runParserOrPanic pDef "(def f ((x : Float)) (mul x 2.0))"
-    let (env,ae1) = annotDef e1
-    let de1_expected = runParserOrPanic pDef "(def D$f ((x : Float)) (lmScale Float 2.0))"
-    let (env1,ade1_expected) = annotDef de1_expected
-    let ade1 = gradDef emptyST ae1
-    describe "AD" $ do
-      it "AD" $
-        ade1 `shouldBe` ade1_expected
--}


### PR DESCRIPTION
It hasn't been used for over a year and we have much more comprehensive
tests for AD now.