### PR TITLE
Cgen for dps$build

### DIFF
--- a/src/ksc/Ksc/CatLang.hs
+++ b/src/ksc/Ksc/CatLang.hs
@@ -184,6 +184,8 @@ to_cl_call pruned env f e
   = pprPanic "toCLExpr Call of DrvFun" (ppr call)
   | TFun _ (ShapeFun _) <- f
   = pprPanic "toCLExpr Call of ShapeFun" (ppr call)
+  | TFun _ (DpsFun _) <- f
+  = pprPanic "toCLExpr Call of DpsFun" (ppr call)
   where
     call = Call f e
 

--- a/src/ksc/Ksc/Futhark.hs
+++ b/src/ksc/Ksc/Futhark.hs
@@ -381,6 +381,9 @@ toCall f@(L.TFun _ L.DrvFun{}) args =
 toCall f@(L.TFun _ L.ShapeFun{}) args =
   Call (Var (toTypedName f (L.typeof args))) [toFutharkExp args]
 
+toCall f@(L.TFun _ L.DpsFun{}) args =
+  Call (Var (toTypedName f (L.typeof args))) [toFutharkExp args]
+
 toFuthark :: L.TDef -> Def
 toFuthark d = case LU.oneArgifyDef d of {
   L.Def f (L.VarPat args) res_ty (L.UserRhs e) ->

--- a/src/ksc/Main.hs
+++ b/src/ksc/Main.hs
@@ -315,6 +315,7 @@ testC compiler fsTestKs = do
   testRunKSViaCatLang compiler "test/ksc/gmm.ks"
   testRunKSViaCatLang compiler "test/ksc/fold.ks"
   testRunKS compiler "test/ksc/copydown.ks"
+  testRunKS compiler "test/ksc/dps.ks"
   compileKscPrograms compiler fsTestKs
 
 profileArgs :: String -> FilePath -> FilePath -> FilePath -> IO ()

--- a/src/ksc/Parse.hs
+++ b/src/ksc/Parse.hs
@@ -229,6 +229,7 @@ pType = (pReserved "Integer" >> return TypeInteger)
     <|> (pReserved "Float"   >> return TypeFloat)
     <|> (pReserved "String"  >> return TypeString)
     <|> (pReserved "Bool"    >> return TypeBool)
+    <|> (pReserved "Allocator" >> return TypeAllocator)
     <|> parens pKType
 
 pTypes :: Parser [TypeX]

--- a/src/ksc/Shapes.hs
+++ b/src/ksc/Shapes.hs
@@ -17,6 +17,9 @@ shapeDef :: HasCallStack => TDef -> Maybe TDef
 shapeDef (Def { def_fun = ShapeFun _ })
   = Nothing
 
+shapeDef (Def { def_fun = DpsFun _ })
+  = Nothing
+
 shapeDef (Def { def_fun = f
               , def_pat = VarPat params
               , def_rhs = UserRhs def_rhs

--- a/test/ksc/dps.ks
+++ b/test/ksc/dps.ks
@@ -1,0 +1,48 @@
+
+
+(def mkvec (Vec Float) ((n : Integer) (start : Float))
+    (build n (lam (i : Integer) (add start (to_float i)))))
+
+(def add_k (Vec Float) ((v : (Vec Float)) (k : Float))
+    (build (size v) (lam (i : Integer) (add (index i v) k))))
+
+(def add_ones (Vec Float) (v : (Vec Float))
+    (add_k v 1.0))
+
+(def add_ones_vec_vec (Vec (Vec Float)) (v : (Vec (Vec Float)))
+    (build (size v) (lam (i : Integer) (add_ones (index i v)))))
+
+(def dps$add_k (Vec Float) ((dest : Allocator) (v_k : (Tuple (Vec Float) Float)))
+    (let ((v k) v_k)
+        (dps$build dest (tuple (size v)
+                               (lam (dest_i : (Tuple Allocator Integer))
+                                   (add (index (get$2$2 dest_i) v) k))))))
+
+(def dps$add_ones (Vec Float) ((dest : Allocator) (v : (Vec Float)))
+    (dps$add_k dest (tuple v 1.0)))
+
+(def dps$add_ones_vec_vec (Vec (Vec Float)) ((dest : Allocator) (v : (Vec (Vec Float))))
+    (dps$build dest (tuple (size v)
+                           (lam (dest_i : (Tuple Allocator Integer)) 
+                               (let ((dest_inner i) dest_i)
+                                  (dps$add_ones dest_inner (index i v)))))))
+
+(def main Integer ()
+    (let (testvec (mkvec 10 2.0))
+    (let (testvecvec (build 5 (lam (i : Integer) (mkvec (add 5 i) 10.0))))
+      (print
+          "\n----\n" 
+          "TESTS FOLLOW"
+
+          "\n----\n"
+          "DPS build (Vec Float)\n"
+          (eq (add_ones testvec)
+              ($allocateAndEmplace 80 (lam (dest : Allocator) (dps$add_ones dest testvec))))
+
+          "\n----\n"
+          "DPS build (Vec (Vec Float))\n"
+          (eq (add_ones_vec_vec testvecvec)
+              ($allocateAndEmplace 600 (lam (dest : Allocator) (dps$add_ones_vec_vec dest testvecvec))))
+      ))))
+
+


### PR DESCRIPTION
Part 1 of DPS implementation: in this version, the only primitive function that can be called using DPS is `build`. You can also write user-defined DPS functions, as shown in the test file.

The aim for this PR is that type checking is successful and the generated C++ is valid, with the results of DPS calls being successfully placed in the allocated destination. But this PR does not actually improve memory usage when DPS is used: for that, we also need to mark/reset the bump allocator in new places, where DPS makes this possible. I've left this for a separate change because it seems a bit more subtle.
