### PR TITLE
Update projects to .NET Core 3.1

### DIFF
--- a/examples/dl-fcdnn/dl-fcdnn.fsproj
+++ b/examples/dl-fcdnn/dl-fcdnn.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>dl_fcdnn</RootNamespace>
   </PropertyGroup>
 

--- a/examples/dl-rnn/dl-rnn.fsproj
+++ b/examples/dl-rnn/dl-rnn.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>dl_rnn</RootNamespace>
   </PropertyGroup>
 

--- a/examples/ml-gmm/ml-gmm.fsproj
+++ b/examples/ml-gmm/ml-gmm.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <!--<DefineConstants>$(DefineConstants);DiffSharp</DefineConstants>-->
   </PropertyGroup>
   <ItemGroup>

--- a/src/f2k/f2k.fsproj
+++ b/src/f2k/f2k.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/test/builds/build_and_test.yml
+++ b/test/builds/build_and_test.yml
@@ -17,7 +17,7 @@ jobs:
 
   - task: UseDotNet@2
     inputs:
-      version: 2.2.300
+      version: 3.1.100
 
   - script: dotnet run --project src/f2k/f2k.fsproj SKIPPED out.ks test/f2k/test0.fs
     env:
@@ -73,7 +73,7 @@ jobs:
   steps:
   - task: DotNetCoreInstaller@0
     inputs:
-      version: 2.2.300
+      version: 3.1.100
 
   - script: dotnet run --project .\src\f2k\f2k.fsproj SKIPPED out.ks .\test\f2k\test0.fs
     env:


### PR DESCRIPTION
.NET Core 2.2 has been end-of-life'd
https://devblogs.microsoft.com/dotnet/net-core-2-2-will-reach-end-of-life-on-december-23-2019/

I'm not aware of this changing any behaviour that would affect F2K. People will likely need to update their tooling: https://dotnet.microsoft.com/download or Visual Studio 2019 generally.

https://github.com/microsoft/knossos-ksc/pull/161#issuecomment-572044533