### PR TITLE
Use basename of tempfile as module name to avoid name clash

### DIFF
--- a/src/python/ksc/utils.py
+++ b/src/python/ksc/utils.py
@@ -11,8 +11,6 @@ from ksc.type import Type
 ShapeType = namedtuple("ShapeType", ["shape", "type"])
 
 
-PYTHON_MODULE_NAME = "ks_mod"
-
 def import_module_from_path(module_name, path):
     # These three lines are for loading a module from a file in Python 3.5+
     # https://bugs.python.org/issue21436
@@ -27,7 +25,8 @@ def translate_and_import(*args):
     with NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
         f.write(py_out)
     print(f.name)
-    return import_module_from_path(PYTHON_MODULE_NAME, f.name)
+    module_name = os.path.basename(f.name).split(".")[0]
+    return import_module_from_path(module_name, f.name)
 
 def subprocess_run(cmd, env=None):
     return subprocess.run(cmd, stdout=subprocess.PIPE, env=env).stdout.decode().strip("\n")


### PR DESCRIPTION
This prevents Python from wrongly caching the imported module, when we `translate_and_import` multiple ks string, for example

```python
ks_str1 = """
(def test Integer ((x : Integer))
    (abs x)
)
"""
py_out1 = translate_and_import(ks_str1, "common")
py_out1.test(-1) == 1

ks_str2 = """
(def test Integer ((x : Integer))
    x
)
"""
py_out2 = translate_and_import(ks_str2, "common")
py_out2.test(-1) == 1 # still uses the old module
```
