### PR TITLE
Simplify occAnalE of a tuple

### DIFF
--- a/src/ksc/OptLet.hs
+++ b/src/ksc/OptLet.hs
@@ -80,18 +80,18 @@ occAnalE (Let tv rhs@(Tuple _) body)
     n = case tv `M.lookup` vsb of
           Just n  -> n
           Nothing -> 0
-    (rhs', uvsr)  = occAnalE rhs
+    (rhs', vsr)   = occAnalE rhs
     (body', vsb)  = occAnalE body
     vsb_no_tv     = tv `M.delete` vsb
     vs | n == 0    = vsb_no_tv
 
        -- See Note [Making optLets idempotent]
        | n == 1    = vsb_no_tv
-                     `unionOccMap` uvsr
+                     `unionOccMap` vsr
 
        -- Note [Inline tuples], item (2)
        | otherwise = vsb_no_tv
-                     `unionOccMap` markMany uvsr
+                     `unionOccMap` markMany vsr
 
 occAnalE (Let tv rhs body)
   = (Let (n, tv) rhs' body', vs)


### PR DESCRIPTION
We can reuse the `occAnalE` branch for `Tuple` which does exactly the same thing. It had essentially been inlined here. Consequently, the `Let` of `Tuple` branch looks more similar to the `Let` of anything else branch, casting in sharper relief the *difference* between the two (which is only that, in the former, we check that `tv` is used exactly once).
