### PR TITLE
Python debugging configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,14 @@
 {
 	"version": "0.2.0",
 	"configurations": [
-        {
+		{
+			"name": "Python: Current File",
+			"type": "python",
+			"request": "launch",
+			"program": "${file}",
+			"console": "integratedTerminal"
+		},
+		{
 			"name": "Run Extension",
 			"type": "extensionHost",
 			"request": "launch",
@@ -24,8 +31,13 @@
 			"type": "cppdbg",
 			"request": "launch",
 			"program": "${workspaceFolder}/build/bin/ksc-mlir",
-			"_args": ["TEST"],
-			"args": ["LLVM", "${workspaceFolder}/mlir/test/Ksc/tuple.ks"],
+			"_args": [
+				"TEST"
+			],
+			"args": [
+				"LLVM",
+				"${workspaceFolder}/mlir/test/Ksc/tuple.ks"
+			],
 			"_miDebuggerPath": "/usr/bin/gdb",
 			"MIMode": "gdb",
 			"setupCommands": [
@@ -37,8 +49,8 @@
 			],
 			"externalConsole": false,
 			"logging": {
-			  "moduleLoad": false,
-			  "trace": true
+				"moduleLoad": false,
+				"trace": true
 			}
 		},
 		{


### PR DESCRIPTION
[10:43] Colin Gravill
I've been configuring VSCode to launch Python scripts in the debugger but not checking the entry to launch.json. Any thoughts on me permanently adding them to microsoft/knossos-ksc?
​[14:06] Andrew Fitzgibbon
I believe we should check in changes to launch.json, and possibly settings.json.  If we find it annoying, then we should gitignore them.
​[14:56] Colin Gravill
I do have local changes for settings.json too: selecting my Python venv. However, it's very machine specific so I'm just trying to be careful to not check it in. I'm not aware of per directory VSCode user settings, am I missing a trick?
