### PR TITLE
Remove non-BUMPY vec implementation

### DIFF
--- a/src/runtime/knossos.cpp
+++ b/src/runtime/knossos.cpp
@@ -2,9 +2,7 @@
 #include "knossos.h"
 
 namespace ks {
-#ifdef BUMPY
 	allocator g_alloc{ 1'000'000'000 };
-#endif
 
 	int log_indent = 8;
 	bool do_log = false;


### PR DESCRIPTION
@awf do we want to keep the macroed-out `vec` implementation based on `std::vector`? It's rotted slightly: just needs a `vec(zero_tag_t, ...)` constructor to make it work again. But maintaining it will become a bit more annoying once we start trying out alternative allocation strategies, so if we don't intend to keep it, now would be a good time to remove the code. This PR would remove it.