### PR TITLE
Put multi-line assertions in a new scope

### DIFF
--- a/src/ksc/Cgen.hs
+++ b/src/ksc/Cgen.hs
@@ -119,6 +119,11 @@ spc x y = x ++ " " ++ y
 indent :: [String] -> [String]
 indent = map ("  " ++)
 
+makeBlock :: [String] -> [String]
+makeBlock [] = []
+makeBlock [line] = [line]
+makeBlock lines = [ "{" ] ++ indent lines ++ [ "}" ]
+
 -------------- State for var generator
 
 type M = S.State Int
@@ -478,8 +483,9 @@ cgenExprR env = \case
     case tycond of CType TypeBool -> return ()
                    _              -> error "tycond was not TypeBool"
     (CG declbody vbody tybody          ) <- cgenExprR env body
-    return $ CG (  declcond
-                ++ [ "KS_ASSERT(" ++ vcond ++ ");" ]
+    return $ CG (  makeBlock (  declcond
+                             ++ [ "KS_ASSERT(" ++ vcond ++ ");" ]
+                             )
                 ++ declbody
                 )
                 vbody


### PR DESCRIPTION
Small change, creating a new block for an assertion when it involves the declaration of local variables.

Ostensible reason for this: a cosmetic change, making it more obvious in the generated code that the variables being declared are only used for the assertion.

Actual reason: I'm hoping to do a subsequent PR which changes the way variable names are generated when required. Adding a new scope here would mean that this can be done more neatly without the potential for naming conflicts.

<img width="891" alt="diff" src="https://user-images.githubusercontent.com/38362796/94551781-cffaf580-024d-11eb-85b5-55cdcb11296c.png">
