### PR TITLE
Refactor OptLet

### DIFF
--- a/src/ksc/OptLet.hs
+++ b/src/ksc/OptLet.hs
@@ -84,7 +84,10 @@ occAnalE (Let tv rhs body)
     (body', vsb)  = occAnalE body
     vsb_no_tv     = tv `M.delete` vsb
 
-    vs | n == 0    = vsb_no_tv
+    binding_dead  = n == 0
+
+    vs | binding_dead
+                   = vsb_no_tv
 
        -- Note [Inline tuples], Item (1)
        | Tuple _ <- rhs


### PR DESCRIPTION
Hi Simon, I have refactored the current implementation of OptLet on master. It would be nice if you can check this and we can merge it before we merge [tuple patterns](https://github.com/microsoft/knossos-ksc/pull/409/files) because having it in master will make the tuple patterns diff simpler.

This is intended to be a refactoring only, i.e. all existing behaviour should be preserved.