### PR TITLE
Add mem_ref to knossos.h

### DIFF
--- a/src/runtime/knossos.h
+++ b/src/runtime/knossos.h
@@ -286,17 +286,17 @@ namespace ks
 		}
 	};
 
-	class mem_ref : public allocator_base
+	class allocator_ref : public allocator_base
 	{
 	public:
-		mem_ref(unsigned char * buf, size_t size) :
-			allocator_base(buf, size, size) // We don't need to track peak memory usage for mem_ref, so can set peak=size to minimize overhead.
+		allocator_ref(unsigned char * buf, size_t size) :
+			allocator_base(buf, size, size) // We don't need to track peak memory usage for allocator_ref, so can set peak=size to minimize overhead.
 		{ }
-	};
 
-	mem_ref allocateMemRef(allocator_base * alloc, size_t numBytes) {
-		return mem_ref((unsigned char*)alloc->allocate(numBytes), numBytes);
-	}
+		static allocator_ref create_from_allocation(allocator_base * alloc, size_t numBytes) {
+			return allocator_ref((unsigned char*)alloc->allocate(numBytes), numBytes);
+		}
+	};
 
 	// ===============================  Zero  ==================================
 	// This template to be overloaded when e.g. a vector of T needs to use val to discover a size


### PR DESCRIPTION
Adds a `mem_ref` class to knossos.h, which has the same interface as our existing `allocator` but does not have ownership of its buffer. This is the type that will be used for the "destination" in destination-passing style.

I've created a common base class for `allocator` and `mem_ref`. I don't think it should ever be necessary to use `allocator_base` in the generated code: non-DPS functions can still take an `allocator` argument, whereas DPS functions take an `allocator` and a `mem_ref`. But having the base class avoids duplication in `knossos.h` itself.