### PR TITLE
Redefine tensor indexing operator

### DIFF
--- a/test/ksc/tensor.ks
+++ b/test/ksc/tensor.ks
@@ -25,6 +25,8 @@
                 (let ((i j k) ijk)
                     (testElement i j k 2.5)))))
       (print
+          "t = " t
+
           "\n----\n" 
           "TESTS FOLLOW"
 


### PR DESCRIPTION
Previously `t[i]` was equivalent to `t.data()[i]`. This PR changes this so that `t[i]` returns a `(Dim-1)`-dimensional tensor when `Dim >= 2`.