### PR TITLE
Generate cost$ and shape$ functions for each edef

### DIFF
--- a/src/python/ksc/backends/common.py
+++ b/src/python/ksc/backends/common.py
@@ -43,6 +43,9 @@ def max_(a, b):
 def neg(a):
     return -a
 
+def pow(a, b):
+    return a ** b
+
 def to_float_i(a):
     return float(a)
 

--- a/src/python/ksc/tracing/functions/core.py
+++ b/src/python/ksc/tracing/functions/core.py
@@ -1,3 +1,5 @@
+from functools import reduce
+
 import ksc
 from ksc.type import Type
 from ksc.tracing import node
@@ -11,31 +13,51 @@ from ksc.tracing.functions.type_propagation_rules import (
     keep_shape_prop_rule
 )
 
-add = make_edef("add", ["a", "b"], elementwise)
+add = make_edef(
+    "add", ["a", "b"], elementwise,
+    lambda a, b: a.shape,
+    lambda a, b: a.size
+)
 
-sub = make_edef("sub", ["a", "b"], elementwise)
+sub = make_edef(
+    "sub", ["a", "b"], elementwise,
+    lambda a, b: a.shape,
+    lambda a, b: a.size
+)
 
-mul = make_edef("mul", ["a", "b"], elementwise)
+mul = make_edef(
+    "mul", ["a", "b"], elementwise,
+    lambda a, b: a.shape,
+    lambda a, b: a.size * 2
+)
 
-div = make_edef("div", ["a", "b"], elementwise)
+div = make_edef(
+    "div", ["a", "b"], elementwise,
+    lambda a, b: a.shape,
+    lambda a, b: a.size * 2
+)
 
-flatten = make_edef("flatten", ["x"], flatten_type_prop_rule)
+pow = make_edef(
+    "pow", ["a", "b"], elementwise
+)
+
+flatten = make_edef(
+    "flatten", ["x"], flatten_type_prop_rule,
+    lambda x: (lambda s: make_tuple(s[0], reduce(mul, s[1:], node.Node.from_data(1))))(x.shape),
+    lambda x: node.Node.from_data(0)
+)
 
 to_float = make_edef("to_float", ["x"], keep_shape_prop_rule(Type.Float))
 
-def get_tuple_element(index, x):
-    size = len(x)
-    def shape_prop_function(arg):
-        x_shape, x_type = arg.shape_type
-        return ShapeType(x_shape[index], x_type.children[index])
-    class GetTupleElement(TraceableFunction):
+def make_builtin(name, arg_names, shape_prop_function):
+    class Builtin(TraceableFunction):
         is_edef = False
         is_builtin = True
         def __init__(self):
-            super().__init__(f"get${index+1}${size}", arg_names=["x"])
+            super().__init__(name, arg_names)
         def trace(self, *args):
-            assert len(args) == 1
-            o_shape, o_type = shape_prop_function(args[0])
+            assert len(args) == len(arg_names)
+            o_shape, o_type = shape_prop_function(*args)
             body = node.Node(
                 name=self.name,
                 shape=o_shape,
@@ -44,4 +66,47 @@ def get_tuple_element(index, x):
                 shape_prop_function=shape_prop_function)
             shape_types = tuple(arg.shape_type for arg in args)
             return Trace(body, ShapeType(o_shape, o_type), shape_types)
-    return GetTupleElement()(x)
+    return Builtin()
+
+def get_vector_element(index, x):
+    def shape_prop_function(index, x):
+        x_shape, x_type = x.shape_type
+        assert x_type.kind == "Vec"
+        return ShapeType(x_shape[1:], x_type.children[0])
+    f = make_builtin("index", ["index", "x"], shape_prop_function)
+    return f(index, x)
+
+def get_vector_size(x):
+    def shape_prop_function(x):
+        _, x_type = x.shape_type
+        assert x_type.kind == "Vec"
+        return ShapeType((), Type.Integer)
+    f = make_builtin("size", ["x"], shape_prop_function)
+    return f(x)
+
+def make_tuple(*args):
+    def shape_prop_function(*args):
+        shapes, types = zip(*[arg.shape_type for arg in args])
+        return ShapeType(tuple(shapes), Type.Tuple(*types))
+    arg_names = [f"arg{i}" for i in range(len(args))]
+    f = make_builtin("tuple", arg_names, shape_prop_function)
+    return f(*args)
+
+def get_tuple_element(index, x):
+    size = len(x)
+    def shape_prop_function(arg):
+        x_shape, x_type = arg.shape_type
+        return ShapeType(x_shape[index], x_type.children[index])
+    f = make_builtin(f"get${index+1}${size}", ["x"], shape_prop_function)
+    return f(x)
+
+def type_recursion_helper(fid, fadd, fmulpre, fmulpost, current):
+    type = current._type
+    if type.kind == "Vec":
+        self_shape = get_vector_size(current)
+        return fmulpre(self_shape, type_recursion_helper(fid, fadd, fmulpre, fmulpost, get_vector_element(0, current)))
+    elif type.kind == "Tuple":
+        children = [fmulpost(type_recursion_helper(fid, fadd, fmulpre, fmulpost, get_tuple_element(i, current))) for i in range(len(type.children))]
+        return fadd(*children)
+    else:
+        return fid()

--- a/src/python/ksc/tracing/node.py
+++ b/src/python/ksc/tracing/node.py
@@ -1,6 +1,7 @@
 import hashlib
 
 import ksc
+from ksc.type import Type
 from ksc.tracing import function
 from ksc.tracing import jitting
 from ksc import utils
@@ -94,6 +95,9 @@ class Node:
         from ksc.tracing.functions import core
         return core.add(self, Node.from_data(other))
 
+    def __radd__(self, other):
+        return self.__add__(other)
+
     def __sub__(self, other):
         from ksc.tracing.functions import core
         return core.sub(self, Node.from_data(other))
@@ -102,9 +106,67 @@ class Node:
         from ksc.tracing.functions import core
         return core.mul(self, Node.from_data(other))
 
+    def __rmul__(self, other):
+        return self.__mul__(other)
+
+    def __floordiv__(self, other):
+        from ksc.tracing.functions import core
+        assert self.shape_type.type == Type.Integer
+        if isinstance(other, Node):
+            assert other.shape_type.type == Type.Integer
+        return core.div(self, Node.from_data(other))
+
     def __truediv__(self, other):
         from ksc.tracing.functions import core
         return core.div(self, Node.from_data(other))
+
+    def __pow__(self, other):
+        from ksc.tracing.functions import core
+        return core.pow(self, Node.from_data(other))
+
+    def __getitem__(self, index):
+        from ksc.tracing.functions import core
+        if self._type.kind == "Tuple":
+            if isinstance(index, slice):
+                return (core.get_tuple_element(i, self) for i in range(*index.indices(len(self._type.children))))
+            return core.get_tuple_element(index, self)
+        elif self._type.kind == "Vec":
+            return core.get_vector_element(index, self)
+        else:
+            raise ValueError(f"Tried to call __getitem__ on {self} which is not Tuple or Vec.")
+
+    @property
+    def shape(self):
+        """ Note: in contrast to shape_type, this function returns a program to compute the shape
+        """
+        from ksc.tracing.functions import core
+        if self._type.kind not in ["Vec", "Tuple"]:
+            # because 0-tuple is not allowed in ks, we return an integer constant
+            return Node.from_data(0)
+        shape = core.type_recursion_helper(
+            tuple,
+            core.make_tuple,
+            lambda a, b: (a,) + b,
+            lambda x: core.make_tuple(*x) if isinstance(x, tuple) else x,
+            self
+        )
+        print(f"In shape: shape={shape}")
+        if isinstance(shape, tuple):
+            shape = core.make_tuple(*shape)
+        return shape
+
+    @property
+    def size(self):
+        """ returns a program to compute the number of elements
+        """
+        from ksc.tracing.functions import core
+        return core.type_recursion_helper(
+            lambda : Node.from_data(1),
+            sum,
+            core.mul,
+            lambda x: x,
+            self
+        )
 
     def __repr__(self):
         if self._data is not None:

--- a/src/python/ksc/type.py
+++ b/src/python/ksc/type.py
@@ -31,7 +31,7 @@ class Type:
 
     def __init__(self, kind, children=[]):
         assert kind in Type.node_kinds
-        assert (kind == "Tuple" and len(children) != 1) or (Type.node_kinds[kind] == len(children))
+        assert kind == "Tuple" or (Type.node_kinds[kind] == len(children)) # dont' check for 1-tuple
         assert all((ch is None or isinstance(ch, Type)) for ch in children)
         self.kind = kind
         self.children = children

--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -1,1 +1,3 @@
 sexpdata
+numpy
+jax

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -1,10 +1,10 @@
 from setuptools import setup, find_packages
 
 setup(name='ksc',
-      version='0.1',
+      version='0.3',
       description='Python interface for Knossos',
-      author='Ryota Tomioka',
-      author_email='ryoto@microsoft.com',
-      install_requires=['sexpdata'],
+      author='The Knossos Team',
+      author_email='Knossos@service.microsoft.com',
+      install_requires=['sexpdata', 'numpy'],
       packages=["ksc", "ksc.backends", "ksc.tracing", "ksc.tracing.functions"]
-     )
+)

--- a/test/builds/build_and_test.yml
+++ b/test/builds/build_and_test.yml
@@ -49,6 +49,21 @@ jobs:
   - script: sh ./test/builds/test_pytest.sh
     displayName: Testing ksc python package
 
+  - script: |
+      python3 -m pip install wheel twine
+      pushd ./src/python && python3 setup.py bdist_wheel
+      popd
+    displayName: Prepare for ksc python package publishing
+
+  - task: TwineAuthenticate@1
+    displayName: 'Twine Authenticate'
+    inputs:
+      artifactFeed: Knossos/Knossos
+
+  - script: |
+      python3 -m twine upload -r "Knossos" --skip-existing --config-file $(PYPIRC_PATH) ./src/python/dist/*.whl --verbose
+    displayName: Publishing ksc python package
+
   - script: sh ./test/builds/test_resnet50.sh
     displayName: Testing Resnet50 through ksc
 
@@ -62,6 +77,19 @@ jobs:
       pathToPublish: Artifact
       artifactName: Artifact
       targetPath: Artifact
+
+  - script: |
+      python -m pip install wheel twine
+      pushd ./src/python/ && python setup.py bdist_wheel && popd
+    displayName: Prepare for ksc python package publishing
+  # Python twine upload authenticate V1
+  - task: TwineAuthenticate@1
+    displayName: 'Twine Authenticate'
+    inputs:
+      artifactFeed: Knossos/Knossos # <Project Name>/<Feed Name>
+  - script: |
+      python -m twine upload -r "Knossos" --skip-existing --config-file $(PYPIRC_PATH) ./src/python/dist/*.whl --verbose
+    displayName: Publishing ksc python package
 
   - script: rm -rf *
     displayName: 'Clean'

--- a/test/builds/test_resnet50.py
+++ b/test/builds/test_resnet50.py
@@ -6,7 +6,6 @@ import os
 from PIL import Image
 from urllib.request import urlretrieve
 
-
 INPUT_FILE_URL = "https://knossosbuildpipeline.blob.core.windows.net/static/imagenet/msrc.jpg"
 PYTORCH_RESNET50_ORIGINAL_URL = "https://download.pytorch.org/models/resnet50-19c8e357.pth"
 PYTORCH_RESNET50_URL = "https://knossosbuildpipeline.blob.core.windows.net/static/imagenet/resnet50.npz"
@@ -229,6 +228,9 @@ def main():
     print(f"Loading image {input_file}")
     input = np.asarray(Image.open(input_file)).transpose((2, 0, 1))[None, :, :, :] / 255.0 # NCHW
 
+    # disable name mangling so that the output looks more readable
+    from ksc.tracing import jitting
+    jitting.disable_name_mangling()
     if args.model == "resnet_v2":
         from resnet_v2 import Resnet50 as resnet
         weights = resnet50_v2_weights_from_pytorch(weights)

--- a/test/python/test_tracing_core.py
+++ b/test/python/test_tracing_core.py
@@ -4,7 +4,9 @@ import ksc
 import numpy as np
 
 from ksc.tracing.node import Node
+from ksc.tracing.functions import core
 import ksc.tracing.functions as F
+from ksc.type import Type
 
 @pytest.fixture()
 def backend(pytestconfig):
@@ -117,6 +119,9 @@ def test_flatten():
     out = F.flatten(x)
     assert out.shape_type.shape == (3, 4 * 5 * 6)
     assert np.allclose(out.data, x.reshape((3, 4 * 5 * 6)))
+    shape_def = next(f for key, f in out.creator._jitted.all_called_functions().items()
+                     if key == "shape$flatten@vvvvf")
+    assert shape_def(x) == (3, 4 * 5 * 6)
 
 def test_to_float():
     x = np.arange(9)
@@ -152,3 +157,43 @@ def test_reuse_result(backend):
 
     z = y - x
     assert z.get_data_with_backend(backend) == 48
+
+def test_get_vector_element():
+    xn = np.arange(24).reshape((2, 3, 4))
+    x = Node.from_data(xn)
+    o = x[0]
+    assert o.shape_type.shape == (3, 4)
+    o = o[2]
+    assert o.shape_type.shape == (4,)
+    o = o[3]
+    assert o.shape_type.type == Type.Integer
+    assert o.shape_type.shape == ()
+    o.data == xn[0, 2, 3]
+
+def test_vector_size():
+    xn = np.arange(24).reshape((2, 3, 4))
+    x = Node.from_data(xn)
+    assert core.get_vector_size(x).data == 2
+    o = x[0]
+    assert core.get_vector_size(o).data == 3
+    o = o[2]
+    assert core.get_vector_size(o).data == 4
+
+def test_tensor_shape():
+    x = Node.from_data(np.arange(24).reshape((2, 3, 4)))
+    assert x.shape.data == (2, 3, 4)
+
+    x = Node.from_data(np.random.normal(0, 1, (5, 3, 9)))
+    assert x.shape.data == (5, 3, 9)
+
+    x = Node.from_data((np.arange(6).reshape((2, 3)), np.arange(12).reshape((3, 4))))
+    assert x.shape.data == ((2, 3), (3, 4))
+
+def test_tensor_num_elements():
+    x = Node.from_data(np.arange(24).reshape((2, 3, 4)))
+    assert x.size.data == 24
+
+def test_floor_div(backend):
+    x = Node.from_data(10)
+    o = x // 3
+    assert o.get_data_with_backend(backend) == 3


### PR DESCRIPTION
This PR provides infrastructure to create shape$ and cost$ functions for each edef. These functions are all we need to compute the cost function (because every function is written using edef's as building blocks).

For example, the shape$ and cost$ of `dot` can be specified as
```python
dot = ksc.tracing.make_edef(
  "dot", ["x", "y"], mat_mat_mul_prop_rule,
  # the shape is (m, n) if x = (m, k) and y = (k, n)
  lambda x, y: core.make_tuple(x.shape[0], y.shape[1]),
  # just count the number of flops
  lambda x, y: (lambda s_x, s_y: s_x[0] * s_x[1] * s_y[1] * 2)(x.shape, y.shape)
)
```
The above code generates the following ks
```lisp
(edef dot@vvfvvf (Vec (Vec Float)) ((Vec (Vec Float)) (Vec (Vec Float))))

(def shape$dot@vvfvvf (Tuple Integer Integer) ((x : (Vec (Vec Float)))
                                               (y : (Vec (Vec Float))))
  (let ((v0 (index@ivvf 0 x)))
  (let ((v1 (index@ivvf 0 y)))
    (tuple@ii (get$1$2@<ii> (tuple@ii (size@vvf x) (size@vf v0))) (get$2$2@<ii> (tuple@ii (size@vvf y) (size@vf v1))))
    )
  )
)
(def cost$dot@vvfvvf Integer ((x : (Vec (Vec Float)))
                              (y : (Vec (Vec Float))))
  (let ((v0 (index@ivvf 0 x)))
  (let ((v1 (tuple@ii (size@vvf x) (size@vf v0))))
    (let ((v2 (index@ivvf 0 y)))
      (mul@ii (mul@ii (mul@ii (get$1$2@<ii> v1) (get$2$2@<ii> v1)) (get$2$2@<ii> (tuple@ii (size@vvf y) (size@vf v2)))) 2)
      )
    )
  )
)
```
Generated code is not optimized but it is ok for the purpose.

Preliminary version of cost interpreter is in [ryoto/abstract-backend](https://github.com/microsoft/knossos-ksc/tree/ryoto/abstract-backend) but it will be another PR.