### PR TITLE
Remove go_ty, because it is the identity function

### DIFF
--- a/src/ksc/OptLet.hs
+++ b/src/ksc/OptLet.hs
@@ -240,9 +240,9 @@ optLetsE = go
     go subst (Tuple es)     = Tuple (map (go subst) es)
     go subst (App e1 e2)    = App (go subst e1) (go subst e2)
     go subst (Assert e1 e2) = Assert (go subst e1) (go subst e2)
-    go subst (Lam tv' e)    = Lam tv'' (go subst' e)
+    go subst (Lam tv e)     = Lam tv' (go subst' e)
                                  where
-                                   (tv'', subst') = substBndr tv' subst
+                                   (tv', subst') = substBndr tv subst
 
 {- Note [Inline tuples]
 ~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
(since vector sizes were removed). This came up in my work on implementing tuple-unpacking-let.