### PR TITLE
Remove special case in mangling for Tensor 1

### DIFF
--- a/src/ksc/Cgen.hs
+++ b/src/ksc/Cgen.hs
@@ -641,7 +641,6 @@ mangleType = \case
     TypeFloat     -> "f"
     TypeString    -> "s"
     TypeTuple tys -> "<" ++ concatMap mangleType tys ++ ">"
-    TypeTensor 1 ty -> "v" ++ mangleType ty
     TypeTensor d ty -> "T" ++ show d ++ mangleType ty
     TypeLam a b   -> "l<" ++ mangleType a ++ mangleType b ++ ">"
     TypeLM _ _    -> error "Can't mangle TypeLM"

--- a/src/runtime/knossos-prelude.h
+++ b/src/runtime/knossos-prelude.h
@@ -10,13 +10,13 @@ double edef_example$af(allocator *, double x) { return x; }
 double fwd$edef_example$aff(allocator *, double x, double dx) { return dx; }
 double rev$edef_example$aff(allocator *, double x, double ddr) { return ddr; }
 
-double dot$avfvf(allocator *, vec<double> const& a, vec<double> const& b)
+double dot$aT1fT1f(allocator *, vec<double> const& a, vec<double> const& b)
 {
 	return dot(a,b);
 }
 
 vec<double> 
-mul$Mat$Vec$avvfvf(allocator * alloc, vec<vec<double>> const& M, vec<double> const& v)
+mul$Mat$Vec$aT1T1fT1f(allocator * alloc, vec<vec<double>> const& M, vec<double> const& v)
 {
 	int r = size(M);
 	vec<double> ret(alloc, r);
@@ -26,7 +26,7 @@ mul$Mat$Vec$avvfvf(allocator * alloc, vec<vec<double>> const& M, vec<double> con
 }
 
 tuple<vec<vec<double>>,vec<double>> 
-rev$mul$Mat$Vec$a$dvvfvf$bvf(allocator * alloc, std::tuple<vec<vec<double>>, vec<double>> const& M_v, vec<double> const& dr)
+rev$mul$Mat$Vec$a$dT1T1fT1f$bT1f(allocator * alloc, std::tuple<vec<vec<double>>, vec<double>> const& M_v, vec<double> const& dr)
 {
         auto [M, v] = M_v;
 	int r = size(M);

--- a/test/ksc/adbench-lstmpy.cpp
+++ b/test/ksc/adbench-lstmpy.cpp
@@ -51,8 +51,8 @@ PYBIND11_MODULE(PYTHON_MODULE_NAME, m) {
   declare_vec<ks::vec<ks::vec<ks::vec<double> > > >(m, std::string("vec_vec_vec_double"));
   declare_vec<ks::vec<ks::vec<ks::vec<ks::vec<double> > > > >(m, std::string("vec_vec_vec_vec_double"));
   m.def("sigmoid", withGlobalAllocator(&ks::sigmoid$af));
-  m.def("logsumexp", withGlobalAllocator(&ks::logsumexp$avf));
-  m.def("lstm_model", withGlobalAllocator(&ks::lstm_model$avfvfvfvfvfvfvfvfvfvfvf));
-  m.def("lstm_predict", withGlobalAllocator(&ks::lstm_predict$av$dvfvfvfvfvfvfvfvfvfvf$bvfvfvfvf));
-  m.def("lstm_objective", withGlobalAllocator(&ks::lstm_objective$av$dvfvfvfvfvfvfvfvfvfvf$bvfvfvfv$dvfvf$b));
+  m.def("logsumexp", withGlobalAllocator(&ks::logsumexp$aT1f));
+  m.def("lstm_model", withGlobalAllocator(&ks::lstm_model$aT1fT1fT1fT1fT1fT1fT1fT1fT1fT1fT1f));
+  m.def("lstm_predict", withGlobalAllocator(&ks::lstm_predict$aT1$dT1fT1fT1fT1fT1fT1fT1fT1fT1fT1f$bT1fT1fT1fT1f));
+  m.def("lstm_objective", withGlobalAllocator(&ks::lstm_objective$aT1$dT1fT1fT1fT1fT1fT1fT1fT1fT1fT1f$bT1fT1fT1fT1$dT1fT1f$b));
 }

--- a/test/ksc/gmmpy.cpp
+++ b/test/ksc/gmmpy.cpp
@@ -48,6 +48,6 @@ PYBIND11_MODULE(PYTHON_MODULE_NAME, m) {
   declare_vec<ks::vec<ks::vec<double> > >(m, std::string("vec_vec_double"));
   declare_vec<ks::vec<ks::vec<ks::vec<double> > > >(m, std::string("vec_vec_vec_double"));
   declare_vec<ks::vec<ks::vec<ks::vec<ks::vec<double> > > > >(m, std::string("vec_vec_vec_vec_double"));
-  m.def("gmm_knossos_gmm_objective", withGlobalAllocator(&ks::gmm_knossos_gmm_objective$avvfvfvvfvvfvvf$dfi$b));
-  m.def("rev_gmm_knossos_gmm_objective", withGlobalAllocator(&ks::rev$gmm_knossos_gmm_objective$a$dvvfvfvvfvvfvvf$dfi$b$bf));
+  m.def("gmm_knossos_gmm_objective", withGlobalAllocator(&ks::gmm_knossos_gmm_objective$aT1T1fT1fT1T1fT1T1fT1T1f$dfi$b));
+  m.def("rev_gmm_knossos_gmm_objective", withGlobalAllocator(&ks::rev$gmm_knossos_gmm_objective$a$dT1T1fT1fT1T1fT1T1fT1T1f$dfi$b$bf));
 }

--- a/test/ksc/mnistcnnpy.cpp
+++ b/test/ksc/mnistcnnpy.cpp
@@ -36,6 +36,6 @@ PYBIND11_MODULE(PYTHON_MODULE_NAME, m) {
   declare_vec<ks::vec<ks::vec<double> > >(m, std::string("vec_vec_double"));
   declare_vec<ks::vec<ks::vec<ks::vec<double> > > >(m, std::string("vec_vec_vec_double"));
   declare_vec<ks::vec<ks::vec<ks::vec<ks::vec<double> > > > >(m, std::string("vec_vec_vec_vec_double"));
-  m.def("conv2d", withGlobalAllocator(&ks::conv2d$avvvvfvfvvvf));
-  m.def("mnist", withGlobalAllocator(&ks::mnist$avvvfvvvvfvfvvvvfvfvvvvfvfvvfvf));
+  m.def("conv2d", withGlobalAllocator(&ks::conv2d$aT1T1T1T1fT1fT1T1T1f));
+  m.def("mnist", withGlobalAllocator(&ks::mnist$aT1T1T1fT1T1T1T1fT1fT1T1T1T1fT1fT1T1T1T1fT1fT1T1fT1f));
 }


### PR DESCRIPTION
Initial Tensor implementation mangled `Tensor 1` as "v" to avoid changing existing C++ files. This PR removes that special case.