### PR TITLE
[WIP / RFC] Workaround venv / system dependency on python-config

### DIFF
--- a/src/python/ksc/utils.py
+++ b/src/python/ksc/utils.py
@@ -3,6 +3,7 @@ import importlib.util
 import os
 import numpy as np
 import subprocess
+import sysconfig
 import sys
 from tempfile import NamedTemporaryFile
 
@@ -135,7 +136,9 @@ def build_py_module_from_cpp(cpp_str, pybind11_path):
     with NamedTemporaryFile(mode="w", suffix=".cpp", delete=False) as fcpp:
         fcpp.write(cpp_str)
 
-    extension_suffix = subprocess_run(['python3-config', '--extension-suffix'])
+    extension_suffix = sysconfig.get_config_var('EXT_SUFFIX')
+    if extension_suffix is None:
+        extension_suffix = sysconfig.get_config_var('SO')
 
     with NamedTemporaryFile(mode="w", suffix=extension_suffix, delete=False) as fpymod:
         pass


### PR DESCRIPTION
On Windows (but also other environments - https://stackoverflow.com/questions/42020937/why-pyvenv-does-not-install-python-config/48946977#48946977 ) python-config/python3-config doesn't seem to be present and I've not found a straightforward automated way to get it installed.

As a possible alternative we can get this information from `sysconfig`. I guess even on Linux most people will be relying on `python3-config` in the system Python rather than a controlled virtual environment? That's what happened when I tested on Ubuntu with a venv I created, without also installing python-dev. It seems like it's better to rely on your local Python, even if work fine either way.

Any thoughts on this? Am I approaching in the wrong way?

For context I'm trying to get the excellent Python module creation from ksc strings working. I could just switch to solely Linux where it works.