### PR TITLE
Add shape of edef in gmm.ks

### DIFF
--- a/test/ksc/gmm.ks
+++ b/test/ksc/gmm.ks
@@ -46,6 +46,8 @@
 
 ; mul Mat Vec
 (edef mul$Mat$Vec (Vec Float) ((Vec (Vec Float)) (Vec Float)))
+(def shape$mul$Mat$Vec (Vec (Tuple)) ((m : (Vec (Vec Float))) (v : (Vec Float)))
+          (constVec (size m) (tuple)))
 
 (edef D$mul$Mat$Vec (LM (Tuple (Vec (Vec Float)) (Vec Float)) (Vec Float))
           ((Vec (Vec Float)) (Vec Float)))


### PR DESCRIPTION
Adds `shape$mul$Mat$Vec`, which is needed for the generation of shapes for other functions in gmm.ks.

This appears to be the only edef which needs to have `shape$` defined, out of all the examples in the repo. In particular, we won't need to define `shape$` for functions which return scalars, because those shape functions would never be used.

