### PR TITLE
Ensure a new enough version (3.0) of Cabal on Windows

### DIFF
--- a/README-ksc.md
+++ b/README-ksc.md
@@ -14,7 +14,7 @@ This section describes how to get them.
 #### Windows
 Install [Chocolatey](https://chocolatey.org/), then:
 ```cmd
-choco install ghc --version 8.6.5 cabal --version 3.2.0.0 -y
+choco install ghc --version 8.6.5 cabal --version 3.0.0.0 -y
 cabal v2-update
 choco install mingw --version 7.3.0 -y
 choco install msys2


### PR DESCRIPTION
The GHC 8.6.5 indirect dependency on Cabal allows for too old a version:
https://chocolatey.org/packages/ghc/8.6.5#dependencies
so control Cabal's version be new enough and match the Ubuntu command