### PR TITLE
Install ksc as "--editable"

### DIFF
--- a/src/python/README.md
+++ b/src/python/README.md
@@ -3,7 +3,7 @@
 ## Installing
 In this directory
 ```
-pip install -U .
+pip install --editable .
 ```
 
 ## Compiling ksc from Python

--- a/test/builds/test_pytest.sh
+++ b/test/builds/test_pytest.sh
@@ -6,7 +6,7 @@ python3 -m pip install pytest numpy
 
 echo Installing ksc...
 cd ./src/python
-python3 -m pip install .
+python3 -m pip install --editable .
 cd ../..
 
 echo Running pytest

--- a/test/builds/test_resnet50.sh
+++ b/test/builds/test_resnet50.sh
@@ -8,7 +8,7 @@ python3 -m pip install -U Pillow jax==0.1.57 jaxlib==0.1.37
 
 echo Installing ksc...
 cd ./src/python
-python3 -m pip install .
+python3 -m pip install --editable .
 cd ../..
 
 echo Translating Knossos to Python


### PR DESCRIPTION
Currently, we access the ksc module by installing it centrally before running tests, i.e. 
```
cd $PROJECT/src/python
pip install -U .
cd $PROJECT
pytest test
```
This means that multiple copies of files exist, and running tests manually or through IDE integration needs an extra step, or risks running on stale data.

If instead, we install ``--editable``, the original source locations are used, so multiple copies are avoided.
```
cd $PROJECT/src/python
pip install --editable .
```
