### PR TITLE
notFreeIn: don't distinguish vars with same name but different types

### DIFF
--- a/src/ksc/LangUtils.hs
+++ b/src/ksc/LangUtils.hs
@@ -98,7 +98,7 @@ notFreeIn :: TVar -> TExpr -> Bool
 notFreeIn = go
  where
    go:: TVar -> TExpr -> Bool
-   go v (Var v2)     = v /= v2
+   go v (Var v2)     = tVarVar v /= tVarVar v2
    go v (Dummy {})   = True
    go v (Konst _)    = True
    go v (Tuple es)   = all (go v) es


### PR DESCRIPTION
Is this change right?  Distinguishing vars with the same name but different types just caused some subtle behaviour in my one-arg that I think is unintentional.