### PR TITLE
Improve primCallResultTy_maybe

### DIFF
--- a/src/ksc/Prim.hs
+++ b/src/ksc/Prim.hs
@@ -383,15 +383,19 @@ primCallResultTy_maybe fun arg_ty
             Left err -> Left err
             Right res_ty -> Right (mkGradType adp arg_ty res_ty)
 
-      DrvFun f (AD _ Fwd)    -- f :: S1 -> T, then fwd$f :: (S1, S2_t) -> T_t
-        | TypeTuple [x, _dx] <- arg_ty
+      DrvFun f adm
+        | AD BasicAD Fwd <- adm    -- f :: S1 -> T, then fwd$f :: (S1, S2_t) -> T_t
+        , TypeTuple [x, _dx] <- arg_ty
         , Right t_ty <- primCallResultTy_maybe (Fun f) x
         -> Right (tangentType t_ty)
-        | otherwise
-        -> Left (text "Ill-typed call to:" <+> ppr fun)
 
-      DrvFun _ (AD _ Rev)    -- f :: S1 -> T, then rev$f :: (S1, T_t) -> S1_t
-        | TypeTuple [s, _dt] <- arg_ty
+        | AD TupleAD Fwd <- adm    -- f :: S1 -> T, then fwdt$f :: (S1, S2_t) -> (T,T_t)
+        , TypeTuple [x, _dx] <- arg_ty
+        , Right t_ty <- primCallResultTy_maybe (Fun f) x
+        -> Right (TypeTuple [t_ty, tangentType t_ty])
+
+        | AD BasicAD Rev <- adm    -- f :: S1 -> T, then rev$f :: (S1, T_t) -> S1_t
+        , TypeTuple [s, _dt] <- arg_ty
         -> Right (tangentType s)
         | otherwise
         -> Left (text "Ill-typed call to:" <+> ppr fun)


### PR DESCRIPTION
Allow it to check tupled forward correctly, and also make it a bit more regular

[Part of Elliot-style AD, but it stands alone and I'd rather get it in first to make the Elliot AD PR simpler]