### PR TITLE
Add equality operators for vec

### DIFF
--- a/src/runtime/knossos.h
+++ b/src/runtime/knossos.h
@@ -506,7 +506,7 @@ namespace ks
 				return false;
 			}
 			for (int i = 0; i != size(); ++i) {
-				if (!((*this)[i] == other[i])) {
+				if ((*this)[i] != other[i]) {
 					return false;
 				}
 			}


### PR DESCRIPTION
Adds `operator==` and `operator!=` for class `vec`, mainly for use in debugging. This also completes the implementation of the ks primitive functions `eq` and `ne` (which are implemented as a call to the corresponding operator).

This does look a bit inconsistent with #381, where `operator+` and `operator*` were removed in favour of the named functions `ts_add` and `ts_scale`. We could do the same kind of thing here by providing versions of `eq` and `ne` overloaded for `vec`. But arguably the operators make more sense here because

- Testing for equality doesn't require an allocator to be passed;
- The standard library provides `operator==` and `operator!=` for `tuple`, so if we use operators consistently then we can avoid the extra boilerplate of writing out `eq` and `ne` for `tuple`.
