### PR TITLE
Use copydown for sumbuild

### DIFF
--- a/src/ksc/Cgen.hs
+++ b/src/ksc/Cgen.hs
@@ -193,9 +193,6 @@ markAllocator bumpmark allocVar = "ks::alloc_mark_t " ++ bumpmark ++ " = " ++ al
 resetAllocator :: String -> String -> String
 resetAllocator bumpmark allocVar = allocVar ++ "->reset(" ++ bumpmark ++ ");"
 
-declareMark :: String -> String
-declareMark bumpmark = "ks::alloc_mark_t " ++ bumpmark ++ ";"
-
 moveMark :: String -> String -> String
 moveMark bumpmark allocVar = bumpmark ++ " = " ++ allocVar ++ "->mark();"
 
@@ -362,16 +359,18 @@ cgenExprWithoutResettingAlloc env = \case
               cretty ++ " " ++ ret ++ ";",
               "{" ]
         ++ indent (  [ varcty ++ " " ++ cgenVar var ++ " = 0;",
-                       declareMark bumpmark,
+                       markAllocator bumpmark allocatorParameterName,
                        "do {" ]
                   ++ indent (  bodydecl
-                            -- First time round, deep copy it, put it in the ret, then mark the allocator
+                               -- Make a deep copy on the first iteration, using a copydown to
+                               -- reclaim other memory allocated in that iteration.
+                               -- Subsequent iterations can then accumulate into this copy.
                             ++ [ "if (" ++ cgenVar var ++ " == 0) {" ]
-                            ++ indent [ ret ++ " = inflated_deep_copy(" ++ allocatorParameterName ++ ", " ++ bodyex ++ ");",
+                            ++ indent [ ret ++ " = ks::copydown(" ++ allocatorParameterName ++ ", " ++ bumpmark ++ ", " ++ bodyex ++ ");",
                                         moveMark bumpmark allocatorParameterName ]
                             ++ [ "} else {" ]
                             ++ indent [ "inplace_add_t<"++ cretty ++">::go(&" ++ ret ++ ", " ++ bodyex ++ ");",
-                                      -- Release the allocator back to where it was on iter 0
+                                      -- Release the allocator back to where it was after iter 0
                                         resetAllocator bumpmark allocatorParameterName ]
                             ++ [ "}" ]
                             )


### PR DESCRIPTION
Replace `inflated_deep_copy` with a copydown on the first iteration of a sumbuild. Resolves #367.

This achieves a significant improvement in peak memory usage for some examples, without compromising on speed (copydown is not noticeably slower than the existing deep copy).

e.g. GMM d=k=10, peak memory usage reduced from 482K to 293K.

Diff of generated code:

<img width="896" alt="copydown-sumbuild" src="https://user-images.githubusercontent.com/38362796/97432060-45bcb480-1913-11eb-9535-cbc95ea05f2f.png">
