### PR TITLE
Clearer error

### DIFF
--- a/src/ksc/Annotate.hs
+++ b/src/ksc/Annotate.hs
@@ -165,7 +165,8 @@ tcExpr (Call fx es)
 
 tcExpr (Let vx rhs body)
   = do { let (var, mb_ty) = getLetBndr @p vx
-       ; TE arhs rhs_ty <- tcExpr rhs
+       ; TE arhs rhs_ty <- addCtxt (text "In the rhs of the binding for:" <+> ppr var) $
+                           tcExpr rhs
        ; rhs_ty <- checkTypes_maybe mb_ty rhs_ty $
          text "Let binding mis-match for" <+> ppr var
        ; let tvar = TVar rhs_ty var


### PR DESCRIPTION
Used to say

```
--------------------------
Type errors in Type checking
  Ill-typed call to primitive: index
    In a call of: index (Fun (PrimFun "index"))
     Arg types: [Float, Vec (Vec Float)]
     Args: [1.0, means]
    ST lookup: Nothing
  In the call of: sub$VecR$VecR
  In the call of: mul$Mat$Vec
  In the call of: build
  In the call of: logsumexp
  In the call of: build
  In the call of: sum
  In the definition of gmm_knossos_gmm_objective
End of type errors
--------------------------
```

Now says


```
--------------------------
Type errors in Type checking
  Ill-typed call to primitive: index
    In a call of: index (Fun (PrimFun "index"))
     Arg types: [Float, Vec (Vec Float)]
     Args: [1.0, means]
    ST lookup: Nothing
  In the call of: sub$VecR$VecR
  In the call of: mul$Mat$Vec
  In the binding for: mahal_vec
  In the call of: build
  In the call of: logsumexp
  In the call of: build
  In the call of: sum
  In the binding for: slse
  In the definition of gmm_knossos_gmm_objective
End of type errors
--------------------------
```