### PR TITLE
VS Code extension: update syntax highlighting

### DIFF
--- a/etc/ks-vscode/syntaxes/Knossos.tmLanguage
+++ b/etc/ks-vscode/syntaxes/Knossos.tmLanguage
@@ -73,7 +73,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(\b(?i:(def|edef))\b)(\s+)((\w|\-|\!|\?)*)</string>
+			<string>(\b(?i:(def|edef))\b)(\s+)((\w|\-|\!|\?|\@|\$)*)</string>
 			<key>name</key>
 			<string>meta.function.lisp</string>
 		</dict>


### PR DESCRIPTION
This PR updates the regex for function names, to allow the `@` and `$` characters we're using to record type, shape, and cost information in intermediate function names.