### PR TITLE
Printing of nested tuples is rejected by clang

### DIFF
--- a/src/runtime/knossos.h
+++ b/src/runtime/knossos.h
@@ -202,6 +202,11 @@ namespace ks
 		typedef tuple<T, Ts...> type;
 	};
 
+	// This needs to be declared before tuple_print in order to support printing of nested tuples
+	// (gcc will accept the code even without this declaration, but clang will not).
+	template <class... Ts>
+	std::ostream& operator<<(std::ostream& s, tuple<Ts...> const& t);
+
 	template <size_t i, class... Ts>
 	std::ostream& tuple_print(std::ostream& s, tuple<Ts...> const& t)
 	{


### PR DESCRIPTION
Recent versions of clang want `operator<<(std::ostream&, std::tuple<Ts..> const&)` to be declared before `tuple_print`, otherwise we have this error in `tuple_print`:
```
error: call to function 'operator<<' that is neither visible in the template definition nor found by argument-dependent lookup
                        s << std::get<i>(t);
```

when `std::get<i>(t)` is itself a `std::tuple<...>`. This is an instance of the problem described [here](http://clang.llvm.org/compatibility.html#dep_lookup).