### PR TITLE
Reset allocator after every expression which returns a scalar

### DIFF
--- a/src/ksc/Cgen.hs
+++ b/src/ksc/Cgen.hs
@@ -390,7 +390,7 @@ cgenExprWithoutResettingAlloc env = \case
     let cgargtype = typeof t
     let cdecls = map getDecl cgvs
     let ctypes = map getType cgvs
-    let callocusage = mconcat (map getAllocatorUsage cgvs)
+    let callocusage = foldMap getAllocatorUsage cgvs
 
     let cftype = ctypeofFun env (tf, cgargtype) ctypes
 
@@ -463,7 +463,7 @@ cgenExprWithoutResettingAlloc env = \case
     let cdecls = map getDecl cgvs
     let cexprs = map getExpr cgvs
     let ctypes = map getType cgvs
-    let callocusage = mconcat (map getAllocatorUsage cgvs)
+    let callocusage = foldMap getAllocatorUsage cgvs
     let ctype  = CTuple ctypes
 
     return $ CG (concat cdecls)


### PR DESCRIPTION
Improves peak memory usage by finding better places to mark/reset the bump allocator.

Previously, whenever a function returned a scalar, we would mark the allocator at the start of the function and reset to the marked position at the end.

With this PR, this is extended from function calls to all expressions: for every expression which returns a scalar, we can mark the allocator before evaluating the expression and reset afterwards.

A simple version of this would result in large numbers of mark/reset calls, most of which are redundant. To avoid this, when generating code for an expression we also return an `AllocatorUsage` value which describes whether the allocator was actually used at all, and if so, whether it has been reset. Then we only need to wrap the expression in a mark/reset pair if the AllocatorUsage indicates that this may have an effect.