### PR TITLE
Change bump allocator behaviour in sumbuild to match comments

### DIFF
--- a/src/ksc/Cgen.hs
+++ b/src/ksc/Cgen.hs
@@ -317,14 +317,7 @@ cgenExprR env = \case
         ++ cretty ++ " " ++ ret ++ ";\n"
         ++ "{\n"
         ++ "   " ++ varcty ++ " " ++ cgenVar var ++ " = 0;\n"
-        -- We don't actually want to mark the allocator here.  We want
-        -- to mark it after the first time round the loop, below.  On
-        -- the other hand, we need to *declare* the variable
-        -- "bumpmark" somewhere outside the "if" because it is used in
-        -- both branches.  We use $MRK here then as a cheeky way of
-        -- declaring "bumpmark".  TODO: Make a cleaner way of doing
-        -- this.
-        ++ "   " ++ gc "$MRK"
+        ++ "   " ++ gc "$DECLAREMRK"
         ++ "   do {\n"
         ++       bodydecl
         --       First time round, deep copy it, put it in the ret, then mark the allocator

--- a/src/runtime/knossos.h
+++ b/src/runtime/knossos.h
@@ -271,6 +271,7 @@ namespace ks
 	inline alloc_mark_t mark_bump_allocator_if_present() { return g_alloc.mark(); }
 	inline void reset_bump_allocator_if_present(alloc_mark_t top) { g_alloc.reset(top); }
 #define $MRK(var) alloc_mark_t var = mark_bump_allocator_if_present()
+#define $DECLAREMRK(var) alloc_mark_t var
 #define $MOVEMRK(var) var = mark_bump_allocator_if_present()
 #define $REL(var) reset_bump_allocator_if_present(var)
 #else
@@ -278,6 +279,7 @@ namespace ks
 	inline alloc_mark_t mark_bump_allocator_if_present() { return 0; }
 	inline void reset_bump_allocator_if_present(alloc_mark_t top) { }
 #define $MRK(var)
+#define $DECLAREMRK(var)
 #define $MOVEMRK(var)
 #define $REL(var)
 #endif


### PR DESCRIPTION
The `$MRK` and `$REL` calls in the generated C++ for sumbuild don't work in the way implied by the comments in `Cgen.hs`. In particular, the `$MRK` which happens after `inflated_deep_copy` on iteration 0 has no effect: this declares a new variable which shadows the original one and is unused. In order to work as intended it looks like we should move the original declaration out of the loop, and properly assign to it on iteration 0.

The original code actually works fine, and all the calls to `$REL` take the same values either way. We're unnecessarily re-marking the allocator position at the start of each iteration, but this is indeed equivalent to marking it once at the end of iteration 0.

This PR changes the code to match the comments; we could change the comments instead but should at least remove the spurious `$MRK` in that case.

(The original code _doesn't_ work if you try to apply it to the 2D case, which is how I discovered this!)

Example of generated C++ for a simple loop, original version:

```
ty$f$ai f$ai(int m) {
/* sumbuild */
KS_ASSERT(m > 0);
vec<double> c$2;
{
   int i = 0;
   do {
     $MRK(c$3);
vec<double> c$0 = g$ai(i);
     if (i == 0) {
       c$2 = inflated_deep_copy(c$0);
       $MRK(c$3);
     } else {
       inplace_add_t<vec<double>>::go(&c$2, c$0);
       $REL(c$3);
     }
   } while (++i < m);
}
return (c$2);
}
```

New version:

```
ty$f$ai f$ai(int m) {
/* sumbuild */
KS_ASSERT(m > 0);
vec<double> c$2;
{
   int i = 0;
   $MRK(c$3);
   do {
vec<double> c$0 = g$ai(i);
     if (i == 0) {
       c$2 = inflated_deep_copy(c$0);
       $MOVEMRK(c$3);
     } else {
       inplace_add_t<vec<double>>::go(&c$2, c$0);
       $REL(c$3);
     }
   } while (++i < m);
}
return (c$2);
}
```
