### PR TITLE
New test file cumsum.ks

### DIFF
--- a/test/ksc/cumsum.ks
+++ b/test/ksc/cumsum.ks
@@ -16,7 +16,7 @@
           (tuple (build 0 (lam (i : Integer) 0.0)) 0.0)
           xs)))
 
-(def shape$cumsum (Vec (Tuple)) (xs : (Vec Float))
+(def [shape cumsum] Integer (xs : (Vec Float))
     (shape xs))
 
 (def cumsum_aux (Tuple (Vec Float) Float)


### PR DESCRIPTION
Examples of functions which implement a cumulative sum.

~Draft PR: this cannot currently be merged because it fails the ksc tests. There are two issues:~

- ~Derivatives of `deltaVec` are not supported. (There's no implementation in `knossos.h` - though perhaps ksc should not be generating such code in the first place?)~
- ~The file contains a user-supplied `shape$cumsum`; ksc currently _also_ generates a version of this function, violating ODR.~