### PR TITLE
Remove TypeSize from ksc

### DIFF
--- a/src/ksc/Lang.hs
+++ b/src/ksc/Lang.hs
@@ -229,12 +229,6 @@ deriving instance Show (DefX Parsed)
 deriving instance Show (DeclX Parsed)
 deriving instance Show (RuleX Parsed)
 
--- TypeSize is used to document when an integer represents a Size.
--- It's too viral to use a separate Integer type because most integer operations
--- need to be supported, e.g. the size of a lower-triangular matrix is d*(d+1)/2
-pattern TypeSize :: TypeX
-pattern TypeSize = TypeInteger
-
 ----------------------------------
 --- Tangent space
 
@@ -429,7 +423,7 @@ argVar :: Var
 argVar = Simple "ksc$argVar"
 
 indexTVar :: TVar
-indexTVar = TVar TypeSize (Simple "ksc$indexTVar")
+indexTVar = TVar TypeInteger (Simple "ksc$indexTVar")
 
 mkArgVar :: Int -> Var
 mkArgVar n = Simple ("ksc$argVar" ++ show n)
@@ -818,7 +812,6 @@ instance Pretty TypeX where
   pprPrec p (TypeLM s t)      = parensIf p precTyApp $ text "LM" <+> pprParendType s <+> pprParendType t
   pprPrec _ TypeFloat         = text "Float"
   pprPrec _ TypeInteger       = text "Integer"
-  pprPrec _ TypeSize          = text "Size"
   pprPrec _ TypeString        = text "String"
   pprPrec _ TypeBool          = text "Bool"
   pprPrec _ TypeUnknown       = text "UNKNOWN"

--- a/src/ksc/Opt.hs
+++ b/src/ksc/Opt.hs
@@ -658,7 +658,7 @@ optGradPrim _ "ts_add" arg
 
 optGradPrim _ "sum" e
   | TypeTensor 1 t <- typeof e
-  = Just (lmBuildT (pSize e) (Lam (TVar TypeSize $ Simple "sum$i")
+  = Just (lmBuildT (pSize e) (Lam (TVar TypeInteger $ Simple "sum$i")
                              (lmOne t)))
 
 optGradPrim _ "size" e

--- a/src/ksc/Prim.hs
+++ b/src/ksc/Prim.hs
@@ -557,7 +557,7 @@ primFunCallResultTy_maybe fun args
                      [TypeInteger, TypeLam TypeInteger t]) -> Just t
       ("index"    , TypeTuple [TypeInteger, TypeTensor 1 t]) -> Just t
       ("shape"    , t)                                     -> Just (shapeType t)
-      ("size"     , TypeTensor 1 _)                        -> Just TypeSize
+      ("size"     , TypeTensor 1 _)                        -> Just TypeInteger
       ("sum"      , TypeTensor 1 t)                        -> Just t
 
       ("unzip"    , TypeTensor d (TypeTuple ts))           -> Just (TypeTuple (map (TypeTensor d) ts))


### PR DESCRIPTION
`TypeSize` needs to change in some way, because the current `pattern TypeSize = TypeInteger` won't support multi-dimensional tensors.

Since we're not actually distinguishing sizes from integers at the moment, this PR suggests removing `TypeSize` completely.