### PR TITLE
Ad hoc overloading

### DIFF
--- a/src/f2k/Knossos.ks
+++ b/src/f2k/Knossos.ks
@@ -30,36 +30,36 @@
 (edef rev$pow@Float (Tuple Float Float) (Float Float Float))
 
 (def add@Float,Float Float ((a : Float) (b : Float))
-   (add@ff a b))
+   (add a b))
 
 (def add@Integer,Integer Integer ((a : Integer) (b : Integer))
-   (add@ii a b))
+   (add a b))
 
 (def mul@Float,Float Float ((a : Float) (b : Float))
-   (mul@ff a b))
+   (mul a b))
 
 (def mul@Integer,Integer Integer ((a : Integer) (b : Integer))
-   (mul@ii a b))
+   (mul a b))
 
 (def div@Integer,Integer  Integer ((a : Integer) (b : Integer))
-   (div@ii a b))
+   (div a b))
 
 (def sub@Integer,Integer  Integer ((a : Integer) (b : Integer))
-   (sub@ii a b))
+   (sub a b))
 
 (def sub@Float,Float Float ((a : Float) (b : Float))
-   (sub@ff a b))
+   (sub a b))
 
 (def sub@V[[Float]],Float (Vec Float) ((a : Vec Float) (b : Float))
   (let (n (size a))
-    (build n (lam (i : Integer) (sub@ff (index i a) b)))))
+    (build n (lam (i : Integer) (sub (index i a) b)))))
 
 (def sub@V[[Float]],V[[Float]] (Vec Float) ((a : Vec Float) (b : Vec Float))
   (let (n (size a))
-    (build n (lam (i : Integer) (sub@ff (index i a) (index i b))))))
+    (build n (lam (i : Integer) (sub (index i a) (index i b))))))
 
 (def sqr Float (a : Float)
-   (mul@ff a a))
+   (mul a a))
 
 ; mul Mat Vec
 (edef mul$Mat$Vec (Vec Float) ((Vec (Vec Float)) (Vec Float)))
@@ -94,4 +94,4 @@
 ;;   (build n (lam (i : Integer) (f (index i v)))))
 
 (def gt@Float Bool ((a : Float) (b : Float))
-   (gt@ff a b))
+   (gt a b))

--- a/src/f2k/lispgen.fs
+++ b/src/f2k/lispgen.fs
@@ -108,7 +108,7 @@ let strVal (v:FSharpMemberOrFunctionOrValue) =
   | "op_LessThan"           -> "lt"
   // These monomorphised versions are not correct in general.
   // F2K needs to take into account that there may be Integers.
-  | "op_GreaterThan"        -> "gt@ff"
+  | "op_GreaterThan"        -> "gt"
   | "op_LessThanOrEqual"    -> "lt"
   | "op_GreaterThanOrEqual" -> "gt"
   | "op_Exponentiation"     -> "pow"

--- a/src/ksc/Cgen.hs
+++ b/src/ksc/Cgen.hs
@@ -153,10 +153,10 @@ getExpr (CG _ ex _) = ex
 getType :: CGenResult -> CType
 getType (CG _ _ ty) = ty
 
-type CSTKey = Fun
+type CSTKey = (Fun, Type)
 type CST    = Map.Map CSTKey ()
 
-cstMaybeLookupFun :: HasCallStack => Fun -> CST -> Maybe ()
+cstMaybeLookupFun :: HasCallStack => CSTKey -> CST -> Maybe ()
 cstMaybeLookupFun = Map.lookup
 
 cComment :: String -> String
@@ -168,9 +168,10 @@ cgenDefs defs = concatMap cdecl $
  where
   env = Map.fromList (mapMaybe (\(Def { def_fun = f
                                       , def_rhs = rhs
+                                      , def_args = arg
                                       }) ->
                                   case rhs of
-                                    UserRhs _ -> Just (f, ())
+                                    UserRhs _ -> Just ((f, typeof arg), ())
                                     _         -> Nothing) defs)
 
   cdecl def =
@@ -209,7 +210,7 @@ mkCTypedVar (TVar ty var) = cgenType (mkCType ty) `spc` cgenVar var
 cgenDefE :: CST -> TDef -> CGenResult
 cgenDefE env (Def { def_fun = f, def_args = param
                   , def_rhs = UserRhs body }) =
-  let cf                         = cgenUserFun f
+  let cf                         = cgenUserFun (f, typeof param)
       (params, withPackedParams) = params_withPackedParams param
       CG cbodydecl cbodyexpr cbodytype =
         runM $ cgenExpr env (withPackedParams body)
@@ -313,12 +314,12 @@ cgenExprR env = \case
 
   Call tf@(TFun _ fun) vs -> do
     cgvs_tys <- do cgv <- cgenExprR env vs; return (cgv, typeof vs)
-    let cgvs = fst cgvs_tys
+    let (cgvs, cgargtype) = cgvs_tys
     let cdecls = getDecl cgvs
     let cexprs_tys = (\(v, ty) -> (getExpr v, ty)) cgvs_tys
     let ctypes = getType cgvs
 
-    let cftype = ctypeofFun env tf [ctypes]
+    let cftype = ctypeofFun env (tf, cgargtype) [ctypes]
 
     v        <- freshCVar
     bumpmark <- freshCVar
@@ -328,7 +329,7 @@ cgenExprR env = \case
                     then tag ++ "(" ++ bumpmark ++ ");\n"
                     else ""
 
-    let cf = cgenAnyFun tf cftype
+    let cf = cgenAnyFun (tf, cgargtype) cftype
 
     return $ CG
       (  cdecls
@@ -488,11 +489,33 @@ mangleFun = substitute $ \case
     '*' -> Just "$x"
     _   -> Nothing
 
-cgenFunId :: FunId -> String
+-- | Produces a short string that uniquely identifies the input type.
+--
+-- This is used to prevent name clashes between generated functions in
+-- the backend. When we emit names to C/C++ we want to ensure unique
+-- names for each signature.  This is required in C, and desirable in
+-- C++, as otherwise delicate interactions with C++ overloading rules
+-- will impose a maintenance burden.  This function generates a string
+-- encoding of a type that is C-compatible, and guaranteed 1-1.
+mangleType :: TypeX -> String
+mangleType = \case
+    TypeBool      -> "b"
+    TypeInteger   -> "i"
+    TypeFloat     -> "f"
+    TypeString    -> "s"
+    TypeTuple tys -> "<" ++ (concatMap mangleType tys) ++ ">"
+    TypeVec ty    -> "v" ++ mangleType ty
+    TypeLam a b   -> "l<" ++ mangleType a ++ mangleType b ++ ">"
+    TypeLM _ _    -> error "Can't mangle TypeLM"
+    TypeUnknown   -> error "Can't mangle TypeUnknown"
+
+cgenFunId :: (FunId, Type) -> String
 cgenFunId = \case
-  UserFun fun -> mangleFun fun
-  PrimFun fun -> translateFun fun
-  SelFun i _  -> "ks::get<" ++ show (i - 1) ++ ">"
+  (UserFun fun, TypeTuple [])  -> mangleFun fun
+  (UserFun fun, TypeTuple tys) -> mangleFun (fun ++ "@" ++ concatMap mangleType tys)
+  (UserFun fun, ty)  -> mangleFun (fun ++ "@" ++ mangleType ty)
+  (PrimFun fun, _ty) -> translateFun fun
+  (SelFun i _, _ty)  -> "ks::get<" ++ show (i - 1) ++ ">"
  where
   translateFun :: String -> String
   translateFun = \case
@@ -503,17 +526,17 @@ cgenFunId = \case
     "ts_scale" -> "mul"
     s    -> s
 
-cgenUserFun :: HasCallStack => Fun -> String
-cgenUserFun f = case f of
-  Fun funId     -> cgenFunId funId
-  GradFun  s _  -> "D$" ++ cgenFunId s
-  DrvFun   s (AD BasicAD Fwd) -> "fwd$" ++ cgenFunId s
-  DrvFun   s (AD BasicAD Rev) -> "rev$" ++ cgenFunId s
-  DrvFun   s (AD TupleAD Fwd) -> "fwdt$" ++ cgenFunId s
-  DrvFun   s (AD TupleAD Rev) -> "revt$" ++ cgenFunId s
+cgenUserFun :: HasCallStack => (Fun, Type) -> String
+cgenUserFun (f, ty) = case f of
+  Fun funId     -> cgenFunId (funId, ty)
+  GradFun  s _  -> "D$" ++ cgenFunId (s, ty)
+  DrvFun   s (AD BasicAD Fwd) -> "fwd$" ++ cgenFunId (s, ty)
+  DrvFun   s (AD BasicAD Rev) -> "rev$" ++ cgenFunId (s, ty)
+  DrvFun   s (AD TupleAD Fwd) -> "fwdt$" ++ cgenFunId (s, ty)
+  DrvFun   s (AD TupleAD Rev) -> "revt$" ++ cgenFunId (s, ty)
 
-cgenAnyFun :: HasCallStack => TFun -> CType -> String
-cgenAnyFun tf cftype = case tf of
+cgenAnyFun :: HasCallStack => (TFun, Type) -> CType -> String
+cgenAnyFun (tf, ty) cftype = case tf of
   TFun _ (Fun (PrimFun "lmApply")) -> "lmApply"
   TFun ty (Fun (PrimFun "build")) ->
     case ty of
@@ -523,7 +546,7 @@ cgenAnyFun tf cftype = case tf of
     "sumbuild<" ++ cgenType (mkCType ty) ++ ">"
   -- This is one of the LM subtypes, e.g. HCat<...>  Name is just HCat<...>::mk
   TFun (TypeLM _ _) (Fun (PrimFun _)) -> cgenType cftype ++ "::mk"
-  TFun _            f                 -> cgenUserFun f
+  TFun _            f                 -> cgenUserFun (f, ty)
 
 cgenType :: HasCallStack => CType -> String
 cgenType = \case
@@ -560,10 +583,10 @@ cgenTypeLang = \case
     "std::function<" ++ cgenTypeLang to ++ "(" ++ cgenTypeLang from ++ ")>"
   TypeLM s t -> error $ "LM<" ++ cgenTypeLang s ++ "," ++ cgenTypeLang t ++ ">"
 
-ctypeofFun :: HasCallStack => CST -> TFun -> [CType] -> CType
-ctypeofFun env (TFun ty f) ctys = case cstMaybeLookupFun f env of
+ctypeofFun :: HasCallStack => CST -> (TFun, Type) -> [CType] -> CType
+ctypeofFun env (TFun ty f, argty) ctys = case cstMaybeLookupFun (f, argty) env of
   Just _ -> -- trace ("Found fun " ++ show f) $
-    UseTypeDef ("ty$" ++ cgenUserFun f)
+    UseTypeDef ("ty$" ++ cgenUserFun (f, argty))
   Nothing -> -- trace ("Did not find fun " ++ show tf ++ " in\n     " ++ show env) $
     ctypeofFun1 ty f ctys
 

--- a/src/ksc/Opt.hs
+++ b/src/ksc/Opt.hs
@@ -207,7 +207,7 @@ optFun _ (SelFun i _) arg
 -- $inline needs to look up the global symtab
 optFun env (PrimFun "$inline") arg
   | Call (TFun _ fun) inner_arg <- arg
-  , Just fun_def <- lookupGblST fun (optGblST env)
+  , Just fun_def <- lookupGblST (fun, typeof inner_arg) (optGblST env)
   , Def { def_args = bndrs, def_rhs = UserRhs body } <- fun_def
   = Just (inlineCall bndrs body inner_arg)
 

--- a/src/ksc/Prim.hs
+++ b/src/ksc/Prim.hs
@@ -369,10 +369,10 @@ pToFloat :: TExpr -> TExpr
 pToFloat from = userCall "to_float" TypeFloat from
 
 pMulii :: TExpr -> TExpr -> TExpr
-pMulii x1 x2 = userCall "mul@ii" TypeInteger (Tuple [x1, x2])
+pMulii x1 x2 = userCall "mul" TypeInteger (Tuple [x1, x2])
 
 pMulff :: TExpr -> TExpr -> TExpr
-pMulff x1 x2 = userCall "mul@ff" TypeFloat (Tuple [x1, x2])
+pMulff x1 x2 = userCall "mul" TypeFloat (Tuple [x1, x2])
 
 
 ---------------------------------------------

--- a/src/python/ksc/backends/common.py
+++ b/src/python/ksc/backends/common.py
@@ -13,6 +13,12 @@ def div_ii(a, b):
 def div_ff(a, b):
     return a / b
 
+def div(a, b):
+    if isinstance(a, int):
+        return a // b
+    else:
+        return a / b
+
 def eq(a, b):
     return a == b
 

--- a/src/python/ksc/ks_function.py
+++ b/src/python/ksc/ks_function.py
@@ -50,7 +50,7 @@ class KsFunction:
         print(ks_str)
         if backend == "cpp":
             if self._py_mod is None:
-                self._py_mod = utils.generate_and_compile_cpp_from_ks(ks_str, self.name)
+                self._py_mod = utils.generate_and_compile_cpp_from_ks(ks_str, self.name, self._arg_types)
         else:
             if self._py_mod is None:
                 self._py_mod = utils.translate_and_import(ks_str, backend)

--- a/src/python/ksc/utils.py
+++ b/src/python/ksc/utils.py
@@ -102,7 +102,10 @@ def build_py_module_from_cpp(cpp_str, pybind11_path):
         os.unlink(fcpp.name)
     return module_name, module_path
 
-def generate_and_compile_cpp_from_ks(ks_str, name_to_call, pybind11_path="pybind11"):
+def arg_type_strings(types):
+    return "".join(t.shortstr() for t in types)
+
+def generate_and_compile_cpp_from_ks(ks_str, name_to_call, arg_types, pybind11_path="pybind11"):
 
     cpp_str = """
 #include <pybind11/pybind11.h>
@@ -134,7 +137,7 @@ PYBIND11_MODULE(PYTHON_MODULE_NAME, m) {{
 }}
 """.format(
         generated_cpp_source=generate_cpp_from_ks(ks_str),
-        name_to_call=name_to_call.replace("@", "$a")
+        name_to_call=(name_to_call + "@" + arg_type_strings(arg_types)).replace("@", "$a")
     )
     module_name, module_path = build_py_module_from_cpp(cpp_str, pybind11_path)
     return import_module_from_path(module_name, module_path)

--- a/src/python/setup.py
+++ b/src/python/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='ksc',
-      version='0.4',
+      version='0.5',
       description='Python interface for Knossos',
       author='The Knossos Team',
       author_email='Knossos@service.microsoft.com',

--- a/src/runtime/knossos-prelude.h
+++ b/src/runtime/knossos-prelude.h
@@ -6,17 +6,17 @@ namespace ks {
 // We should probably come up with a better story for the
 // tests but at the time of writing I didn't want to hold back
 // edef support any longer.
-double edef_example(double x) { return x; }
-double fwd$edef_example(double x, double dx) { return dx; }
-double rev$edef_example(double x, double ddr) { return ddr; }
+double edef_example$af(double x) { return x; }
+double fwd$edef_example$aff(double x, double dx) { return dx; }
+double rev$edef_example$aff(double x, double ddr) { return ddr; }
 
-double dotv(vec<double> const& a, vec<double> const& b)
+double dot$avfvf(vec<double> const& a, vec<double> const& b)
 {
 	return dot(a,b);
 }
 
 vec<double> 
-mul$Mat$Vec(vec<vec<double>> const& M, vec<double> const& v)
+mul$Mat$Vec$avvfvf(vec<vec<double>> const& M, vec<double> const& v)
 {
 	int r = size(M);
 	vec<double> ret(r);
@@ -26,7 +26,7 @@ mul$Mat$Vec(vec<vec<double>> const& M, vec<double> const& v)
 }
 
 tuple<vec<vec<double>>,vec<double>> 
-rev$mul$Mat$Vec(std::tuple<vec<vec<double>>, vec<double>> const& M_v, vec<double> const& dr)
+rev$mul$Mat$Vec$a$dvvfvf$bvf(std::tuple<vec<vec<double>>, vec<double>> const& M_v, vec<double> const& dr)
 {
         auto [M, v] = M_v;
 	int r = size(M);
@@ -85,12 +85,12 @@ double digamma(double x)
 	throw "digamma unimp!\n";
 }
 
-double rev$lgamma(double x, double dr)
+double rev$lgamma$aff(double x, double dr)
 {
 	std::cerr << "rev$lgamma unimp!\n" << std::endl;
 	throw "rev$gamma unimp!\n";
 }
-double fwd$lgamma(double x, double dx)
+double fwd$lgamma$aff(double x, double dx)
 {
   if (dx == 0.0) {
     return 0.0;
@@ -171,9 +171,19 @@ inline int neg$ai(int t)
 	return -t;
 }
 
+inline double exp$af(double d) { return exp(d); }
+inline double log$af(double d) { return log(d); }
+inline double sin$af(double d) { return sin(d); }
+inline double cos$af(double d) { return cos(d); }
+inline double tanh$af(double d) { return tanh(d); }
+inline double lgamma$af(double d) { return lgamma(d); }
+
+inline double to_float$ai(int d) { return d; }
+inline auto D$to_float$ai(int d) { return LM::Zero<int, double>(); }
+
 inline double to_float(int d) { return d; }
 inline auto D$to_float(int d) { return LM::Zero<int, double>(); }
 
-inline bool ks_or(int b1, int b2)  { return b1 || b2; }
-inline bool ks_and(int b1, int b2) { return b1 && b2; }
+inline bool ks_or$abb(int b1, int b2)  { return b1 || b2; }
+inline bool ks_and$abb(int b1, int b2) { return b1 && b2; }
 }

--- a/src/runtime/knossos.fut
+++ b/src/runtime/knossos.fut
@@ -1,40 +1,40 @@
 let build (n, l) = tabulate n l
-let exp = f64.exp
-let log = f64.log
-let sin = f64.sin
-let cos = f64.cos
-let tanh = const 1f64 -- FIXME
+let exp__af = f64.exp
+let log__af = f64.log
+let sin__af = f64.sin
+let cos__af = f64.cos
+let tanh__af = const 1f64 -- FIXME
 let sum = f64.sum
-let to_float = r64
+let to_float__ai = r64
 let neg (x: f64) = -x
-let lgamma = f64.lgamma
-let digamma = const 1f64 -- FIXME
-let fwd__lgamma = const 1f64 -- FIXME
-let rev__lgamma = const 1f64 -- FIXME
-let dotv (xs, ys) = map2 (*) xs ys |> f64.sum
-let mul__Mat__Vec (xss, ys) = map (\xs -> dotv (ys, xs)) xss
+let lgamma__af = f64.lgamma
+let digamma__af = const 1f64 -- FIXME
+let fwd__lgamma__a__dff__b = const 1f64 -- FIXME
+let rev__lgamma__a__dff__b = const 1f64 -- FIXME
+let dot__a__dvfvf__b (xs, ys) = map2 (*) xs ys |> f64.sum
+let mul__Mat__Vec__a__dvvfvf__b (xss, ys) = map (\xs -> dot__a__dvfvf__b (ys, xs)) xss
 let constVec (n, x) = replicate n x
 let size = length
-let gt__aii (x: i32, y: i32) = x > y
-let gt__aff (x: f64, y: f64) = x > y
-let lt__aii (x: i32, y: i32) = x < y
-let lt__aff (x: f64, y: f64) = x < y
-let gte__aii (x: i32, y: i32) = x >= y
-let gte__aff (x: f64, y: f64) = x >= y
-let lte__aii (x: i32, y: i32) = x <= y
-let lte__aff (x: f64, y: f64) = x <= y
-let add__aii (x: i32, y: i32) = x + y
-let add__aff (x: f64, y: f64) = x + y
-let sub__aii (x: i32, y: i32) = x - y
-let sub__aff (x: f64, y: f64) = x - y
-let div__aii (x: i32, y: i32) = x / y
-let div__aff (x: f64, y: f64) = x / y
-let mul__aii (x: i32, y: i32) = x * y
-let mul__aff (x: f64, y: f64) = x * y
+let gt__a__dii__b (x: i32, y: i32) = x > y
+let gt__a__dff__b (x: f64, y: f64) = x > y
+let lt__a__dii__b (x: i32, y: i32) = x < y
+let lt__a__dff__b (x: f64, y: f64) = x < y
+let gte__a__dii__b (x: i32, y: i32) = x >= y
+let gte__a__dff__b (x: f64, y: f64) = x >= y
+let lte__a__dii__b (x: i32, y: i32) = x <= y
+let lte__a__dff__b (x: f64, y: f64) = x <= y
+let add__a__dii__b (x: i32, y: i32) = x + y
+let add__a__dff__b (x: f64, y: f64) = x + y
+let sub__a__dii__b (x: i32, y: i32) = x - y
+let sub__a__dff__b (x: f64, y: f64) = x - y
+let div__a__dii__b (x: i32, y: i32) = x / y
+let div__a__dff__b (x: f64, y: f64) = x / y
+let mul__a__dii__b (x: i32, y: i32) = x * y
+let mul__a__dff__b (x: f64, y: f64) = x * y
 let neg__ai (x: i32) = -x
 let neg__af (x: f64) = -x
-let ks_or (x, y)  = x || y
-let ks_and (x, y) = x && y
+let ks_or__a__dbb__b (x, y)  = x || y
+let ks_and__a__dbb__b (x, y) = x && y
 
 
 let deltaVec 't (zero: t) (n: i32) i (v: t) : [n]t =
@@ -43,7 +43,7 @@ let deltaVec 't (zero: t) (n: i32) i (v: t) : [n]t =
 let delta 't (zero: t) (i: i32) (j: i32) (v: t) =
   if i == j then v else zero
 
-let rev__mul__Mat__Vec [r][c] (M_v: ([r][c]f64, [c]f64), dr: [r]f64): ([r][c]f64, [c]f64) =
+let rev__mul__Mat__Vec__a__d__dvvfvf__bvf__b [r][c] (M_v: ([r][c]f64, [c]f64), dr: [r]f64): ([r][c]f64, [c]f64) =
   let (M, v) = M_v
   in (map (\x -> map (*x) v) dr,
       map (\col -> f64.sum (map2 (*) col dr)) (transpose M))
@@ -73,5 +73,5 @@ let u__ranhash (v: u64): u64 =
   let v = v ^ (v << 5)
   in v
 
-let u__ranhashdoub (v: i32): f64 =
+let u__ranhashdoub__ai (v: i32): f64 =
   5.42101086242752217E-20 * f64.u64(u__ranhash (u64.i32 v))

--- a/src/runtime/knossos.h
+++ b/src/runtime/knossos.h
@@ -1501,11 +1501,11 @@ namespace ks
 		return t1 * t2;
 	}
 
-	inline double abs(double d) { return d > 0 ? d : -d; }
-	inline auto D$abs(double d) { return LM::Scale::mk(d > 0 ? 1.0 : -1.0); }
+	inline double abs$af(double d) { return d > 0 ? d : -d; }
+	inline auto D$abs$af(double d) { return LM::Scale::mk(d > 0 ? 1.0 : -1.0); }
 
-	inline double max(double a, double b) { return a > b ? a : b; }
-	inline auto D$max(double a, double b) {
+	inline double max$aff(double a, double b) { return a > b ? a : b; }
+	inline auto D$max$aff(double a, double b) {
 		double s = a > b ? 1.0 : 0.0;
 		return LM::HCat<LM::Scale, LM::Scale>::mk(LM::Scale::mk(s), LM::Scale::mk(1.0 - s));
 	}
@@ -1560,7 +1560,7 @@ namespace ks
           return v;
         }
 
-        inline double $ranhashdoub(int32_t v) {
+        inline double $ranhashdoub$ai(int32_t v) {
           return 5.42101086242752217E-20 * $ranhash(v);
         }
 
@@ -1632,7 +1632,7 @@ namespace ks
 		);
 	*/
 
-#define $BENCH(FUN) ks::benchmark(ks::repeat([&]() { \
+#define $BENCH$al$d$d$bf$b(FUN) ks::benchmark(ks::repeat([&]() { \
 																								$MRK(t); \
 																								FUN(); \
 																								$REL(t); \
@@ -1704,7 +1704,7 @@ namespace ks
 		std::cout << " D2=" << d2 << std::endl;
 		*/
 
-		return abs(d1 - d2)/(abs(d1) + abs(d2));
+		return std::abs(d1 - d2)/(std::abs(d1) + std::abs(d2));
 	}
 } // namespace ks
 

--- a/src/runtime/prelude.ks
+++ b/src/runtime/prelude.ks
@@ -1,294 +1,295 @@
 ;; add :: Number x Number -> Number
 ;; add (x, y) = x + y
-(edef add@ff Float (Float Float))
-(edef D$add@ff (LM (Tuple Float Float) Float) (Float Float))
-(edef Dt$add@ff (Tuple Float (LM (Tuple Float Float) Float)) (Float Float))
+(edef add Float (Float Float))
+(edef D$add (LM (Tuple Float Float) Float) (Float Float))
+(edef Dt$add (Tuple Float (LM (Tuple Float Float) Float)) (Float Float))
 (def
- fwd$add@ff Float
+ fwd$add Float
  ((xt : (Tuple Float Float)) (dxt : (Tuple Float Float)))
  (let
   ((dx1 (get$1$2 dxt))
    (dx2 (get$2$2 dxt)))
-  (add@ff dx1 dx2)))
+  (add dx1 dx2)))
 (def
- rev$add@ff (Tuple Float Float)
+ rev$add (Tuple Float Float)
  ((xt : (Tuple Float Float)) (drt : Float))
  (let
   ((d_dadd drt))
   (tuple d_dadd d_dadd)))
 
-(edef add@ii Integer (Integer Integer))
-(edef D$add@ii (LM (Tuple Integer Integer) Integer) (Integer Integer))
-(edef Dt$add@ii (Tuple Integer (LM (Tuple Integer Integer) Integer)) (Integer Integer))
+(edef add Integer (Integer Integer))
+(edef D$add (LM (Tuple Integer Integer) Integer) (Integer Integer))
+(edef Dt$add (Tuple Integer (LM (Tuple Integer Integer) Integer)) (Integer Integer))
 (def
- fwd$add@ii (Tuple)
+ fwd$add (Tuple)
  ((xt : (Tuple Integer Integer)) (dxt : (Tuple (Tuple) (Tuple))))
   (tuple))
 (def
- rev$add@ii (Tuple (Tuple) (Tuple))
+ rev$add (Tuple (Tuple) (Tuple))
  ((xt : (Tuple Integer Integer)) (drt : (Tuple)))
   (tuple (tuple) (tuple)))
 
 ;; sub :: Number x Number -> Number
 ;; sub (x, y) = x - y
-(edef sub@ff Float (Float Float))
-(edef D$sub@ff (LM (Tuple Float Float) Float) (Float Float))
-(edef Dt$sub@ff (Tuple Float (LM (Tuple Float Float) Float)) (Float Float))
+(edef sub Float (Float Float))
+(edef D$sub (LM (Tuple Float Float) Float) (Float Float))
+(edef Dt$sub (Tuple Float (LM (Tuple Float Float) Float)) (Float Float))
 (def
- fwd$sub@ff Float
+ fwd$sub Float
  ((xt : (Tuple Float Float)) (dxt : (Tuple Float Float)))
  (let
   ((dx1 (get$1$2 dxt))
    (dx2 (get$2$2 dxt)))
-  (sub@ff dx1 dx2)))
+  (sub dx1 dx2)))
 (def
- rev$sub@ff (Tuple Float Float)
+ rev$sub (Tuple Float Float)
  ((xt : (Tuple Float Float)) (drt : Float))
  (let
   ((d_dsub drt))
-  (tuple d_dsub (neg@f d_dsub))))
+  (tuple d_dsub (neg d_dsub))))
 
-(edef sub@ii Integer (Integer Integer))
-(edef D$sub@ii (LM (Tuple Integer Integer) Integer) (Integer Integer))
-(edef Dt$sub@ii (Tuple Integer (LM (Tuple Integer Integer) Integer)) (Integer Integer))
+(edef sub Integer (Integer Integer))
+(edef D$sub (LM (Tuple Integer Integer) Integer) (Integer Integer))
+(edef Dt$sub (Tuple Integer (LM (Tuple Integer Integer) Integer)) (Integer Integer))
 (def
- fwd$sub@ii (Tuple)
+ fwd$sub (Tuple)
  ((xt : (Tuple Integer Integer)) (dxt : (Tuple (Tuple) (Tuple))))
   (tuple))
 (def
- rev$sub@ii (Tuple (Tuple) (Tuple))
+ rev$sub (Tuple (Tuple) (Tuple))
  ((xt : (Tuple Integer Integer)) (drt : (Tuple)))
   (tuple (tuple) (tuple)))
 
 ;; div :: Number x Number -> Number
 ;; div (x, y) = x / y
-(edef div@ff Float (Float Float))
-(edef D$div@ff (LM (Tuple Float Float) Float) (Float Float))
-(edef Dt$div@ff (Tuple Float (LM (Tuple Float Float) Float)) (Float Float))
+(edef div Float (Float Float))
+(edef D$div (LM (Tuple Float Float) Float) (Float Float))
+(edef Dt$div (Tuple Float (LM (Tuple Float Float) Float)) (Float Float))
 (def
- fwd$div@ff Float
+ fwd$div Float
  ((xt : (Tuple Float Float)) (dxt : (Tuple Float Float)))
  (let
   ((x1 (get$1$2 xt))
    (x2 (get$2$2 xt))
    (dx1 (get$1$2 dxt))
    (dx2 (get$2$2 dxt)))
-  (div@ff (sub@ff (mul@ff x2 dx1)
-                  (mul@ff x1 dx2))
-          (mul@ff x2 x2))))
+  (div (sub (mul x2 dx1)
+                  (mul x1 dx2))
+          (mul x2 x2))))
 (def
- rev$div@ff (Tuple Float Float)
+ rev$div (Tuple Float Float)
  ((xt : (Tuple Float Float)) (drt : Float))
  (let
   ((x1 (get$1$2 xt))
    (x2 (get$2$2 xt))
    (d_ddiv drt))
-  (tuple (div@ff d_ddiv x2)
-         (neg@f (div@ff (mul@ff x1 d_ddiv)
-                         (mul@ff x2 x2))))))
-(edef div@ii Integer (Integer Integer))
-(edef D$div@ii (LM (Tuple Integer Integer) Integer) (Integer Integer))
-(edef Dt$div@ii (Tuple Integer (LM (Tuple Integer Integer) Integer)) (Integer Integer))
+  (tuple (div d_ddiv x2)
+         (neg (div (mul x1 d_ddiv)
+                         (mul x2 x2))))))
+(edef div Integer (Integer Integer))
+(edef D$div (LM (Tuple Integer Integer) Integer) (Integer Integer))
+(edef Dt$div (Tuple Integer (LM (Tuple Integer Integer) Integer)) (Integer Integer))
 (def
- fwd$div@ii (Tuple)
+ fwd$div (Tuple)
  ((xt : (Tuple Integer Integer)) (dxt : (Tuple (Tuple) (Tuple))))
   (tuple))
 (def
- rev$div@ii (Tuple (Tuple) (Tuple))
+ rev$div (Tuple (Tuple) (Tuple))
  ((xt : (Tuple Integer Integer)) (drt : (Tuple)))
   (tuple (tuple) (tuple)))
 
 ;; mul :: Number x Number -> Number
 ;; mul (x, y) = x * y
-(edef mul@ff Float (Float Float))
-(edef D$mul@ff (LM (Tuple Float Float) Float) (Float Float))
-(edef Dt$mul@ff (Tuple Float (LM (Tuple Float Float) Float)) (Float Float))
+(edef mul Float (Float Float))
+(edef D$mul (LM (Tuple Float Float) Float) (Float Float))
+(edef Dt$mul (Tuple Float (LM (Tuple Float Float) Float)) (Float Float))
 (def
- fwd$mul@ff Float
+ fwd$mul Float
  ((xt : (Tuple Float Float)) (dxt : (Tuple Float Float)))
  (let
   ((x1 (get$1$2 xt))
    (x2 (get$2$2 xt))
    (dx1 (get$1$2 dxt))
    (dx2 (get$2$2 dxt)))
-  (add@ff (mul@ff x2 dx1) (mul@ff x1 dx2))))
+  (add (mul x2 dx1) (mul x1 dx2))))
 (def
- rev$mul@ff (Tuple Float Float)
+ rev$mul (Tuple Float Float)
  ((xt : (Tuple Float Float)) (drt : Float))
  (let
   ((x1 (get$1$2 xt))
    (x2 (get$2$2 xt))
    (d_dmul drt))
-  (tuple (mul@ff d_dmul x2) (mul@ff d_dmul x1))))
+  (tuple (mul d_dmul x2) (mul d_dmul x1))))
 
-(edef mul@ii Integer (Integer Integer))
-(edef D$mul@ii (LM (Tuple Integer Integer) Integer) (Integer Integer))
-(edef Dt$mul@ii (Tuple Integer (LM (Tuple Integer Integer) Integer)) (Integer Integer))
+(edef mul Integer (Integer Integer))
+(edef D$mul (LM (Tuple Integer Integer) Integer) (Integer Integer))
+(edef Dt$mul (Tuple Integer (LM (Tuple Integer Integer) Integer)) (Integer Integer))
 (def
- fwd$mul@ii (Tuple)
+ fwd$mul (Tuple)
  ((xt : (Tuple Integer Integer)) (dxt : (Tuple (Tuple) (Tuple))))
   (tuple))
 (def
- rev$mul@ii (Tuple (Tuple) (Tuple))
+ rev$mul (Tuple (Tuple) (Tuple))
  ((xt : (Tuple Integer Integer)) (drt : (Tuple)))
   (tuple (tuple) (tuple)))
 
 ;; neg :: Number -> Number
 ;; neg x = -x
-(edef neg@f Float (Float))
-(edef D$neg@f (LM Float Float) (Float))
-(edef Dt$neg@f (Tuple Float (LM Float Float)) (Float))
-(def fwd$neg@f Float ((x : Float) (dx : Float))
-     (neg@f dx))
-(def rev$neg@f Float ((x : Float) (d_dneg : Float))
-     (neg@f d_dneg))
+(edef neg Float (Float))
+(edef D$neg (LM Float Float) (Float))
+(edef Dt$neg (Tuple Float (LM Float Float)) (Float))
+(def fwd$neg Float ((x : Float) (dx : Float))
+     (neg dx))
+(def rev$neg Float ((x : Float) (d_dneg : Float))
+     (neg d_dneg))
 
-(edef neg@i Integer (Integer))
-(edef D$neg@i (LM Integer Integer) (Integer))
-(edef Dt$neg@i (Tuple Integer (LM Integer Integer)) (Integer))
-(def fwd$neg@i (Tuple) ((x : Integer) (dx : (Tuple)))
+(edef neg Integer (Integer))
+(edef D$neg (LM Integer Integer) (Integer))
+(edef Dt$neg (Tuple Integer (LM Integer Integer)) (Integer))
+(def fwd$neg (Tuple) ((x : Integer) (dx : (Tuple)))
      (tuple))
-(def rev$neg@i (Tuple) ((x : Integer) (d_dneg : (Tuple)))
+(def rev$neg (Tuple) ((x : Integer) (d_dneg : (Tuple)))
      (tuple))
+
 
 ;; gt :: Number x Number -> Bool
 ;; gt (x, y) = x > y
-(edef gt@ff Bool (Float Float))
-(edef D$gt@ff (LM (Tuple Float Float) Bool) (Float Float))
-(edef Dt$gt@ff (Tuple Bool (LM (Tuple Float Float) Bool)) (Float Float))
+(edef gt Bool (Float Float))
+(edef D$gt (LM (Tuple Float Float) Bool) (Float Float))
+(edef Dt$gt (Tuple Bool (LM (Tuple Float Float) Bool)) (Float Float))
 (def
- fwd$gt@ff (Tuple)
+ fwd$gt (Tuple)
  ((xt : (Tuple Float Float)) (dxt : (Tuple Float Float)))
   (tuple))
 (def
- rev$gt@ff (Tuple Float Float)
+ rev$gt (Tuple Float Float)
  ((xt : (Tuple Float Float)) (drt : (Tuple)))
   (tuple 0.0 0.0))
 
-(edef gt@ii Bool (Integer Integer))
-(edef D$gt@ii (LM (Tuple Integer Integer) Bool) (Integer Integer))
-(edef Dt$gt@ii (Tuple Bool (LM (Tuple Integer Integer) Bool)) (Integer Integer))
+(edef gt Bool (Integer Integer))
+(edef D$gt (LM (Tuple Integer Integer) Bool) (Integer Integer))
+(edef Dt$gt (Tuple Bool (LM (Tuple Integer Integer) Bool)) (Integer Integer))
 (def
- fwd$gt@ii (Tuple)
+ fwd$gt (Tuple)
  ((xt : (Tuple Integer Integer)) (dxt : (Tuple (Tuple) (Tuple))))
   (tuple))
 (def
- rev$gt@ii (Tuple (Tuple) (Tuple))
+ rev$gt (Tuple (Tuple) (Tuple))
  ((xt : (Tuple Integer Integer)) (drt : (Tuple)))
   (tuple (tuple) (tuple)))
 
 ;; lt :: Number x Number -> Bool
 ;; lt (x, y) = x < y
-(edef lt@ff Bool (Float Float))
-(edef D$lt@ff (LM (Tuple Float Float) Bool) (Float Float))
-(edef Dt$lt@ff (Tuple Bool (LM (Tuple Float Float) Bool)) (Float Float))
+(edef lt Bool (Float Float))
+(edef D$lt (LM (Tuple Float Float) Bool) (Float Float))
+(edef Dt$lt (Tuple Bool (LM (Tuple Float Float) Bool)) (Float Float))
 (def
- fwd$lt@ff (Tuple)
+ fwd$lt (Tuple)
  ((xt : (Tuple Float Float)) (dxt : (Tuple Float Float)))
   (tuple))
 (def
- rev$lt@ff (Tuple Float Float)
+ rev$lt (Tuple Float Float)
  ((xt : (Tuple Float Float)) (drt : (Tuple)))
   (tuple 0.0 0.0))
 
-(edef lt@ii Bool (Integer Integer))
-(edef D$lt@ii (LM (Tuple Integer Integer) Bool) (Integer Integer))
-(edef Dt$lt@ii (Tuple Bool (LM (Tuple Integer Integer) Bool)) (Integer Integer))
+(edef lt Bool (Integer Integer))
+(edef D$lt (LM (Tuple Integer Integer) Bool) (Integer Integer))
+(edef Dt$lt (Tuple Bool (LM (Tuple Integer Integer) Bool)) (Integer Integer))
 (def
- fwd$lt@ii (Tuple)
+ fwd$lt (Tuple)
  ((xt : (Tuple Integer Integer)) (dxt : (Tuple (Tuple) (Tuple))))
   (tuple))
 (def
- rev$lt@ii (Tuple (Tuple) (Tuple))
+ rev$lt (Tuple (Tuple) (Tuple))
  ((xt : (Tuple Integer Integer)) (drt : (Tuple)))
   (tuple (tuple) (tuple)))
 
 ;; lte :: Number x Number -> Bool
 ;; lte (x, y) = x <= y
-(edef lte@ff Bool (Float Float))
-(edef D$lte@ff (LM (Tuple Float Float) Bool) (Float Float))
-(edef Dt$lte@ff (Tuple Bool (LM (Tuple Float Float) Bool)) (Float Float))
+(edef lte Bool (Float Float))
+(edef D$lte (LM (Tuple Float Float) Bool) (Float Float))
+(edef Dt$lte (Tuple Bool (LM (Tuple Float Float) Bool)) (Float Float))
 (def
- fwd$lte@ff (Tuple)
+ fwd$lte (Tuple)
  ((xt : (Tuple Float Float)) (dxt : (Tuple Float Float)))
   (tuple))
 (def
- rev$lte@ff (Tuple Float Float)
+ rev$lte (Tuple Float Float)
  ((xt : (Tuple Float Float)) (drt : (Tuple)))
   (tuple 0.0 0.0))
 
-(edef lte@ii Bool (Integer Integer))
-(edef D$lte@ii (LM (Tuple Integer Integer) Bool) (Integer Integer))
-(edef Dt$lte@ii (Tuple Bool (LM (Tuple Integer Integer) Bool)) (Integer Integer))
+(edef lte Bool (Integer Integer))
+(edef D$lte (LM (Tuple Integer Integer) Bool) (Integer Integer))
+(edef Dt$lte (Tuple Bool (LM (Tuple Integer Integer) Bool)) (Integer Integer))
 (def
- fwd$lte@ii (Tuple)
+ fwd$lte (Tuple)
  ((xt : (Tuple Integer Integer)) (dxt : (Tuple (Tuple) (Tuple))))
   (tuple))
 (def
- rev$lte@ii (Tuple (Tuple) (Tuple))
+ rev$lte (Tuple (Tuple) (Tuple))
  ((xt : (Tuple Integer Integer)) (drt : (Tuple)))
   (tuple (tuple) (tuple)))
 
 ;; gte :: Number x Number -> Bool
 ;; gte (x, y) = x >= y
-(edef gte@ff Bool (Float Float))
-(edef D$gte@ff (LM (Tuple Float Float) Bool) (Float Float))
-(edef Dt$gte@ff (Tuple Bool (LM (Tuple Float Float) Bool)) (Float Float))
+(edef gte Bool (Float Float))
+(edef D$gte (LM (Tuple Float Float) Bool) (Float Float))
+(edef Dt$gte (Tuple Bool (LM (Tuple Float Float) Bool)) (Float Float))
 (def
- fwd$gte@ff (Tuple)
+ fwd$gte (Tuple)
  ((xt : (Tuple Float Float)) (dxt : (Tuple Float Float)))
   (tuple))
 (def
- rev$gte@ff (Tuple Float Float)
+ rev$gte (Tuple Float Float)
  ((xt : (Tuple Float Float)) (drt : (Tuple)))
   (tuple 0.0 0.0))
 
-(edef gte@ii Bool (Integer Integer))
-(edef D$gte@ii (LM (Tuple Integer Integer) Bool) (Integer Integer))
-(edef Dt$gte@ii (Tuple Bool (LM (Tuple Integer Integer) Bool)) (Integer Integer))
+(edef gte Bool (Integer Integer))
+(edef D$gte (LM (Tuple Integer Integer) Bool) (Integer Integer))
+(edef Dt$gte (Tuple Bool (LM (Tuple Integer Integer) Bool)) (Integer Integer))
 (def
- fwd$gte@ii (Tuple)
+ fwd$gte (Tuple)
  ((xt : (Tuple Integer Integer)) (dxt : (Tuple (Tuple) (Tuple))))
   (tuple))
 (def
- rev$gte@ii (Tuple (Tuple) (Tuple))
+ rev$gte (Tuple (Tuple) (Tuple))
  ((xt : (Tuple Integer Integer)) (drt : (Tuple)))
   (tuple (tuple) (tuple)))
 
 (edef log Float (Float))
 (edef D$log (LM Float Float) (Float))
-(def fwd$log Float ((x : Float) (dx : Float)) (div@ff dx x))
-(def rev$log Float ((x : Float) (d_dlog : Float)) (div@ff d_dlog x))
+(def fwd$log Float ((x : Float) (dx : Float)) (div dx x))
+(def rev$log Float ((x : Float) (d_dlog : Float)) (div d_dlog x))
 (edef Dt$log (Tuple Float (LM Float Float)) (Float))
 
 (edef exp Float (Float))
 (edef D$exp (LM Float Float) (Float))
-(def fwd$exp Float ((x : Float) (dx : Float)) (mul@ff (exp x) dx))
-(def rev$exp Float ((x : Float) (d_dexp : Float)) (mul@ff (exp x) d_dexp))
+(def fwd$exp Float ((x : Float) (dx : Float)) (mul (exp x) dx))
+(def rev$exp Float ((x : Float) (d_dexp : Float)) (mul (exp x) d_dexp))
 (edef Dt$exp (Tuple Float (LM Float Float)) (Float))
 
 (edef sin Float (Float))
 (edef cos Float (Float))
 
 (edef D$sin (LM Float Float) (Float))
-(def fwd$sin Float ((x : Float) (dx : Float)) (mul@ff (cos x) dx))
-(def rev$sin Float ((x : Float) (d_dsin : Float)) (mul@ff (cos x) d_dsin))
+(def fwd$sin Float ((x : Float) (dx : Float)) (mul (cos x) dx))
+(def rev$sin Float ((x : Float) (d_dsin : Float)) (mul (cos x) d_dsin))
 (edef Dt$sin (Tuple Float (LM Float Float)) (Float))
 
 (edef D$cos (LM Float Float) (Float))
-(def fwd$cos Float ((x : Float) (dx : Float)) (neg@f (mul@ff (sin x) dx)))
-(def rev$cos Float ((x : Float) (d_dcos : Float)) (neg@f (mul@ff (sin x) d_dcos)))
+(def fwd$cos Float ((x : Float) (dx : Float)) (neg (mul (sin x) dx)))
+(def rev$cos Float ((x : Float) (d_dcos : Float)) (neg (mul (sin x) d_dcos)))
 (edef Dt$cos (Tuple Float (LM Float Float)) (Float))
 
 (edef tanh Float (Float))
 (def fwd$tanh Float ((x : Float) (dx : Float))
      (let ((tanh_x (tanh x))
-           (tanh_x_2 (mul@ff tanh_x tanh_x)))
-       (mul@ff tanh_x_2 dx)))
+           (tanh_x_2 (mul tanh_x tanh_x)))
+       (mul tanh_x_2 dx)))
 (def rev$tanh Float ((x : Float) (d_dr : Float))
      (let ((tanh_x (tanh x))
-           (tanh_x_2 (mul@ff tanh_x tanh_x)))
-       (mul@ff tanh_x_2 d_dr)))
+           (tanh_x_2 (mul tanh_x tanh_x)))
+       (mul tanh_x_2 d_dr)))
 (edef D$tanh (LM Float Float) (Float))
 (edef Dt$tanh (Tuple Float (LM Float Float)) (Float))
 
@@ -305,9 +306,9 @@
 
 (edef abs Float (Float))
 (edef D$abs (LM Float Float) (Float))
-(def fwd$abs Float ((x : Float) (dx : Float)) (if (gt@ff x 0.0) dx (neg@f dx)))
+(def fwd$abs Float ((x : Float) (dx : Float)) (if (gt x 0.0) dx (neg dx)))
 (def rev$abs Float ((x : Float) (d_dabs : Float))
-     (if (gt@ff x 0.0) d_dabs (neg@f d_dabs)))
+     (if (gt x 0.0) d_dabs (neg d_dabs)))
 (edef Dt$abs (Tuple Float (LM Float Float)) (Float))
 
 (edef to_float Float (Integer))

--- a/test/builds/test_resnet50.py
+++ b/test/builds/test_resnet50.py
@@ -228,9 +228,6 @@ def main():
     print(f"Loading image {input_file}")
     input = np.asarray(Image.open(input_file)).transpose((2, 0, 1))[None, :, :, :] / 255.0 # NCHW
 
-    # disable name mangling so that the output looks more readable
-    from ksc.tracing import jitting
-    jitting.disable_name_mangling()
     if args.model == "resnet_v2":
         from resnet_v2 import Resnet50 as resnet
         weights = resnet50_v2_weights_from_pytorch(weights)

--- a/test/ksc/CA-subst.ks
+++ b/test/ksc/CA-subst.ks
@@ -2,10 +2,10 @@
 ; Licensed under the MIT license.
 
 (def f Integer ( (y : Integer) (p : Integer))
-    (let (y (add@ii y y))
-    (let (z (add@ii y y))
-    (let (y (mul@ii p p))
-    (sum (build 3 (lam (y : Integer) (add@ii z (div@ii y y)))))
+    (let (y (add y y))
+    (let (z (add y y))
+    (let (y (mul p p))
+    (sum (build 3 (lam (y : Integer) (add z (div y y)))))
     ))))
 
 #| Tests capture-avoiding substitution |#

--- a/test/ksc/adbench-lstm.ks
+++ b/test/ksc/adbench-lstm.ks
@@ -7,7 +7,7 @@
 ;     https://github.com/awf/ADBench/blob/master/src/cpp/shared/lstm.h
 
 (def sigmoid Float (x : Float)
-     (div@ff 1.0 (add@ff 1.0 (exp (neg@f x)))))
+     (div 1.0 (add 1.0 (exp (neg x)))))
 
 (def exp$VecR (Vec Float) ((v : Vec Float))
  (let (n (size v))
@@ -18,7 +18,7 @@
 ;
 ;     https://github.com/awf/ADBench/issues/143
 (def logsumexp Float ((v : Vec Float))
-    (log (add@ff 2.0 (sum (exp$VecR v)))))
+    (log (add 2.0 (sum (exp$VecR v)))))
 
 ; all Vecs size h
 (def lstm_model (Tuple (Vec Float) (Vec Float))
@@ -32,13 +32,13 @@
 
      (let ((h (size wf))
            (cell_out (build h (lam (hi : Integer)
-              (let ((forget  (sigmoid (add@ff (mul@ff (index hi input)  (index hi wf)) (index hi bf))))
-                    (ingate  (sigmoid (add@ff (mul@ff (index hi hidden) (index hi wi)) (index hi bi))))
-                    (change  (tanh    (add@ff (mul@ff (index hi hidden) (index hi wc)) (index hi bc)))))
-                (add@ff (mul@ff (index hi cell) forget) (mul@ff ingate change))))))
+              (let ((forget  (sigmoid (add (mul (index hi input)  (index hi wf)) (index hi bf))))
+                    (ingate  (sigmoid (add (mul (index hi hidden) (index hi wi)) (index hi bi))))
+                    (change  (tanh    (add (mul (index hi hidden) (index hi wc)) (index hi bc)))))
+                (add (mul (index hi cell) forget) (mul ingate change))))))
            (hidden_out (build h (lam (hi : Integer)
-              (let ((outgate (sigmoid (add@ff (mul@ff (index hi input)  (index hi wo)) (index hi bo)))))
-                (mul@ff outgate (tanh (index hi cell_out))))))))
+              (let ((outgate (sigmoid (add (mul (index hi input)  (index hi wo)) (index hi bo)))))
+                (mul outgate (tanh (index hi cell_out))))))))
        (tuple hidden_out cell_out)))
 
 ; Return (Tuple (Vec h Float) (Vec l (Tuple (Vec h Float) (Vec h Float)))
@@ -60,7 +60,7 @@
 
      (let ((h (size in_weight))
            (l (size wf_bf_wi_bi_wo_bo_wc_bc_hidden_cell))
-           (output1 (build h (lam (bi : Integer) (mul@ff (index bi input) (index bi in_weight)))))
+           (output1 (build h (lam (bi : Integer) (mul (index bi input) (index bi in_weight)))))
            (final_output_i_o_v (fold (lam
                (layer_output_params
                 : (Tuple (Tuple Integer (Vec Float) (Vec (Tuple (Vec Float) (Vec Float))))
@@ -91,7 +91,7 @@
                               (if (eq li iteration)
                                   hidden_cell
                                 (index li vec_output))))))
-                 (tuple (add@ii iteration 1) layer_output_next vec_output_next)))
+                 (tuple (add iteration 1) layer_output_next vec_output_next)))
 
                          (tuple 0
                                 output1
@@ -101,7 +101,7 @@
            (final_output (get$2$3 final_output_i_o_v))
            (final_output_vec (get$3$3 final_output_i_o_v))
            (output (build h (lam (bi : Integer)
-                       (add@ff (mul@ff (index bi final_output) (index bi out_weight))
+                       (add (mul (index bi final_output) (index bi out_weight))
                             (index bi out_bias))))))
        (tuple output final_output_vec)))
 
@@ -149,18 +149,18 @@
                          (ypred (get$1$2 ypred_v))
                          (hidden_cell_next (get$2$2 ypred_v))
                          (lse (logsumexp ypred))
-                         (ynorm (build h (lam (hi : Integer) (sub@ff (index hi ypred) lse))))
+                         (ynorm (build h (lam (hi : Integer) (sub (index hi ypred) lse))))
 
                          (total_increment (sumbuild h (lam (hi : Integer)
-                                              (mul@ff (index hi ygold) (index hi ynorm)))))
+                                              (mul (index hi ygold) (index hi ynorm)))))
 
-                         (total_next (add@ff total total_increment)))
+                         (total_next (add total total_increment)))
                      (tuple total_next hidden_cell_next))
                    )
                                (tuple 0.0 (build l (lam (li : Integer) (tuple (get$9$10 (index li wf_bf_wi_bi_wo_bo_wc_bc_hidden_cell))
                                                                               (get$10$10 (index li wf_bf_wi_bi_wo_bo_wc_bc_hidden_cell))))))
                         sequence))
            (total (get$1$2 total_hidden))
-           (count (to_float (mul@ii cm1 h)))
-           (loss (neg@f (div@ff total count))))
+           (count (to_float (mul cm1 h)))
+           (loss (neg (div total count))))
        loss))

--- a/test/ksc/adbench-lstmpy.cpp
+++ b/test/ksc/adbench-lstmpy.cpp
@@ -44,9 +44,9 @@ PYBIND11_MODULE(PYTHON_MODULE_NAME, m) {
   declare_vec<ks::vec<ks::vec<double> > >(m, std::string("vec_vec_double"));
   declare_vec<ks::vec<ks::vec<ks::vec<double> > > >(m, std::string("vec_vec_vec_double"));
   declare_vec<ks::vec<ks::vec<ks::vec<ks::vec<double> > > > >(m, std::string("vec_vec_vec_vec_double"));
-  m.def("sigmoid", &ks::sigmoid);
-  m.def("logsumexp", &ks::logsumexp);
-  m.def("lstm_model", &ks::lstm_model);
-  m.def("lstm_predict", &ks::lstm_predict);
-  m.def("lstm_objective", &ks::lstm_objective);
+  m.def("sigmoid", &ks::sigmoid$af);
+  m.def("logsumexp", &ks::logsumexp$avf);
+  m.def("lstm_model", &ks::lstm_model$avfvfvfvfvfvfvfvfvfvfvf);
+  m.def("lstm_predict", &ks::lstm_predict$av$dvfvfvfvfvfvfvfvfvfvf$bvfvfvfvf);
+  m.def("lstm_objective", &ks::lstm_objective$av$dvfvfvfvfvfvfvfvfvfvf$bvfvfvfv$dvfvf$b);
 }

--- a/test/ksc/derivative-selection.ks
+++ b/test/ksc/derivative-selection.ks
@@ -1,29 +1,29 @@
 ; Copyright (c) Microsoft Corporation.
 ; Licensed under the MIT license.
 (def f Float ((x : Float) (y : Float))
-     (let (z (mul@ff x y))
-       (add@ff (mul@ff z x) (mul@ff z y))))
+     (let (z (mul x y))
+       (add (mul z x) (mul z y))))
 
 (def rev_f (Tuple Float Float)
      ((x : Float) (y : Float) (d_r : Float))
-     (let (z (mul@ff x y))
-          (tuple (add@ff (add@ff (mul@ff y (mul@ff x d_r))
-                       (mul@ff z d_r))
-                    (mul@ff y (mul@ff y d_r)))
-                 (add@ff (mul@ff x (mul@ff x d_r))
-                    (add@ff (mul@ff x (mul@ff y d_r))
-                       (mul@ff z d_r))))))
+     (let (z (mul x y))
+          (tuple (add (add (mul y (mul x d_r))
+                       (mul z d_r))
+                    (mul y (mul y d_r)))
+                 (add (mul x (mul x d_r))
+                    (add (mul x (mul y d_r))
+                       (mul z d_r))))))
 
 (def fst_rev_f Float
      ((x : Float) (y : Float) (d_r : Float))
-     (let (z (mul@ff x y))
+     (let (z (mul x y))
        (get$1$2
-          (tuple (add@ff (add@ff (mul@ff y (mul@ff x d_r))
-                       (mul@ff z d_r))
-                    (mul@ff y (mul@ff y d_r)))
-                 (add@ff (mul@ff x (mul@ff x d_r))
-                    (add@ff (mul@ff x (mul@ff y d_r))
-                       (mul@ff z d_r)))))))
+          (tuple (add (add (mul y (mul x d_r))
+                       (mul z d_r))
+                    (mul y (mul y d_r)))
+                 (add (mul x (mul x d_r))
+                    (add (mul x (mul y d_r))
+                       (mul z d_r)))))))
 
 (def fst_rev_f_inline Float
      ((x : Float) (y : Float) (d_r : Float))

--- a/test/ksc/edef.ks
+++ b/test/ksc/edef.ks
@@ -8,4 +8,4 @@
 (edef fwdt$edef_example Float (Float Float))
 (edef rev$edef_example Float (Float Float))
 
-(def g Float ((x : Float) (y : Float)) (add@ff (edef_example x) y))
+(def g Float ((x : Float) (y : Float)) (add (edef_example x) y))

--- a/test/ksc/ex0.ks
+++ b/test/ksc/ex0.ks
@@ -1,6 +1,6 @@
 ; Copyright (c) Microsoft Corporation.
 ; Licensed under the MIT license.
-(rule "mul2" (v : Float) (mul@ff v 2.0) (add@ff v v))
+(rule "mul2" (v : Float) (mul v 2.0) (add v v))
 
 (def f Float ( x : Float )
-     (let (y (mul@ff x 2.0)) (add@ff x y)))
+     (let (y (mul x 2.0)) (add x y)))

--- a/test/ksc/ex1.ks
+++ b/test/ksc/ex1.ks
@@ -1,6 +1,6 @@
 ; Copyright (c) Microsoft Corporation.
 ; Licensed under the MIT license.
 (def g Float ( x : Float )
-     (let (y (mul@ff x x))
-     (let (z (add@ff x y))
-     (mul@ff y z))))
+     (let (y (mul x x))
+     (let (z (add x y))
+     (mul y z))))

--- a/test/ksc/ex2.ks
+++ b/test/ksc/ex2.ks
@@ -1,8 +1,8 @@
 ; Copyright (c) Microsoft Corporation.
 ; Licensed under the MIT license.
 (def f2a Float (x : Float)
-     (let ((zt (let (y1 (mul@ff x x))
-                   (tuple y1 (add@ff x y1))))
+     (let ((zt (let (y1 (mul x x))
+                   (tuple y1 (add x y1))))
            (y2 (get$1$2 zt))
            (z  (get$2$2 zt)))
-     (mul@ff y2 z)))
+     (mul y2 z)))

--- a/test/ksc/ex3.ks
+++ b/test/ksc/ex3.ks
@@ -1,5 +1,5 @@
 ; Copyright (c) Microsoft Corporation.
 ; Licensed under the MIT license.
 (def h Float ( (x : Float) (y : Float))
-       (let (z (add@ff x y))
-            (mul@ff y z)))
+       (let (z (add x y))
+            (mul y z)))

--- a/test/ksc/ex4.ks
+++ b/test/ksc/ex4.ks
@@ -1,8 +1,8 @@
 ; Copyright (c) Microsoft Corporation.
 ; Licensed under the MIT license.
 (def f5 Float ( (x : Float) (y : Float) )
-        (let ((p (mul@ff 7.0 x))
-              (r (div@ff 1.0 y))
-              (q (mul@ff p (mul@ff x 5.0)))
-              (v (add@ff (mul@ff 2.0 (mul@ff p q)) (mul@ff 3.0 r))))
+        (let ((p (mul 7.0 x))
+              (r (div 1.0 y))
+              (q (mul p (mul x 5.0)))
+              (v (add (mul 2.0 (mul p q)) (mul 3.0 r))))
         v))

--- a/test/ksc/ex5.ks
+++ b/test/ksc/ex5.ks
@@ -1,7 +1,7 @@
 ; Copyright (c) Microsoft Corporation.
 ; Licensed under the MIT license.
 (def mulvec (Vec Float) ( (x : Vec Float) (y : Vec Float) )
-     (build (size x) (lam (i : Integer) (mul@ff (index i x) (index i y)))))
+     (build (size x) (lam (i : Integer) (mul (index i x) (index i y)))))
 
 (def f6 Float ( (x : Vec Float) (y : Vec Float) )
         (sum (mulvec x y)))

--- a/test/ksc/ex6.ks
+++ b/test/ksc/ex6.ks
@@ -3,4 +3,4 @@
 (def f7 Float ( (x : Vec Float) (y : Vec Float) )
         (sum (build (size x)
                     (lam (i : Integer)
-                         (mul@ff (index i x) (index i y))))))
+                         (mul (index i x) (index i y))))))

--- a/test/ksc/ex7.ks
+++ b/test/ksc/ex7.ks
@@ -1,4 +1,4 @@
 ; Copyright (c) Microsoft Corporation.
 ; Licensed under the MIT license.
 (def f7 Float (x : Vec Float)
-        (sum (build (size x) (lam (i : Integer) (neg@f (index i x))))))
+        (sum (build (size x) (lam (i : Integer) (neg (index i x))))))

--- a/test/ksc/ex8.ks
+++ b/test/ksc/ex8.ks
@@ -1,4 +1,4 @@
-(def doubleFloat Float (x : Float) (add@ff x x))
+(def doubleFloat Float (x : Float) (add x x))
 
 (def muld Float ( (x : Float) (y : Float) )
-  (mul@ff (doubleFloat x) (doubleFloat y)))
+  (mul (doubleFloat x) (doubleFloat y)))

--- a/test/ksc/fold.ks
+++ b/test/ksc/fold.ks
@@ -5,20 +5,20 @@
      (if
          (eq i (size v))
          acc
-       (fold_f env (add@ii i 1) v (f (tuple env (tuple acc (index i v)))))))
+       (fold_f env (add i 1) v (f (tuple env (tuple acc (index i v)))))))
 
 (def prod Float ((i : Integer) (v : Vec Float) (acc : Float))
      (if
          (eq i (size v))
          acc
-       (prod (add@ii i 1) v (mul@ff acc (index i v)))))
+       (prod (add i 1) v (mul acc (index i v)))))
 
 ; This ends up calculating prod(v) * pow(closure, size(v))
 (def prod_fold Float ((v : Vec Float) (closure : Float))
      (fold (lam (acc_x : Tuple Float Float)
                 (let ((acc (get$1$2 acc_x))
                       (x   (get$2$2 acc_x)))
-                  (mul@ff (mul@ff acc x) closure)))
+                  (mul (mul acc x) closure)))
            1.0
            v))
 
@@ -28,7 +28,7 @@
      (fold (lam (acc_x : Tuple Float Float)
                 (let ((acc (get$1$2 acc_x))
                       (x   (get$2$2 acc_x)))
-                  (mul@ff acc x)))
+                  (mul acc x)))
            1.0
            v))
 
@@ -54,37 +54,37 @@
 
 (def mkfloat Float ((seed  : Integer)
                     (scale : Float))
-       (mul@ff ($ranhashdoub seed) scale))
+       (mul ($ranhashdoub seed) scale))
 
 (def mkvec (Vec Float) ((seed  : Integer)
                         (n     : Integer)
                         (scale : Float))
-    (build n (lam (j : Integer) (mkfloat (add@ii j seed) scale))))
+    (build n (lam (j : Integer) (mkfloat (add j seed) scale))))
 
 (def main Integer ()
      (let ((seed 20000)
            (delta 0.0001)
-           (v  (mkvec   (add@ii seed 0)    10 1.0))
-           (c  (mkfloat (add@ii seed 1000)    1.0))
-           (dv (mkvec   (add@ii seed 2000) 10 delta))
-           (dc (mkfloat (add@ii seed 3000)    delta))
+           (v  (mkvec   (add seed 0)    10 1.0))
+           (c  (mkfloat (add seed 1000)    1.0))
+           (dv (mkvec   (add seed 2000) 10 delta))
+           (dc (mkfloat (add seed 3000)    delta))
            (checked ($check (lam (t : Tuple (Vec Float) Float) (prod_fold t))
                             (lam (t : Tuple (Tuple (Vec Float) Float) Float) (rev$prod_fold t))
                             (tuple v  c)
                             (tuple v  c)
                             (tuple dv dc)
                             1.0))
-           (rev_ok (lt@ff (abs checked) 0.001))
+           (rev_ok (lt (abs checked) 0.001))
            (fold_x   (prod_fold v c))
-           (fold_xpd (prod_fold (ts_add v dv) (add@ff c dc)))
+           (fold_xpd (prod_fold (ts_add v dv) (add c dc)))
            (fold_fwd (fwd$prod_fold (tuple v c) (tuple dv dc)))
-           (fold_fd  (sub@ff fold_xpd fold_x))
+           (fold_fd  (sub fold_xpd fold_x))
            (everything_works_as_expected
             (let ((tolerance 0.001)
                   (actual fold_fd)
                   (expected fold_fwd))
-              (lt@ff (abs (sub@ff actual expected))
-                      (mul@ff (add@ff (abs expected) (abs actual))
+              (lt (abs (sub actual expected))
+                      (mul (add (abs expected) (abs actual))
                          tolerance)))))
        (pr
         "v"
@@ -104,7 +104,7 @@
         "fd fold"
         fold_fd
         "fwd - fd"
-        (sub@ff fold_fwd fold_fd)
+        (sub fold_fwd fold_fd)
         "rev fold"
         (rev$prod_fold (tuple v c) 1.0)
         "checked (should be small)"

--- a/test/ksc/generated_deltavecs.ks
+++ b/test/ksc/generated_deltavecs.ks
@@ -10,7 +10,7 @@
          (k (size (index 0 w))))
      (build o (lam (oi : Integer)
      (sumbuild k (lam (ki : Integer)
-       (mul@ff (index ki (index oi w))
+       (mul (index ki (index oi w))
           (index ki image))
        ))))))
 
@@ -22,18 +22,18 @@
            (k (size w)))
      (build o (lam (oi : Integer)
      (sumbuild k (lam (ki : Integer)
-       (mul@ff (index oi (index ki w))
+       (mul (index oi (index ki w))
           (index ki image))
        ))))))
 
-(def max_ Float ((x1 : Float) (x2 : Float)) (if (gt@ff x1 x2) x1 x2))
+(def max_ Float ((x1 : Float) (x2 : Float)) (if (gt x1 x2) x1 x2))
 
 (def maxpool
      (Vec Float)
      (image : Vec Float)
-     (build (div@ii (size image) 2) (lam (ni : Integer)
-       (max_ (index (mul@ii 2 ni) image)
-             (index (add@ii 1 (mul@ii 2 ni)) image)))))
+     (build (div (size image) 2) (lam (ni : Integer)
+       (max_ (index (mul 2 ni) image)
+             (index (add 1 (mul 2 ni)) image)))))
 
 ; This function stands in for one that could actually be expensive
 (def expensive Float ((x1 : Float) (x2 : Float)) 0.0)
@@ -43,9 +43,9 @@
 (def expensivepool
      (Vec Float)
      (image : Vec Float)
-     (build (div@ii (size image) 2) (lam (ni : Integer)
-       (expensive (index (mul@ii 2 ni) image)
-                  (index (add@ii 1 (mul@ii 2 ni)) image)))))
+     (build (div (size image) 2) (lam (ni : Integer)
+       (expensive (index (mul 2 ni) image)
+                  (index (add 1 (mul 2 ni)) image)))))
 
 (def conv1d
      (Vec (Vec Float))
@@ -62,10 +62,10 @@
      (build n (lam (ni : Integer)
      (sumbuild kn (lam (kni : Integer)
      (sumbuild l  (lam (li  : Integer)
-       (let ((knc (div@ii kn 2))
-             (noi (sub@ii (add@ii ni knc) kni))
-             (outside_image (ks_or (lt@ii noi 0) (gte@ii noi n)))
+       (let ((knc (div kn 2))
+             (noi (sub (add ni knc) kni))
+             (outside_image (ks_or (lt noi 0) (gte noi n)))
              (image_noi
               (if outside_image 0.0 (index noi (index li image)))))
-         (mul@ff image_noi (index kni (index li (index ki kernels))))
+         (mul image_noi (index kni (index li (index ki kernels))))
          ))))))))))))

--- a/test/ksc/gmm-obj.ks
+++ b/test/ksc/gmm-obj.ks
@@ -1,48 +1,48 @@
 ; Copyright (c) Microsoft Corporation.
 ; Licensed under the MIT license.
 (def gmm_knossos_tri Integer ((n : Integer))
-  (div@ii (mul@ii n (sub@ii n 1)) 2))
+  (div (mul n (sub n 1)) 2))
 
 (def exp$VecR (Vec Float) ((v : Vec Float))
   (build (size v) (lam (i : Integer) (exp (index i v)))))
 
 (def mul$R$VecR (Vec Float) ((r : Float) (a : Vec Float))
-    (build (size a) (lam (i : Integer) (mul@ff r (index i a)))))
+    (build (size a) (lam (i : Integer) (mul r (index i a)))))
 
 (def mul$R$VecVecR (Vec (Vec Float)) ((r : Float) (a : Vec (Vec Float)))
     (build (size a) (lam (i : Integer) (mul$R$VecR r (index i a)))))
 
 (def mul$VecR$VecR (Vec Float) ((a : Vec Float) (b : Vec Float))
-  (build (size a) (lam (i : Integer) (mul@ff (index i a) (index i b)))))
+  (build (size a) (lam (i : Integer) (mul (index i a) (index i b)))))
 
 (def sub$VecR$VecR (Vec Float) ((a : Vec Float) (b : Vec Float))
-  (build (size a) (lam (i : Integer) (sub@ff (index i a) (index i b)))))
+  (build (size a) (lam (i : Integer) (sub (index i a) (index i b)))))
 
-; dotv
-(edef dotv Float ((Vec Float) (Vec Float)))
-(edef D$dotv (LM (Tuple (Vec Float) (Vec Float)) Float)
+; dot
+(edef dot Float ((Vec Float) (Vec Float)))
+(edef D$dot (LM (Tuple (Vec Float) (Vec Float)) Float)
              ((Vec Float) (Vec Float)))
-(edef Dt$dotv (Tuple Float (LM (Tuple (Vec Float) (Vec Float)) Float))
+(edef Dt$dot (Tuple Float (LM (Tuple (Vec Float) (Vec Float)) Float))
               ((Vec Float) (Vec Float)))
-(edef R$dotv (LM Float (Tuple (Vec Float) (Vec Float))) ((Vec Float) (Vec Float)))
-(def fwd$dotv Float ((a_b : (Tuple (Vec Float) (Vec Float))) (da_db : (Tuple (Vec Float) (Vec Float))))
+(edef R$dot (LM Float (Tuple (Vec Float) (Vec Float))) ((Vec Float) (Vec Float)))
+(def fwd$dot Float ((a_b : (Tuple (Vec Float) (Vec Float))) (da_db : (Tuple (Vec Float) (Vec Float))))
      (let ((a  (get$1$2 a_b))
            (b  (get$2$2 a_b))
            (da (get$1$2 da_db))
            (db (get$2$2 da_db)))
-    (add@ff (dotv a db) (dotv da b))))
-(def rev$dotv (Tuple (Vec Float) (Vec Float))
+    (add (dot a db) (dot da b))))
+(def rev$dot (Tuple (Vec Float) (Vec Float))
                ((a_b : (Tuple (Vec Float) (Vec Float))) (dr : Float))
      (let ((a  (get$1$2 a_b))
            (b  (get$2$2 a_b)))
     (tuple (mul$R$VecR dr b) (mul$R$VecR dr a))))
 
-(def dotvv Float ((a : Vec (Vec Float)) (b : Vec (Vec Float)))
-  (sum (build (size a) (lam (i : Integer) (dotv (index i a) (index i b)))))
+(def dot Float ((a : Vec (Vec Float)) (b : Vec (Vec Float)))
+  (sum (build (size a) (lam (i : Integer) (dot (index i a) (index i b)))))
   )
 
 (def sqnorm Float ((v : Vec Float))
-  (dotv v v))
+  (dot v v))
 
 ; mul Mat Vec
 (edef mul$Mat$Vec (Vec Float) ((Vec (Vec Float)) (Vec Float)))
@@ -73,11 +73,11 @@
    (assert (eq (size l) (gmm_knossos_tri D))
     (build D (lam (i : Integer)
         (build D (lam (j : Integer)
-           (if (lt@ii i j)
+           (if (lt i j)
             0.0
             (if (eq i j)
               (exp (index i q))
-              (index (add@ii (gmm_knossos_tri (sub@ii i 1)) j) l))
+              (index (add (gmm_knossos_tri (sub i 1)) j) l))
            )
            )))))))
 
@@ -87,10 +87,10 @@
 ; TODO deriv lgamma - but no deriv wishart_m anyway.
 ; wishart_m -> int
 (def log_gamma_distrib Float ((a : Float) (p : Integer))
-    (let ((out (mul@ff 0.28618247146235004 (to_float (mul@ii p (sub@ii p 1)))))) ; 0.25 log pi
-      (add@ff out
+    (let ((out (mul 0.28618247146235004 (to_float (mul p (sub p 1)))))) ; 0.25 log pi
+      (add out
          (sum (build p (lam (j : Integer)
-                 (lgamma (sub@ff a (mul@ff 0.5 (to_float j))))))))))
+                 (lgamma (sub a (mul 0.5 (to_float j))))))))))
 
 (def log_wishart_prior Float ((wishart : Tuple Float Integer)
                               (log_Qdiag : Vec Float)
@@ -102,16 +102,16 @@
           (sum_qs        (sum log_Qdiag))
           (Qdiag         (exp$VecR log_Qdiag))
 
-          (n  (add@ii p (add@ii wishart_m 1)))
-          (C  (sub@ff (mul@ff (to_float (mul@ii n p))
-                    (sub@ff (log wishart_gamma)
-                       (mul@ff 0.5 (log 2.0))))
-                 (log_gamma_distrib (mul@ff 0.5 (to_float n)) p)))
-          (frobenius (add@ff  (sqnorm Qdiag) (sqnorm ltri_Q)))
-          (w2f   (mul@ff 0.5 (mul@ff (mul@ff wishart_gamma wishart_gamma) frobenius)))
+          (n  (add p (add wishart_m 1)))
+          (C  (sub (mul (to_float (mul n p))
+                    (sub (log wishart_gamma)
+                       (mul 0.5 (log 2.0))))
+                 (log_gamma_distrib (mul 0.5 (to_float n)) p)))
+          (frobenius (add  (sqnorm Qdiag) (sqnorm ltri_Q)))
+          (w2f   (mul 0.5 (mul (mul wishart_gamma wishart_gamma) frobenius)))
           )
-        (sub@ff (sub@ff w2f
-              (mul@ff (to_float wishart_m)
+        (sub (sub w2f
+              (mul (to_float wishart_m)
                   sum_qs))
             C)
     ))
@@ -129,42 +129,42 @@
        (triD (size (index 0 ls)))   ; Ugh
       )
   (assert (eq triD (gmm_knossos_tri D))
-    (let ((CONSTANT (mul@ff (to_float (mul@ii N D)) (neg@f 0.9189385332046727)) ) ; n * d*-0.5*log(2 * PI)
+    (let ((CONSTANT (mul (to_float (mul N D)) (neg 0.9189385332046727)) ) ; n * d*-0.5*log(2 * PI)
           (sum_qs   (build K (lam (k12 : Integer) (sum (index k12 qs)))))
           (slse     (sum (build N (lam (i : Integer)
                           (logsumexp (build K (lam (k : Integer)
                             (let ((Q         (gmm_knossos_makeQ (index k qs) (index k ls)))
                                   (mahal_vec (mul$Mat$Vec Q
                                                       (sub$VecR$VecR (index i x) (index k means)))))
-                              (sub@ff (add@ff (index k alphas)
+                              (sub (add (index k alphas)
                                     ; (index k sum_qs)
                                     (sum (index k qs))
                               )
-                                (mul@ff 0.500000  (sqnorm mahal_vec)))
+                                (mul 0.500000  (sqnorm mahal_vec)))
                             ))))
                           ))))
           )
-            (add@ff (add@ff CONSTANT
-                (sub@ff slse
-                  (mul@ff (to_float N) (logsumexp alphas))))
+            (add (add CONSTANT
+                (sub slse
+                  (mul (to_float N) (logsumexp alphas))))
             (sum (build K (lam (k : Integer)
                     (log_wishart_prior wishart (index k qs) (index k ls))))))
     ))))
 
 (def mkfloat Float ((seed  : Integer)
                     (scale : Float))
-       (mul@ff ($ranhashdoub seed) scale))
+       (mul ($ranhashdoub seed) scale))
 
 (def mkvec (Vec Float) ((seed  : Integer)
                         (n     : Integer)
                         (scale : Float))
-    (build n (lam (j : Integer) (mkfloat (add@ii j seed) scale))))
+    (build n (lam (j : Integer) (mkfloat (add j seed) scale))))
 
 (def mkvecvec (Vec (Vec Float)) ((seed  : Integer)
                                  (n     : Integer)
                                  (m     : Integer)
                                  (scale : Float))
-     (build n (lam (j : Integer) (mkvec (add@ii (mul@ii j m) seed) m scale))))
+     (build n (lam (j : Integer) (mkvec (add (mul j m) seed) m scale))))
 
 (def main Integer ()
     (let ((D 64)
@@ -174,11 +174,11 @@
           (scale_unity 1.0)
           (scale_small 0.1)
 
-          (x       (mkvecvec (add@ii seed 0)    N D scale_unity))
-          (alphas  (mkvec    (add@ii seed 1000) K   scale_unity))
-          (mus     (mkvecvec (add@ii seed 2000) K D scale_unity))
-          (qs      (mkvecvec (add@ii seed 3000) K D scale_small))
-          (ls      (mkvecvec (add@ii seed 4000) K (gmm_knossos_tri D) scale_unity))
+          (x       (mkvecvec (add seed 0)    N D scale_unity))
+          (alphas  (mkvec    (add seed 1000) K   scale_unity))
+          (mus     (mkvecvec (add seed 2000) K D scale_unity))
+          (qs      (mkvecvec (add seed 3000) K D scale_small))
+          (ls      (mkvecvec (add seed 4000) K (gmm_knossos_tri D) scale_unity))
           (wishart (tuple 3.1 7))
         )
 

--- a/test/ksc/gmm-rev.ks
+++ b/test/ksc/gmm-rev.ks
@@ -1,48 +1,48 @@
 ; Copyright (c) Microsoft Corporation.
 ; Licensed under the MIT license.
 (def gmm_knossos_tri Integer ((n : Integer))
-  (div@ii (mul@ii n (sub@ii n 1)) 2))
+  (div (mul n (sub n 1)) 2))
 
 (def exp$VecR (Vec Float) ((v : Vec Float))
   (build (size v) (lam (i : Integer) (exp (index i v)))))
 
 (def mul$R$VecR (Vec Float) ((r : Float) (a : Vec Float))
-    (build (size a) (lam (i : Integer) (mul@ff r (index i a)))))
+    (build (size a) (lam (i : Integer) (mul r (index i a)))))
 
 (def mul$R$VecVecR (Vec (Vec Float)) ((r : Float) (a : Vec (Vec Float)))
     (build (size a) (lam (i : Integer) (mul$R$VecR r (index i a)))))
 
 (def mul$VecR$VecR (Vec Float) ((a : Vec Float) (b : Vec Float))
-  (build (size a) (lam (i : Integer) (mul@ff (index i a) (index i b)))))
+  (build (size a) (lam (i : Integer) (mul (index i a) (index i b)))))
 
 (def sub$VecR$VecR (Vec Float) ((a : Vec Float) (b : Vec Float))
-  (build (size a) (lam (i : Integer) (sub@ff (index i a) (index i b)))))
+  (build (size a) (lam (i : Integer) (sub (index i a) (index i b)))))
 
-; dotv
-(edef dotv Float ((Vec Float) (Vec Float)))
-(edef D$dotv (LM (Tuple (Vec Float) (Vec Float)) Float)
+; dot
+(edef dot Float ((Vec Float) (Vec Float)))
+(edef D$dot (LM (Tuple (Vec Float) (Vec Float)) Float)
              ((Vec Float) (Vec Float)))
-(edef Dt$dotv (Tuple Float (LM (Tuple (Vec Float) (Vec Float)) Float))
+(edef Dt$dot (Tuple Float (LM (Tuple (Vec Float) (Vec Float)) Float))
               ((Vec Float) (Vec Float)))
-(edef R$dotv (LM Float (Tuple (Vec Float) (Vec Float))) ((Vec Float) (Vec Float)))
-(def fwd$dotv Float ((a_b : (Tuple (Vec Float) (Vec Float))) (da_db : (Tuple (Vec Float) (Vec Float))))
+(edef R$dot (LM Float (Tuple (Vec Float) (Vec Float))) ((Vec Float) (Vec Float)))
+(def fwd$dot Float ((a_b : (Tuple (Vec Float) (Vec Float))) (da_db : (Tuple (Vec Float) (Vec Float))))
      (let ((a  (get$1$2 a_b))
            (b  (get$2$2 a_b))
            (da (get$1$2 da_db))
            (db (get$2$2 da_db)))
-    (add@ff (dotv a db) (dotv da b))))
-(def rev$dotv (Tuple (Vec Float) (Vec Float))
+    (add (dot a db) (dot da b))))
+(def rev$dot (Tuple (Vec Float) (Vec Float))
                ((a_b : (Tuple (Vec Float) (Vec Float))) (dr : Float))
      (let ((a  (get$1$2 a_b))
            (b  (get$2$2 a_b)))
     (tuple (mul$R$VecR dr b) (mul$R$VecR dr a))))
 
-(def dotvv Float ((a : Vec (Vec Float)) (b : Vec (Vec Float)))
-  (sum (build (size a) (lam (i : Integer) (dotv (index i a) (index i b)))))
+(def dot Float ((a : Vec (Vec Float)) (b : Vec (Vec Float)))
+  (sum (build (size a) (lam (i : Integer) (dot (index i a) (index i b)))))
   )
 
 (def sqnorm Float ((v : Vec Float))
-  (dotv v v))
+  (dot v v))
 
 ; mul Mat Vec
 (edef mul$Mat$Vec (Vec Float) ((Vec (Vec Float)) (Vec Float)))
@@ -73,11 +73,11 @@
    (assert (eq (size l) (gmm_knossos_tri D))
     (build D (lam (i : Integer)
         (build D (lam (j : Integer)
-           (if (lt@ii i j)
+           (if (lt i j)
             0.0
             (if (eq i j)
               (exp (index i q))
-              (index (add@ii (gmm_knossos_tri (sub@ii i 1)) j) l))
+              (index (add (gmm_knossos_tri (sub i 1)) j) l))
            )
            )))))))
 
@@ -87,10 +87,10 @@
 ; TODO deriv lgamma - but no deriv wishart_m anyway.
 ; wishart_m -> int
 (def log_gamma_distrib Float ((a : Float) (p : Integer))
-    (let ((out (mul@ff 0.28618247146235004 (to_float (mul@ii p (sub@ii p 1)))))) ; 0.25 log pi
-      (add@ff out
+    (let ((out (mul 0.28618247146235004 (to_float (mul p (sub p 1)))))) ; 0.25 log pi
+      (add out
          (sum (build p (lam (j : Integer)
-                 (lgamma (sub@ff a (mul@ff 0.5 (to_float j))))))))))
+                 (lgamma (sub a (mul 0.5 (to_float j))))))))))
 
 (def log_wishart_prior Float ((wishart : Tuple Float Integer)
                               (log_Qdiag : Vec Float)
@@ -102,16 +102,16 @@
           (sum_qs        (sum log_Qdiag))
           (Qdiag         (exp$VecR log_Qdiag))
 
-          (n  (add@ii p (add@ii wishart_m 1)))
-          (C  (sub@ff (mul@ff (to_float (mul@ii n p))
-                    (sub@ff (log wishart_gamma)
-                       (mul@ff 0.5 (log 2.0))))
-                 (log_gamma_distrib (mul@ff 0.5 (to_float n)) p)))
-          (frobenius (add@ff  (sqnorm Qdiag) (sqnorm ltri_Q)))
-          (w2f   (mul@ff 0.5 (mul@ff (mul@ff wishart_gamma wishart_gamma) frobenius)))
+          (n  (add p (add wishart_m 1)))
+          (C  (sub (mul (to_float (mul n p))
+                    (sub (log wishart_gamma)
+                       (mul 0.5 (log 2.0))))
+                 (log_gamma_distrib (mul 0.5 (to_float n)) p)))
+          (frobenius (add  (sqnorm Qdiag) (sqnorm ltri_Q)))
+          (w2f   (mul 0.5 (mul (mul wishart_gamma wishart_gamma) frobenius)))
           )
-        (sub@ff (sub@ff w2f
-              (mul@ff (to_float wishart_m)
+        (sub (sub w2f
+              (mul (to_float wishart_m)
                   sum_qs))
             C)
     ))
@@ -129,42 +129,42 @@
        (triD (size (index 0 ls)))   ; Ugh
       )
   (assert (eq triD (gmm_knossos_tri D))
-    (let ((CONSTANT (mul@ff (to_float (mul@ii N D)) (neg@f 0.9189385332046727)) ) ; n * d*-0.5*log(2 * PI)
+    (let ((CONSTANT (mul (to_float (mul N D)) (neg 0.9189385332046727)) ) ; n * d*-0.5*log(2 * PI)
           (sum_qs   (build K (lam (k12 : Integer) (sum (index k12 qs)))))
           (slse     (sum (build N (lam (i : Integer)
                           (logsumexp (build K (lam (k : Integer)
                             (let ((Q         (gmm_knossos_makeQ (index k qs) (index k ls)))
                                   (mahal_vec (mul$Mat$Vec Q
                                                       (sub$VecR$VecR (index i x) (index k means)))))
-                              (sub@ff (add@ff (index k alphas)
+                              (sub (add (index k alphas)
                                     ; (index k sum_qs)
                                     (sum (index k qs))
                               )
-                                (mul@ff 0.500000  (sqnorm mahal_vec)))
+                                (mul 0.500000  (sqnorm mahal_vec)))
                             ))))
                           ))))
           )
-            (add@ff (add@ff CONSTANT
-                (sub@ff slse
-                  (mul@ff (to_float N) (logsumexp alphas))))
+            (add (add CONSTANT
+                (sub slse
+                  (mul (to_float N) (logsumexp alphas))))
             (sum (build K (lam (k : Integer)
                     (log_wishart_prior wishart (index k qs) (index k ls))))))
     ))))
 
 (def mkfloat Float ((seed  : Integer)
                     (scale : Float))
-       (mul@ff ($ranhashdoub seed) scale))
+       (mul ($ranhashdoub seed) scale))
 
 (def mkvec (Vec Float) ((seed  : Integer)
                         (n     : Integer)
                         (scale : Float))
-    (build n (lam (j : Integer) (mkfloat (add@ii j seed) scale))))
+    (build n (lam (j : Integer) (mkfloat (add j seed) scale))))
 
 (def mkvecvec (Vec (Vec Float)) ((seed  : Integer)
                                  (n     : Integer)
                                  (m     : Integer)
                                  (scale : Float))
-     (build n (lam (j : Integer) (mkvec (add@ii (mul@ii j m) seed) m scale))))
+     (build n (lam (j : Integer) (mkvec (add (mul j m) seed) m scale))))
 
 (def main Integer ()
     (let ((D 64)
@@ -174,11 +174,11 @@
           (scale_unity 1.0)
           (scale_small 0.1)
 
-          (x       (mkvecvec (add@ii seed 0)    N D scale_unity))
-          (alphas  (mkvec    (add@ii seed 1000) K   scale_unity))
-          (mus     (mkvecvec (add@ii seed 2000) K D scale_unity))
-          (qs      (mkvecvec (add@ii seed 3000) K D scale_small))
-          (ls      (mkvecvec (add@ii seed 4000) K (gmm_knossos_tri D) scale_unity))
+          (x       (mkvecvec (add seed 0)    N D scale_unity))
+          (alphas  (mkvec    (add seed 1000) K   scale_unity))
+          (mus     (mkvecvec (add seed 2000) K D scale_unity))
+          (qs      (mkvecvec (add seed 3000) K D scale_small))
+          (ls      (mkvecvec (add seed 4000) K (gmm_knossos_tri D) scale_unity))
           (wishart (tuple 3.1 7))
         )
 

--- a/test/ksc/gmm.ks
+++ b/test/ksc/gmm.ks
@@ -1,48 +1,48 @@
 ; Copyright (c) Microsoft Corporation.
 ; Licensed under the MIT license.
 (def gmm_knossos_tri Integer ((n : Integer))
-  (div@ii (mul@ii n (sub@ii n 1)) 2))
+  (div (mul n (sub n 1)) 2))
 
 (def exp$VecR (Vec Float) ((v : Vec Float))
   (build (size v) (lam (i : Integer) (exp (index i v)))))
 
 (def mul$R$VecR (Vec Float) ((r : Float) (a : Vec Float))
-    (build (size a) (lam (i : Integer) (mul@ff r (index i a)))))
+    (build (size a) (lam (i : Integer) (mul r (index i a)))))
 
 (def mul$R$VecVecR (Vec (Vec Float)) ((r : Float) (a : Vec (Vec Float)))
     (build (size a) (lam (i : Integer) (mul$R$VecR r (index i a)))))
 
 (def mul$VecR$VecR (Vec Float) ((a : Vec Float) (b : Vec Float))
-  (build (size a) (lam (i : Integer) (mul@ff (index i a) (index i b)))))
+  (build (size a) (lam (i : Integer) (mul (index i a) (index i b)))))
 
 (def sub$VecR$VecR (Vec Float) ((a : Vec Float) (b : Vec Float))
-  (build (size a) (lam (i : Integer) (sub@ff (index i a) (index i b)))))
+  (build (size a) (lam (i : Integer) (sub (index i a) (index i b)))))
 
-; dotv
-(edef dotv Float ((Vec Float) (Vec Float)))
-(edef D$dotv (LM (Tuple (Vec Float) (Vec Float)) Float)
+; dot
+(edef dot Float ((Vec Float) (Vec Float)))
+(edef D$dot (LM (Tuple (Vec Float) (Vec Float)) Float)
              ((Vec Float) (Vec Float)))
-(edef Dt$dotv (Tuple Float (LM (Tuple (Vec Float) (Vec Float)) Float))
+(edef Dt$dot (Tuple Float (LM (Tuple (Vec Float) (Vec Float)) Float))
               ((Vec Float) (Vec Float)))
-(edef R$dotv (LM Float (Tuple (Vec Float) (Vec Float))) ((Vec Float) (Vec Float)))
-(def fwd$dotv Float ((a_b : (Tuple (Vec Float) (Vec Float))) (da_db : (Tuple (Vec Float) (Vec Float))))
+(edef R$dot (LM Float (Tuple (Vec Float) (Vec Float))) ((Vec Float) (Vec Float)))
+(def fwd$dot Float ((a_b : (Tuple (Vec Float) (Vec Float))) (da_db : (Tuple (Vec Float) (Vec Float))))
      (let ((a  (get$1$2 a_b))
            (b  (get$2$2 a_b))
            (da (get$1$2 da_db))
            (db (get$2$2 da_db)))
-    (add@ff (dotv a db) (dotv da b))))
-(def rev$dotv (Tuple (Vec Float) (Vec Float))
+    (add (dot a db) (dot da b))))
+(def rev$dot (Tuple (Vec Float) (Vec Float))
                ((a_b : (Tuple (Vec Float) (Vec Float))) (dr : Float))
      (let ((a  (get$1$2 a_b))
            (b  (get$2$2 a_b)))
     (tuple (mul$R$VecR dr b) (mul$R$VecR dr a))))
 
-(def dotvv Float ((a : Vec (Vec Float)) (b : Vec (Vec Float)))
-  (sum (build (size a) (lam (i : Integer) (dotv (index i a) (index i b)))))
+(def dot Float ((a : Vec (Vec Float)) (b : Vec (Vec Float)))
+  (sum (build (size a) (lam (i : Integer) (dot (index i a) (index i b)))))
   )
 
 (def sqnorm Float ((v : Vec Float))
-  (dotv v v))
+  (dot v v))
 
 ; mul Mat Vec
 (edef mul$Mat$Vec (Vec Float) ((Vec (Vec Float)) (Vec Float)))
@@ -73,11 +73,11 @@
   (assert (eq triD (gmm_knossos_tri D))
     (build D (lam (i : Integer)
         (build D (lam (j : Integer)
-           (if (lt@ii i j)
+           (if (lt i j)
             0.0
             (if (eq i j)
               (exp (index i q))
-              (index (add@ii (sub@ii (gmm_knossos_tri D) (gmm_knossos_tri (sub@ii D j))) (sub@ii (sub@ii i j) 1)) l))
+              (index (add (sub (gmm_knossos_tri D) (gmm_knossos_tri (sub D j))) (sub (sub i j) 1)) l))
            )
            )))))))
 
@@ -86,10 +86,10 @@
 
 ; wishart_m -> int
 (def log_gamma_distrib Float ((a : Float) (p : Integer))
-    (let ((out (mul@ff 0.28618247146235004 (to_float (mul@ii p (sub@ii p 1)))))) ; 0.25 log pi
-      (add@ff out
+    (let ((out (mul 0.28618247146235004 (to_float (mul p (sub p 1)))))) ; 0.25 log pi
+      (add out
          (sum (build p (lam (j : Integer)
-                 (lgamma (sub@ff a (mul@ff 0.5 (to_float j))))))))))
+                 (lgamma (sub a (mul 0.5 (to_float j))))))))))
 
 (def log_wishart_prior Float ((wishart : Tuple Float Integer)
                               (log_Qdiag : Vec Float)
@@ -101,16 +101,16 @@
           (sum_qs        (sum log_Qdiag))
           (Qdiag         (exp$VecR log_Qdiag))
 
-          (n  (add@ii p (add@ii wishart_m 1)))
-          (C  (sub@ff (mul@ff (to_float (mul@ii n p))
-                    (sub@ff (log wishart_gamma)
-                       (mul@ff 0.5 (log 2.0))))
-                 (log_gamma_distrib (mul@ff 0.5 (to_float n)) p)))
-          (frobenius (add@ff  (sqnorm Qdiag) (sqnorm ltri_Q)))
-          (w2f   (mul@ff 0.5 (mul@ff (mul@ff wishart_gamma wishart_gamma) frobenius)))
+          (n  (add p (add wishart_m 1)))
+          (C  (sub (mul (to_float (mul n p))
+                    (sub (log wishart_gamma)
+                       (mul 0.5 (log 2.0))))
+                 (log_gamma_distrib (mul 0.5 (to_float n)) p)))
+          (frobenius (add  (sqnorm Qdiag) (sqnorm ltri_Q)))
+          (w2f   (mul 0.5 (mul (mul wishart_gamma wishart_gamma) frobenius)))
           )
-        (sub@ff (sub@ff w2f
-              (mul@ff (to_float wishart_m)
+        (sub (sub w2f
+              (mul (to_float wishart_m)
                   sum_qs))
             C)
     ))
@@ -128,42 +128,42 @@
        (triD (size (index 0 ls)))   ; Ugh
       )
   (assert (eq triD (gmm_knossos_tri D))
-    (let ((CONSTANT (mul@ff (to_float (mul@ii N D)) (neg@f 0.9189385332046727)) ) ; n * d*-0.5*log(2 * PI)
+    (let ((CONSTANT (mul (to_float (mul N D)) (neg 0.9189385332046727)) ) ; n * d*-0.5*log(2 * PI)
           (sum_qs   (build K (lam (k12 : Integer) (sum (index k12 qs)))))
           (slse     (sum (build N (lam (i : Integer)
                           (logsumexp (build K (lam (k : Integer)
                             (let ((Q         (gmm_knossos_makeQ (index k qs) (index k ls)))
                                   (mahal_vec (mul$Mat$Vec Q
                                                       (sub$VecR$VecR (index i x) (index k means)))))
-                              (sub@ff (add@ff (index k alphas)
+                              (sub (add (index k alphas)
                                     ; (index k sum_qs)
                                     (sum (index k qs))
                               )
-                                (mul@ff 0.500000  (sqnorm mahal_vec)))
+                                (mul 0.500000  (sqnorm mahal_vec)))
                             ))))
                           ))))
           )
-            (add@ff (add@ff CONSTANT
-                (sub@ff slse
-                  (mul@ff (to_float N) (logsumexp alphas))))
+            (add (add CONSTANT
+                (sub slse
+                  (mul (to_float N) (logsumexp alphas))))
             (sum (build K (lam (k : Integer)
                     (log_wishart_prior wishart (index k qs) (index k ls))))))
     ))))
 
 (def mkfloat Float ((seed  : Integer)
                     (scale : Float))
-       (mul@ff ($ranhashdoub seed) scale))
+       (mul ($ranhashdoub seed) scale))
 
 (def mkvec (Vec Float) ((seed  : Integer)
                         (n     : Integer)
                         (scale : Float))
-    (build n (lam (j : Integer) (mkfloat (add@ii j seed) scale))))
+    (build n (lam (j : Integer) (mkfloat (add j seed) scale))))
 
 (def mkvecvec (Vec (Vec Float)) ((seed  : Integer)
                                 (n     : Integer)
                                 (m     : Integer)
                                 (scale : Float))
-     (build n (lam (j : Integer) (mkvec (add@ii (mul@ii j m) seed) m scale))))
+     (build n (lam (j : Integer) (mkvec (add (mul j m) seed) m scale))))
 
 (def not_ Bool (p : Bool) (if p false true))
 
@@ -176,28 +176,28 @@
           (scale_small 0.1)
 
 
-          (x       (mkvecvec (add@ii seed 0)    N D scale_unity))
-          (alphas  (mkvec    (add@ii seed 1000) K   scale_unity))
-          (mus     (mkvecvec (add@ii seed 2000) K D scale_unity))
-          (qs      (mkvecvec (add@ii seed 3000) K D scale_small))
-          (ls      (mkvecvec (add@ii seed 4000) K (gmm_knossos_tri D) scale_unity))
+          (x       (mkvecvec (add seed 0)    N D scale_unity))
+          (alphas  (mkvec    (add seed 1000) K   scale_unity))
+          (mus     (mkvecvec (add seed 2000) K D scale_unity))
+          (qs      (mkvecvec (add seed 3000) K D scale_small))
+          (ls      (mkvecvec (add seed 4000) K (gmm_knossos_tri D) scale_unity))
           (wishart (tuple 3.1 7))
 
           (delta 0.0001)
 
-          (dx       (mkvecvec (add@ii seed 5000)  N D delta))
-          (dalphas  (mkvec    (add@ii seed 6000)  K   delta))
-          (dmus     (mkvecvec (add@ii seed 7000)  K D delta))
-          (dqs      (mkvecvec (add@ii seed 8000)  K D delta))
-          (dls      (mkvecvec (add@ii seed 9000)  K (gmm_knossos_tri D) delta))
-          (dwishart (tuple (mkfloat (add@ii seed 10000) delta) (tuple)))
+          (dx       (mkvecvec (add seed 5000)  N D delta))
+          (dalphas  (mkvec    (add seed 6000)  K   delta))
+          (dmus     (mkvecvec (add seed 7000)  K D delta))
+          (dqs      (mkvecvec (add seed 8000)  K D delta))
+          (dls      (mkvecvec (add seed 9000)  K (gmm_knossos_tri D) delta))
+          (dwishart (tuple (mkfloat (add seed 10000) delta) (tuple)))
 
           (dtheta   (tuple dx dalphas dmus dqs dls dwishart))
 
           (gmm_at_theta (gmm_knossos_gmm_objective x alphas mus qs ls wishart))
           (gmm_at_theta_plus_dtheta (gmm_knossos_gmm_objective (ts_add x dx) (ts_add alphas dalphas) (ts_add mus dmus) (ts_add qs dqs) (ts_add ls dls) (ts_add wishart dwishart)))
 
-          (gmm_fd (sub@ff gmm_at_theta_plus_dtheta gmm_at_theta))
+          (gmm_fd (sub gmm_at_theta_plus_dtheta gmm_at_theta))
           (gmm_fwd (fwd$gmm_knossos_gmm_objective
                     (tuple x  alphas  mus  qs  ls  wishart)
                     (tuple dx dalphas dmus dqs dls dwishart)))
@@ -206,8 +206,8 @@
            (let ((tolerance 0.000001)
                  (actual gmm_at_theta)
                  (expected 76.0882))
-             (lt@ff (abs (sub@ff actual expected))
-                (max (mul@ff (abs expected) tolerance)
+             (lt (abs (sub actual expected))
+                (max (mul (abs expected) tolerance)
                      tolerance))))
 
           (everything_works_as_expected
@@ -218,8 +218,8 @@
            (let ((tolerance 0.001)
                  (actual gmm_fd)
                  (expected gmm_fwd))
-             (lt@ff (abs (sub@ff actual expected))
-                (max (mul@ff (abs expected) tolerance)
+             (lt (abs (sub actual expected))
+                (max (mul (abs expected) tolerance)
                      tolerance))))
           (impossibly_good (eq gmm_fd gmm_fwd))
 
@@ -233,21 +233,21 @@
           (grad_gmm_ls         (get$5$6 grad_gmm))
           (grad_gmm_wishart    (get$6$6 grad_gmm))
 
-          (dot_at_x          (dotvv grad_gmm_x dx))
-          (dot_at_alphas     (dotv  grad_gmm_alphas dalphas))
-          (dot_at_mus        (dotvv grad_gmm_mus dmus))
-          (dot_at_qs         (dotvv grad_gmm_qs dqs))
-          (dot_at_ls         (dotvv grad_gmm_ls dls))
-          (dot_at_wishart    (mul@ff (get$1$2 grad_gmm_wishart) (get$1$2 dwishart)))
+          (dot_at_x          (dot grad_gmm_x dx))
+          (dot_at_alphas     (dot grad_gmm_alphas dalphas))
+          (dot_at_mus        (dot grad_gmm_mus dmus))
+          (dot_at_qs         (dot grad_gmm_qs dqs))
+          (dot_at_ls         (dot grad_gmm_ls dls))
+          (dot_at_wishart    (mul (get$1$2 grad_gmm_wishart) (get$1$2 dwishart)))
 
-          (grad_gmm_dot_dtheta (add@ff      dot_at_x
-                                (add@ff     dot_at_alphas
-                                 (add@ff    dot_at_mus
-                                  (add@ff   dot_at_qs
-                                   (add@ff  dot_at_ls
+          (grad_gmm_dot_dtheta (add      dot_at_x
+                                (add     dot_at_alphas
+                                 (add    dot_at_mus
+                                  (add   dot_at_qs
+                                   (add  dot_at_ls
                                        dot_at_wishart))))))
 
-          (df (sub@ff gmm_at_theta_plus_dtheta gmm_at_theta))
+          (df (sub gmm_at_theta_plus_dtheta gmm_at_theta))
           (rev_ok (tuple grad_gmm_dot_dtheta " ==?== " df))
 
 
@@ -272,7 +272,7 @@
                     1.0))
 
           (tolerance 0.0001)
-          (everything_works_as_expected_reverse (lt@ff checked tolerance))
+          (everything_works_as_expected_reverse (lt checked tolerance))
         )
       (pr x
           (gmm_knossos_makeQ (index 0 qs) (index 0 ls))

--- a/test/ksc/gmmpy.cpp
+++ b/test/ksc/gmmpy.cpp
@@ -42,6 +42,6 @@ PYBIND11_MODULE(PYTHON_MODULE_NAME, m) {
   declare_vec<ks::vec<ks::vec<double> > >(m, std::string("vec_vec_double"));
   declare_vec<ks::vec<ks::vec<ks::vec<double> > > >(m, std::string("vec_vec_vec_double"));
   declare_vec<ks::vec<ks::vec<ks::vec<ks::vec<double> > > > >(m, std::string("vec_vec_vec_vec_double"));
-  m.def("gmm_knossos_gmm_objective", &ks::gmm_knossos_gmm_objective);
-  m.def("rev_gmm_knossos_gmm_objective", &ks::rev$gmm_knossos_gmm_objective);
+  m.def("gmm_knossos_gmm_objective", &ks::gmm_knossos_gmm_objective$avvfvfvvfvvfvvf$dfi$b);
+  m.def("rev_gmm_knossos_gmm_objective", &ks::rev$gmm_knossos_gmm_objective$a$dvvfvfvvfvvfvvf$dfi$b$bf);
 }

--- a/test/ksc/inline.ks
+++ b/test/ksc/inline.ks
@@ -1,5 +1,5 @@
 ; Copyright (c) Microsoft Corporation.
 ; Licensed under the MIT license.
-(def f Float (x : Float) (mul@ff x x))
+(def f Float (x : Float) (mul x x))
 
-(def g Float (y : Float) (add@ff 1.0 ($inline (f (add@ff y y)))))
+(def g Float (y : Float) (add 1.0 ($inline (f (add y y)))))

--- a/test/ksc/lmzero.ks
+++ b/test/ksc/lmzero.ks
@@ -1,7 +1,7 @@
 ; Copyright (c) Microsoft Corporation.
 ; Licensed under the MIT license.
 (def h (Vec Float) (x : Vec Float)
-  (build (mul@ii 2 (size x)) (lam (i : Integer) 1.0)))
+  (build (mul 2 (size x)) (lam (i : Integer) 1.0)))
 
 (def main Integer ()
   (pr 1.1))

--- a/test/ksc/logsumexp.ks
+++ b/test/ksc/logsumexp.ks
@@ -10,9 +10,9 @@
     (log (sum (build (size v) (lam (i : Integer) (exp (index i v)))))))
 
 (def sub$VecR$R (Vec Float) ((v : Vec Float) (x : Float))
-     (build (size v) (lam (ni : Integer) (sub@ff (index ni v) x))))
+     (build (size v) (lam (ni : Integer) (sub (index ni v) x))))
 
-(def max_ Float ((x : Float) (y : Float)) (if (gt@ff x y) x y))
+(def max_ Float ((x : Float) (y : Float)) (if (gt x y) x y))
 
 (def max$VecR Float (v : Vec Float)
      (let ; We can't write -inf in a .ks file so use something very
@@ -28,4 +28,4 @@
 (def logsumexp_safe Float (a : Vec Float)
   (let (mx (max$VecR a))
     (let (sum_exp_minus_x (sum (exp$Vec (sub$VecR$R a mx))))
-        (add@ff (log sum_exp_minus_x) mx))))
+        (add (log sum_exp_minus_x) mx))))

--- a/test/ksc/mnistcnn.ks
+++ b/test/ksc/mnistcnn.ks
@@ -19,27 +19,27 @@
        (sumbuild kn (lam (kni : Integer)
        (sumbuild km (lam (kmi : Integer)
        (sumbuild l  (lam (li  : Integer)
-         (let ((knc (div@ii kn 2))
-               (kmc (div@ii km 2))
-               (noi (add@ii (sub@ii ni knc) kni))
-               (moi (add@ii (sub@ii mi kmc) kmi))
-               (outside_image (ks_or (lt@ii noi 0)
-                              (ks_or (gte@ii noi n)
-                              (ks_or (lt@ii moi 0)
-                                     (gte@ii moi m)))))
+         (let ((knc (div kn 2))
+               (kmc (div km 2))
+               (noi (add (sub ni knc) kni))
+               (moi (add (sub mi kmc) kmi))
+               (outside_image (ks_or (lt noi 0)
+                              (ks_or (gte noi n)
+                              (ks_or (lt moi 0)
+                                     (gte moi m)))))
                (image_noi_moi
                 (if outside_image
                     0.0
                   (index moi (index noi (index li image))))))
 
-           (mul@ff image_noi_moi
+           (mul image_noi_moi
               (index kmi (index kni (index li (index ki kernels)))))
 
            )))))))
        (index ki bias))
        ))))))))
 
-(def max_ Float ((x : Float) (y : Float)) (if (gt@ff x y) x y))
+(def max_ Float ((x : Float) (y : Float)) (if (gt x y) x y))
 
 (def relu Float (x : Float) (max_ x 0.0))
 
@@ -67,14 +67,14 @@
          (n (size image_elt))
          (m (size (index 0 image_elt))))
      (build l (lam (li : Integer)
-     (build (div@ii n 2) (lam (ni : Integer)
-     (build (div@ii m 2) (lam (mi : Integer)
-       (let ((nid (mul@ii 2 ni))
-             (mid (mul@ii 2 mi))
+     (build (div n 2) (lam (ni : Integer)
+     (build (div m 2) (lam (mi : Integer)
+       (let ((nid (mul 2 ni))
+             (mid (mul 2 mi))
              (a00 (index mid (index nid (index li image))))
-             (a01 (index (add@ii 1 mid) (index nid (index li image))))
-             (a10 (index mid (index (add@ii 1 nid) (index li image))))
-             (a11 (index (add@ii 1 mid) (index (add@ii 1 nid) (index li image)))))
+             (a01 (index (add 1 mid) (index nid (index li image))))
+             (a10 (index mid (index (add 1 nid) (index li image))))
+             (a11 (index (add 1 mid) (index (add 1 nid) (index li image)))))
          (max_ (max_ a00 a01) (max_ a10 a11))
          )))))))))
 
@@ -93,7 +93,7 @@
      (sumbuild k (lam (ki : Integer)
      (sumbuild n (lam (ni : Integer)
      (sumbuild m (lam (mi : Integer)
-       (mul@ff (index mi (index ni (index ki (index oi w))))
+       (mul (index mi (index ni (index ki (index oi w))))
              (index mi (index ni (index ki image))))
        ))))))
      (index oi bias))
@@ -110,7 +110,7 @@
      (build o (lam (oi : Integer)
      (ts_add
      (sumbuild k (lam (ki : Integer)
-       (mul@ff (index ki (index oi w))
+       (mul (index ki (index oi w))
              (index ki image))
        ))
      (index oi bias))

--- a/test/ksc/mnistcnnpy.cpp
+++ b/test/ksc/mnistcnnpy.cpp
@@ -30,6 +30,6 @@ PYBIND11_MODULE(PYTHON_MODULE_NAME, m) {
   declare_vec<ks::vec<ks::vec<double> > >(m, std::string("vec_vec_double"));
   declare_vec<ks::vec<ks::vec<ks::vec<double> > > >(m, std::string("vec_vec_vec_double"));
   declare_vec<ks::vec<ks::vec<ks::vec<ks::vec<double> > > > >(m, std::string("vec_vec_vec_vec_double"));
-  m.def("conv2d", &ks::conv2d);
-  m.def("mnist", &ks::mnist);
+  m.def("conv2d", &ks::conv2d$avvvvfvfvvvf);
+  m.def("mnist", &ks::mnist$avvvfvvvvfvfvvvvfvfvvvvfvfvvfvf);
 }

--- a/test/ksc/mul4.ks
+++ b/test/ksc/mul4.ks
@@ -3,7 +3,7 @@
 
 
 (def h Float ( (x1 : Float) (x2 : Float) (x3 : Float) (x4 : Float) )
-       (mul@ff x1 (mul@ff x2 (mul@ff x3 x4))))
+       (mul x1 (mul x2 (mul x3 x4))))
 
 ; (def times ( (x1 : Float) (x2 : Float) ) (mul x1 x2))
 ; (def h ( (x1 : Float) (x2 : Float) (x3 : Float) (x4 : Float) )

--- a/test/ksc/mul8.ks
+++ b/test/ksc/mul8.ks
@@ -1,12 +1,12 @@
 ; Copyright (c) Microsoft Corporation.
 ; Licensed under the MIT license.
-(def xtimes Float ( (x1 : Float) (x2 : Float) ) (mul@ff x1 x2))
+(def xtimes Float ( (x1 : Float) (x2 : Float) ) (mul x1 x2))
 
-(def times Float ( (x1 : Float) (x2 : Float) ) (mul@ff x1 (mul@ff x2 2.0)))
+(def times Float ( (x1 : Float) (x2 : Float) ) (mul x1 (mul x2 2.0)))
 
 ; (def h ( (x1 : Float) (x2 : Float) (x3 : Float) (x4 : Float)
 ;         (x5 : Float) (x6 : Float) (x7 : Float) (x8 : Float))
-;       (mul@ff x1 (mul@ff x2 (mul@ff x3 (mul@ff x4 (mul@ff x5 (mul@ff x6 (mul@ff x7 x8))))))))
+;       (mul x1 (mul x2 (mul x3 (mul x4 (mul x5 (mul x6 (mul x7 x8))))))))
 
 (def h Float
        ( (x1 : Float) (x2 : Float) (x3 : Float) (x4 : Float)

--- a/test/ksc/negative-float-literals.ks
+++ b/test/ksc/negative-float-literals.ks
@@ -1,3 +1,3 @@
 ; Copyright (c) Microsoft Corporation.
 ; Licensed under the MIT license.
-(def f Float (x : Float) (mul@ff x -1.0))
+(def f Float (x : Float) (mul x -1.0))

--- a/test/ksc/power.ks
+++ b/test/ksc/power.ks
@@ -3,7 +3,7 @@
 (def f Float ( (n : Integer) (x : Float) )
     (if (eq n 1) 
         x 
-        (mul@ff x (f (sub@ii n 1) x))))
+        (mul x (f (sub n 1) x))))
 
 (def main Integer ()
     (let ((n 7)
@@ -16,5 +16,5 @@
             ; And forward
             (fwd$f (tuple n x) (tuple (tuple) 1.0))
             ; Is the derivative n*x^(n-1)?
-            (mul@ff (to_float n) (f (sub@ii n 1) x))
+            (mul (to_float n) (f (sub n 1) x))
         )))

--- a/test/ksc/sum.ks
+++ b/test/ksc/sum.ks
@@ -1,4 +1,4 @@
 ; Copyright (c) Microsoft Corporation.
 ; Licensed under the MIT license.
 (def vsum Float ( (i : Integer) (v : Vec Float) )
-       (if (eq i 0) 0.0 (add@ff (index i v) (vsum (add@ii i 1) v))))
+       (if (eq i 0) 0.0 (add (index i v) (vsum (add i 1) v))))

--- a/test/ksc/syntax-primer.ks
+++ b/test/ksc/syntax-primer.ks
@@ -11,7 +11,7 @@
 ; The following defines a function of two variables x and y (both
 ; Integers) which returns an Integer.
 (def f1 Integer ((x : Integer) (y : Integer))
-     (add@ii x y))
+     (add x y))
 
 ; Python equivalent
 ;
@@ -48,7 +48,7 @@ If you prefer block comments then use pairs of #| and |#
       (c : Integer)
       (d : Integer)
       (e : Integer))
-     (sub@ii (add@ii (mul@ii a b) (neg@i c)) (div@ii d e)))
+     (sub (add (mul a b) (neg c)) (div d e)))
 
 ; Python equivalent
 ;
@@ -66,8 +66,8 @@ If you prefer block comments then use pairs of #| and |#
 ; The Knossos boolean type is called "Bool"
 (def if_example Integer ((b1 : Bool) (b2 : Bool) (a : Integer))
      (if (ks_or b1 b2)
-         (add@ii a 10)
-         (sub@ii a 10)))
+         (add a 10)
+         (sub a 10)))
 
 ; Python equivalent
 ;
@@ -110,10 +110,10 @@ If you prefer block comments then use pairs of #| and |#
 ; To create new variables use "let"
 (def let_and_types Float ((b : Bool) (s : String) (i : Integer) (f : Float) (v : Vec Float))
      (let ((b2 (ks_or b false))
-           (i2 (add@ii i 10))
-           (f2 (add@ff f 10.0))
+           (i2 (add i 10))
+           (f2 (add f 10.0))
            (s2 "Hello"))
-       (if (ks_and (gte@ii i 0) (lt@ii i (size v)))
+       (if (ks_and (gte i 0) (lt i (size v)))
            (index i v)
            f2)))
 
@@ -140,7 +140,7 @@ If you prefer block comments then use pairs of #| and |#
 ; a vector of length n where the element at position i is given by the
 ; lambda expression applied to i".
 (def build_example (Vec Float) (n : Integer)
-     (build n (lam (ni : Integer) (to_float (mul@ii ni ni)))))
+     (build n (lam (ni : Integer) (to_float (mul ni ni)))))
 
 ; Python equivalent
 ;
@@ -156,7 +156,7 @@ If you prefer block comments then use pairs of #| and |#
 (def triangle0 Integer (n : Integer)
     (if (eq n 0)
         0
-        (add@ii n (triangle0 (sub@ii n 1)))))
+        (add n (triangle0 (sub n 1)))))
 
 ; Python equivalent
 ;
@@ -186,7 +186,7 @@ If you prefer block comments then use pairs of #| and |#
 (def triangle Integer ((acc : Integer) (n : Integer))
      (if (eq n 0)
          0
-         (triangle (add@ii acc n) (sub@ii n 1))))
+         (triangle (add acc n) (sub n 1))))
 
 ; Python equivalent
 ;
@@ -226,7 +226,7 @@ If you prefer block comments then use pairs of #| and |#
      (fold (lam (s_vi : Tuple Float Float)
                 (let ((s (get$1$2 s_vi))
                       (vi (get$2$2 s_vi)))
-                  (add@ff s vi)))
+                  (add s vi)))
            0.0
            v))
 
@@ -262,6 +262,6 @@ If you prefer block comments then use pairs of #| and |#
 ; manual derivatives for your function.
 (edef my_log Float (Float))
 (edef D$my_log (LM Float Float) (Float))
-(def fwd$my_log Float ((x : Float) (dx : Float)) (div@ff dx x))
-(def rev$my_log Float ((x : Float) (d_dmy_log : Float)) (div@ff d_dmy_log x))
+(def fwd$my_log Float ((x : Float) (dx : Float)) (div dx x))
+(def rev$my_log Float ((x : Float) (d_dmy_log : Float)) (div d_dmy_log x))
 (edef Dt$my_log (Tuple Float (LM Float Float)) (Float))

--- a/test/ksc/test0.ks
+++ b/test/ksc/test0.ks
@@ -1,15 +1,15 @@
 ; Copyright (c) Microsoft Corporation.
 ; Licensed under the MIT license.
 (def h Integer ((y : Integer))
-    (sum (build 3 (lam (y3 : Integer) (add@ii y 2))))
+    (sum (build 3 (lam (y3 : Integer) (add y 2))))
     )
 
 (def f Float (x : Float)
-    ($trace (mul@ff x x))
+    ($trace (mul x x))
 )
 
 (def g Float ((n : Integer) (m : Integer))
-  (to_float (mul@ii n m)))
+  (to_float (mul n m)))
 
 (def e Float ((vn : Vec Integer)
               (t : Tuple (Vec (Vec Float))
@@ -17,11 +17,11 @@
                                 (Vec Float))))
   (let ((n (size vn))
         (m (size (get$1$2 t))))
-  (add@ff (sum (build n (lam (i : Integer) (to_float i))))
+  (add (sum (build n (lam (i : Integer) (to_float i))))
      (sum (build m (lam (j : Integer) (sum (get$2$2 (get$2$2 t)))))))))
 
 (def test_inline (Vec Integer) (x : Vec Float)
-    (build (size x) (lam (i : Integer) (mul@ii i 2))))
+    (build (size x) (lam (i : Integer) (mul i 2))))
 
 (def test_inline2 Integer (x : Vec Float)
   (let (n1 (size x))

--- a/test/ksc/test1.ks
+++ b/test/ksc/test1.ks
@@ -1,21 +1,21 @@
 ; Copyright (c) Microsoft Corporation.
 ; Licensed under the MIT license.
 (def a Float ((x : Float))
-    (mul@ff 3.0 x))
+    (mul 3.0 x))
 
 (def b Float ((y : Float))
-    (mul@ff 2.0 y))
+    (mul 2.0 y))
 
 (def g Float ((x : Float) (y : Float))
-    (mul@ff x y))
+    (mul x y))
 
 ; f = 3z/2y for z=5x so f = 15x/2y so linear in x
 (def f1 Float ((x : Float) (y : Float))
-    (let (z (mul@ff 5.0 x))
-        (div@ff (a z) (b y))))
+    (let (z (mul 5.0 x))
+        (div (a z) (b y))))
 
 (def f Float ((x : Float) (y : Float))
-    (div@ff x y))
+    (div x y))
 
 (def main Integer ()
     (let ((x 1.1)
@@ -26,7 +26,7 @@
         (f 0.0 1.0)
         ; See https://github.com/awf/knossos/issues/281 (D$f 1.1 2.2 )
         (g x y)
-        "FD=" (div@ff (sub@ff (f x (add@ff y delta)) (f x y)) delta)
+        "FD=" (div (sub (f x (add y delta)) (f x y)) delta)
         (fwd$f (tuple x y) (tuple delta delta))
         "CHECK=" ($check (lam (t : Tuple Float Float) (f1 t))
                          (lam (t : Tuple (Tuple Float Float) Float) (rev$f1 t))

--- a/test/ksc/test2.ks
+++ b/test/ksc/test2.ks
@@ -2,23 +2,23 @@
 ; Licensed under the MIT license.
 
 (def f1 Float ((x :  Float) (y :  Float) (i : Integer))
-        (mul@ff (if (lt@ii i 3) (add@ff x 1.0) (mul@ff 7.0 (to_float i))) y)
+        (mul (if (lt i 3) (add x 1.0) (mul 7.0 (to_float i))) y)
 )
 
 (def f2 Float ((x : Vec Float) (y : Vec Float) (i : Integer) )
-        (mul@ff (if (lt@ii i 3) (index i x) 7.0) (index i y))
+        (mul (if (lt i 3) (index i x) 7.0) (index i y))
 )
 
 (def f7 Float ((x : Vec Float) (y : Vec Float) )
     (assert (eq (size x) (size y))
         (sum (build (size x)
-                    (lam (i : Integer) (mul@ff (if (lt@ii i 3) (index i x) 7.0) (index i y))))))
+                    (lam (i : Integer) (mul (if (lt i 3) (index i x) 7.0) (index i y))))))
 )
 
 
 
 (def main Integer ()
-    (let (v1 (build 3 (lam (i : Integer) (mul@ff 3.0 (to_float i)))))
+    (let (v1 (build 3 (lam (i : Integer) (mul 3.0 (to_float i)))))
         (pr (f7 v1 v1)
             ; See https://github.com/awf/knossos/issues/281 (D$f7 v1 v1)
             ; See https://github.com/awf/knossos/issues/281 (D$f1 1.1 2.3 2)

--- a/test/ksc/test3.ks
+++ b/test/ksc/test3.ks
@@ -1,18 +1,18 @@
 ; Copyright (c) Microsoft Corporation.
 ; Licensed under the MIT license.
 (def f Float ((x : Vec Float) (y : Vec Float))
-    (if (lt@ii 2 3) (index 0 x) 7.0)
+    (if (lt 2 3) (index 0 x) 7.0)
 )
 
 (def q (Vec Float) ((r : Float) (m : Integer) (a : Vec Float))
   (let (n (size a))
-    (build (mul@ii 2 n) (lam (i : Integer) (mul@ff r (index (div@ii i m) a))))))
+    (build (mul 2 n) (lam (i : Integer) (mul r (index (div i m) a))))))
 
 (def mkvec (Vec Float) (n : Integer)
     (build n (lam (j : Integer) (to_float j))))
 
 (def sqnorm Float (v : Vec Float)
-  (sum (build (size v) (lam (i : Integer) (let (vi (index i v)) (mul@ff vi vi))))))
+  (sum (build (size v) (lam (i : Integer) (let (vi (index i v)) (mul vi vi))))))
 
 #|
 
@@ -30,8 +30,8 @@
 (def main Integer ()
     (let ((v1 (build 4 (lam (i : Integer) (to_float i))))
           (delta 0.00001)
-          (dv (build 4 (lam (i : Integer) (mul@ff (to_float i) delta))))
-          (dq (build 8 (lam (i : Integer) (div delta (to_float (add@ff 3 i)))))))
+          (dv (build 4 (lam (i : Integer) (mul (to_float i) delta))))
+          (dq (build 8 (lam (i : Integer) (div delta (to_float (add 3 i)))))))
         (pr 1
             ; (D$f v1 v1)
             ; (D$g 1.1)

--- a/test/ksc/test4.ks
+++ b/test/ksc/test4.ks
@@ -1,7 +1,7 @@
 ; Copyright (c) Microsoft Corporation.
 ; Licensed under the MIT license.
 (def test_tuple Integer ((x : Tuple (Vec Float) (Vec (Vec Float)) Integer))
-    (add@ii 1 (if (lt@ii 2 3) 4 5)))
+    (add 1 (if (lt 2 3) 4 5)))
 
 
 (def g Float ((w : Tuple Float Integer))
@@ -9,7 +9,7 @@
 
 (def g2 Float ((wishart : Tuple Float Integer))
     (let ((wishart_gamma (get$1$2 wishart))
-         (f (mul@ff 2.2 wishart_gamma))
+         (f (mul 2.2 wishart_gamma))
          )
       f))
 

--- a/test/ksc/test_stopgrad.ks
+++ b/test/ksc/test_stopgrad.ks
@@ -1,11 +1,11 @@
 ; Copyright (c) Microsoft Corporation.
 ; Licensed under the MIT license.
 (def tri Integer (n : Integer)
-  (div@ii (mul@ii n (sub@ii n 1)) 2))
+  (div (mul n (sub n 1)) 2))
 
 ; NB This doesn't really test "stopgrad" per se anymore, but it is
 ; correct that we no longer try to differentiate with respect to
 ; Integer parameters
 
 (def f Float ((x : Float) (n : Integer))
-  (mul@ff x (to_float n)))
+  (mul x (to_float n)))

--- a/test/ksc/tm-rev.ks
+++ b/test/ksc/tm-rev.ks
@@ -1,4 +1,4 @@
 (def foo Float ((x : Float) (y : Float))
-    (let (a (add@ff (mul@ff 2.0 x) (mul@ff 3.0 y)))
-		(let (b (add@ff (mul@ff 4.0 a) (mul@ff 5.0 a)))
-		  (add@ff (mul@ff 6.0 b) (mul@ff 7.0 b)))))
+    (let (a (add (mul 2.0 x) (mul 3.0 y)))
+		(let (b (add (mul 4.0 a) (mul 5.0 a)))
+		  (add (mul 6.0 b) (mul 7.0 b)))))

--- a/test/ksc/vprod.ks
+++ b/test/ksc/vprod.ks
@@ -3,19 +3,19 @@
 (def vprod Float ( (i : Integer) (v : Vec Float) )
        (if (eq i (size v))
            1.0
-           (mul@ff (index i v) (vprod (add@ii i 1) v))))
+           (mul (index i v) (vprod (add i 1) v))))
 
 (def aprod Float ( (i : Integer) (v : Vec Float) (acc : Float) )
        (if (eq i (size v))
            acc
-         (let (acc (mul@ff acc (index i v)))
-            (aprod (add@ii i 1) v acc))))
+         (let (acc (mul acc (index i v)))
+            (aprod (add i 1) v acc))))
 
 (def fprod Float (v : Vec Float)
      (fold (lam (acc_x : Tuple Float Float)
                 (let ((acc (get$1$2 acc_x))
                       (x   (get$2$2 acc_x)))
-                  (mul@ff acc x)))
+                  (mul acc x)))
            1.0
            v))
 
@@ -30,24 +30,24 @@
 ;; to see progress bars
 (def main Integer ()
   (let ((N 6)
-        (ns (build N (lam (i : Integer) (mul@ii (add@ii i 1) 100)))))
+        (ns (build N (lam (i : Integer) (mul (add i 1) 100)))))
   (print "# Julia code:\n"
       "n=" ns "\n"
       "vp="
       (build N (lam (n : Integer)
-                  (let (v (build (index n ns) (lam (i : Integer) (add@ff ($ranhashdoub i) 0.5))))
+                  (let (v (build (index n ns) (lam (i : Integer) (add ($ranhashdoub i) 0.5))))
                       ($BENCH (lam (_ : (Tuple)) (vprod 0 v))))))
       "\n"
 
       "ap="
       (build N (lam (n : Integer)
-                  (let (v (build (index n ns) (lam (i : Integer) (add@ff ($ranhashdoub i) 0.5))))
+                  (let (v (build (index n ns) (lam (i : Integer) (add ($ranhashdoub i) 0.5))))
                       ($BENCH (lam (_ : (Tuple)) (aprod 0 v 1.0))))))
       "\n"
 
       "fp="
        (build N (lam (n : Integer) 0.0
-;                  (let (v (build (index n ns) (lam (i : Integer) (add@ff ($ranhashdoub i) 0.5))))
+;                  (let (v (build (index n ns) (lam (i : Integer) (add ($ranhashdoub i) 0.5))))
 ;                      ($BENCH (lam (_ : (Tuple)) (fprod v))))))
                      ))
       "\n# C++ currently seems to optimize this to a constant at -O3"
@@ -55,20 +55,20 @@
 
       "rvp="
       (build N (lam (n : Integer)
-                  (let (v (build (index n ns) (lam (i : Integer) (add@ff ($ranhashdoub i) 0.5))))
+                  (let (v (build (index n ns) (lam (i : Integer) (add ($ranhashdoub i) 0.5))))
                       ($BENCH (lam (_ : (Tuple)) (vchomp (rev$vprod (tuple 0 v) 1.0)))))))
       "\n"
 
       "rap="
       (build N (lam (n : Integer)
-                  (let (v (build (index n ns) (lam (i : Integer) (add@ff ($ranhashdoub i) 0.5))))
+                  (let (v (build (index n ns) (lam (i : Integer) (add ($ranhashdoub i) 0.5))))
                       ($BENCH (lam (_ : (Tuple)) (achomp (rev$aprod (tuple 0 v 1.0) 1.0)))))))
 
       "\n"
 
       "rfp="
       (build N (lam (n : Integer)
-                  (let (v (build (index n ns) (lam (i : Integer) (add@ff ($ranhashdoub i) 0.5))))
+                  (let (v (build (index n ns) (lam (i : Integer) (add ($ranhashdoub i) 0.5))))
                       ($BENCH (lam (_ : (Tuple)) (fchomp (rev$fprod v 1.0)))))))
 
       "\n"

--- a/test/python/test_abstract_backend.py
+++ b/test/python/test_abstract_backend.py
@@ -10,11 +10,11 @@ from ksc.tracing.functions import core
 
 def test_get_shape():
     ks_str = """
-(def get_shape@vvvvf (Tuple Integer Integer Integer Integer) ((x : (Vec (Vec (Vec (Vec Float))))))
-  (let ((v0 (index@ivvvvf 0 x)))
-  (let ((v1 (index@ivvvf 0 v0)))
-    (let ((v2 (index@ivvf 0 v1)))
-      (tuple@iiii (size@vvvvf x) (size@vvvf v0) (size@vvf v1) (size@vf v2))
+(def get_shape (Tuple Integer Integer Integer Integer) ((x : (Vec (Vec (Vec (Vec Float))))))
+  (let ((v0 (index 0 x)))
+  (let ((v1 (index 0 v0)))
+    (let ((v2 (index 0 v1)))
+      (tuple (size x) (size v0) (size v1) (size v2))
       )
     )
   )
@@ -28,7 +28,7 @@ def test_get_shape():
 def test_get_tuple_element():
     ks_str = """
 (def flatten (Tuple Integer Integer Integer) ((x : (Tuple (Tuple Integer Integer) Integer)))
-  (tuple@iii (get$1$2 (get$1$2 x)) (get$2$2 (get$1$2 x)) (get$2$2 x))
+  (tuple (get$1$2 (get$1$2 x)) (get$2$2 (get$1$2 x)) (get$2$2 x))
 )
 """
     d = AbstractValue.from_data(((1, 2,), 3))
@@ -57,14 +57,14 @@ def test_tuple_of_tensors():
 
 def test_if_then_else():
     ks_str = """
-(edef lt@ii Bool (Float Float))
-(def cost$lt@ii Float ((a : Float) (b : Float)) 1.0)
-(def shape$lt@ii Integer ((a : Float) (b : Float)) 0)
-(edef eq@ii Bool (Float Float))
-(def cost$eq@ii Float ((a : Float) (b : Float)) 1.0)
-(def shape$eq@ii Integer ((a : Float) (b : Float)) 0)
+(edef lt Bool (Float Float))
+(def cost$lt Float ((a : Float) (b : Float)) 1.0)
+(def shape$lt Integer ((a : Float) (b : Float)) 0)
+(edef eq Bool (Float Float))
+(def cost$eq Float ((a : Float) (b : Float)) 1.0)
+(def shape$eq Integer ((a : Float) (b : Float)) 0)
 (def sign Float ((x : Float))
-    (if (lt@ii x 0) -1.0 (if (eq@ii x 0) 0.0 1.0))
+    (if (lt x 0) -1.0 (if (eq x 0) 0.0 1.0))
 )
 """
     m = translate_and_import(ks_str, "abstract")

--- a/test/python/test_conv1d.py
+++ b/test/python/test_conv1d.py
@@ -5,10 +5,10 @@ from ksc.utils import translate_and_import
 def test_conv1d():
     # we need parentheses around Vec after ':' to parse correctly
     ks_str = """
-(edef add@ii Integer (Integer Integer))
-(edef sub@ii Integer (Integer Integer))
-(edef mul@ii Integer (Integer Integer))
-(edef div@ii Integer (Integer Integer))
+(edef add Integer (Integer Integer))
+(edef sub Integer (Integer Integer))
+(edef mul Integer (Integer Integer))
+(edef div Integer (Integer Integer))
 (edef lt Bool (Integer Integer))
 (edef gte Bool (Integer Integer))
 (edef or Bool (Bool Bool))
@@ -24,12 +24,12 @@ def test_conv1d():
       (build n (lam (ni : Integer)
         (sumbuild kn (lam (kni : Integer)
           (sumbuild l  (lam (li  : Integer)
-            (let ((knc (div@ii kn 2))
-                  (noi (sub@ii (add@ii ni knc) kni))
+            (let ((knc (div kn 2))
+                  (noi (sub (add ni knc) kni))
                   (outside_image (or (lt noi 0) (gte noi n)))
                   (image_noi
                   (if outside_image 0.0 (index noi (index li image)))))
-              (mul@ii image_noi (index kni (index li (index ki kernels))))
+              (mul image_noi (index kni (index li (index ki kernels))))
         )))))))))))"""
     py_out = translate_and_import(ks_str, "common")
     image = np.random.normal(0, 1, (1, 100))

--- a/test/python/test_cost.py
+++ b/test/python/test_cost.py
@@ -10,16 +10,16 @@ from ksc.utils import translate_and_import
 
 def test_afe():
     ks_str = """
-(edef div@ff Float (Float Float))
-(def cost$div@ff Float ((a : Float) (b : Float)) 2.0)
-(def shape$div@ff Integer ((a : Float) (b : Float)) 0)
-(edef add@ff Float (Float Float))
-(def cost$add@ff Float ((a : Float) (b : Float)) 1.0)
-(def shape$add@ff Integer ((a : Float) (b : Float)) 0)
+(edef div Float (Float Float))
+(def cost$div Float ((a : Float) (b : Float)) 2.0)
+(def shape$div Integer ((a : Float) (b : Float)) 0)
+(edef add Float (Float Float))
+(def cost$add Float ((a : Float) (b : Float)) 1.0)
+(def shape$add Integer ((a : Float) (b : Float)) 0)
 
 (def afe Float ((x : Float))
-  (let ((a (div@ff 1.0 x)))
-    (div@ff a (add@ff 1.0 a))
+  (let ((a (div 1.0 x)))
+    (div a (add 1.0 a))
   )
 )
 """
@@ -30,12 +30,12 @@ def test_afe():
 
 def test_build():
     ks_str = """
-(edef add@ff Float (Float Float))
-(def cost$add@ff Float ((a : Float) (b : Float)) 1.0)
-(def shape$add@ff Integer ((a : Float) (b : Float)) 0)
+(edef add Float (Float Float))
+(def cost$add Float ((a : Float) (b : Float)) 1.0)
+(def shape$add Integer ((a : Float) (b : Float)) 0)
 
 (def vec_vec_add (Vec Float) ((a : (Vec Float)) (b : (Vec Float)))
-  (build (size a) (lam (i : Integer) (add@ff (index i a) (index i b))))
+  (build (size a) (lam (i : Integer) (add (index i a) (index i b))))
 )
 """
     args = [AbstractValue((100,), Type.Vec(Type.Float)), AbstractValue((100,), Type.Vec(Type.Float))]
@@ -44,9 +44,9 @@ def test_build():
 
 def test_outer_product():
     ks_str = """
-(edef mul@ff Float (Float Float))
-(def cost$mul@ff Float ((a : Float) (b : Float)) 2.0)
-(def shape$mul@ff Integer ((a : Float) (b : Float)) 0)
+(edef mul Float (Float Float))
+(def cost$mul Float ((a : Float) (b : Float)) 2.0)
+(def shape$mul Integer ((a : Float) (b : Float)) 0)
 (def outer_product (Vec (Vec Float))
  ((var0 : (Tuple (Vec Float) (Vec Float))))
     (let ((x (get$1$2 var0))
@@ -55,7 +55,7 @@ def test_outer_product():
           (n (size y)))
             (build m (lam (i : Integer)
               (build n (lam (j : Integer)
-                (mul@ff
+                (mul
                   (index i x)
                   (index j y))))))))
 """
@@ -65,9 +65,9 @@ def test_outer_product():
 
 def test_sumbuild():
     ks_str = """
-(edef add@ff Float (Float Float))
-(def cost$add@ff Float ((a : Float) (b : Float)) 1.0)
-(def shape$add@ff Integer ((a : Float) (b : Float)) 0)
+(edef add Float (Float Float))
+(def cost$add Float ((a : Float) (b : Float)) 1.0)
+(def shape$add Integer ((a : Float) (b : Float)) 0)
 
 (def sum_of_vec Float ((a : (Vec Float)))
   (sumbuild (size a) (lam (i : Integer) (index i a)))
@@ -78,15 +78,15 @@ def test_sumbuild():
 
 def test_rot():
     ks_str = """
-(edef mul@ff Float (Float Float))
-(def cost$mul@ff Float ((a : Float) (b : Float)) 2.0)
-(def shape$mul@ff Integer ((a : Float) (b : Float)) 0)
-(edef add@ff Float (Float Float))
-(def cost$add@ff Float ((a : Float) (b : Float)) 1.0)
-(def shape$add@ff Integer ((a : Float) (b : Float)) 0)
-(edef neg@f Float (Float))
-(def cost$neg@f Float ((a : Float)) 1.0)
-(def shape$neg@f Integer ((a : Float)) 0)
+(edef mul Float (Float Float))
+(def cost$mul Float ((a : Float) (b : Float)) 2.0)
+(def shape$mul Integer ((a : Float) (b : Float)) 0)
+(edef add Float (Float Float))
+(def cost$add Float ((a : Float) (b : Float)) 1.0)
+(def shape$add Integer ((a : Float) (b : Float)) 0)
+(edef neg Float (Float))
+(def cost$neg Float ((a : Float)) 1.0)
+(def shape$neg Integer ((a : Float)) 0)
 
 (def rot (Tuple (Vec Float) (Vec Float))
          ((var0 : (Tuple (Vec Float) (Vec Float) Float Float)))
@@ -97,13 +97,13 @@ def test_rot():
           (n (size x)))
       (tuple
         (build n (lam (var1 : Integer)
-          (add@ff
-              (mul@ff c (index var1 x))
-              (mul@ff s (index var1 y)))))
+          (add
+              (mul c (index var1 x))
+              (mul s (index var1 y)))))
         (build n (lam (i : Integer)
-          (add@ff
-              (mul@ff (neg@f s) (index i x))
-              (mul@ff c (index i y))))))))
+          (add
+              (mul (neg s) (index i x))
+              (mul c (index i y))))))))
 """
     args = [
         AbstractValue(
@@ -173,28 +173,28 @@ def test_states():
 
 def test_if_then_else():
     ks_str = """
-(edef mul@ii Integer (Integer Integer))
-(def cost$mul@ii Float ((a : Integer) (b : Integer)) 2.0)
-(def shape$mul@ii Integer ((a : Integer) (b : Integer)) 0)
-(edef eq@ii Bool (Float Float))
-(def cost$eq@ii Float ((a : Float) (b : Float)) 1.0)
-(def shape$eq@ii Integer ((a : Float) (b : Float)) 0)
+(edef mul Integer (Integer Integer))
+(def cost$mul Float ((a : Integer) (b : Integer)) 2.0)
+(def shape$mul Integer ((a : Integer) (b : Integer)) 0)
+(edef eq Bool (Float Float))
+(def cost$eq Float ((a : Float) (b : Float)) 1.0)
+(def shape$eq Integer ((a : Float) (b : Float)) 0)
 
 (def select1 (Vec Integer) ((p : Bool) (x : (Vec Integer)))
   (if p
-      (build (size x) (lam (i : Integer) (mul@ii i 2)))  ; expensive branch cost 301
+      (build (size x) (lam (i : Integer) (mul i 2)))  ; expensive branch cost 301
       (build (size x) (lam (i : Integer) (index i x)))   ; cheap branch cost 201
   )
 )
 (def select2 (Vec Integer) ((p : Bool) (x : (Vec Integer)))
   (if p
       (build (size x) (lam (i : Integer) (index i x)))
-      (build (size x) (lam (i : Integer) (mul@ii i 2)))
+      (build (size x) (lam (i : Integer) (mul i 2)))
   )
 )
 (def select3 (Vec Integer) ((x : (Vec Integer)))
-  (if (eq@ii 0 0)
-      (build (size x) (lam (i : Integer) (mul@ii i 2)))
+  (if (eq 0 0)
+      (build (size x) (lam (i : Integer) (mul i 2)))
       (build (size x) (lam (i : Integer) (index i x)))
   )
 )

--- a/test/python/test_fold.py
+++ b/test/python/test_fold.py
@@ -1,20 +1,20 @@
 from ksc.utils import translate_and_import
 
 def test_fold():
-    ks_str = """(edef add@ii Integer (Integer Integer))
-(edef sub@ii Integer (Integer Integer))
-(edef mul@ii Integer (Integer Integer))
-(edef div@ii Integer (Integer Integer))
-(edef eq@ii Bool (Integer Integer))
+    ks_str = """(edef add Integer (Integer Integer))
+(edef sub Integer (Integer Integer))
+(edef mul Integer (Integer Integer))
+(edef div Integer (Integer Integer))
+(edef eq Bool (Integer Integer))
 (def mod (Integer) ((x : Integer) (y : Integer))
-  (sub@ii x (mul@ii (div@ii x y) y)))
+  (sub x (mul (div x y) y)))
 
 (def test Integer ((n : Integer))
     (fold (lam (s_x : (Tuple Integer Integer))
         (let ((count (get$1$2 s_x))
               (x     (get$2$2 s_x)))
-            (if (eq@ii (mod x 3) 0)
-                    (add@ii count 1)
+            (if (eq (mod x 3) 0)
+                    (add count 1)
                     count
             )))
         0

--- a/test/python/test_tracing_core.py
+++ b/test/python/test_tracing_core.py
@@ -63,7 +63,7 @@ def test_jit_anonymous(backend):
     out = F.add(F.add(1, 2,), 3)
     assert out.get_data_with_backend(backend) == 6
     jitted = out.creator._jitted
-    assert jitted.name == "_anonymous@iii"
+    assert jitted.name == "_anonymous"
     assert len(jitted.arg_names) == 3
     assert jitted(2, 3, 4) == 9
 
@@ -82,7 +82,7 @@ def need_let(a, b):
 
 def test_need_let(backend):
     out = need_let(3, 1)
-    assert "(let ((v0 (square@i a)))" in out.creator._jitted.ks_str
+    assert "(let ((v0 (square a)))" in out.creator._jitted.ks_str
     assert out.get_data_with_backend(backend) == 17 # 9 + 8
 
 @ksc.trace
@@ -123,7 +123,7 @@ def test_flatten():
     # function of flatten must be in before.
     before, _ = out.creator._jitted.all_called_functions()
     shape_def = next(f for key, f in before.items()
-                     if key == "shape$flatten@vvvvf")
+                     if key[0] == "shape$flatten")
     assert shape_def(x) == (3, 4 * 5 * 6)
 
 def test_to_float():


### PR DESCRIPTION
Reopening earlier PR (I accidentally deleted the branch): https://github.com/microsoft/knossos-ksc/pull/266

Distinguishes ksc functions not just by their name, but also by their argument type, so we can define the following in the same file

```lisp
(def foo Float (x : Integer) ...)
(def foo Float (x : Float) ...)
```

(but not also `(def foo Integer (x : Integer) ...)`)

