### PR TITLE
Do not pass an allocator argument to "print"

### DIFF
--- a/src/ksc/Cgen.hs
+++ b/src/ksc/Cgen.hs
@@ -600,7 +600,7 @@ cgenAnyFun (tf, ty) cftype = case tf of
 
 funUsesAllocator :: HasCallStack => TFun -> Bool
 funUsesAllocator (TFun _ (Fun (PrimFun fname))) =
-  not $ fname `elem` ["index", "size", "eq", "ne", "delta", "$trace"]
+  not $ fname `elem` ["index", "size", "eq", "ne", "delta", "$trace", "print"]
 funUsesAllocator (TFun _ (Fun (SelFun _ _))) = False
 funUsesAllocator _ = True
 


### PR DESCRIPTION
Alternative to #427, fixes #426