### PR TITLE
Fix derivatives for tanh

### DIFF
--- a/src/runtime/knossos-prelude.h
+++ b/src/runtime/knossos-prelude.h
@@ -152,6 +152,7 @@ inline double exp$af(allocator *, double d) { return exp(d); }
 inline double log$af(allocator *, double d) { return log(d); }
 inline double sin$af(allocator *, double d) { return sin(d); }
 inline double cos$af(allocator *, double d) { return cos(d); }
+inline double cosh$af(allocator *, double d) { return cosh(d); }
 inline double tanh$af(allocator *, double d) { return tanh(d); }
 inline double lgamma$af(allocator *, double d) { return lgamma(d); }
 

--- a/src/runtime/prelude.ks
+++ b/src/runtime/prelude.ks
@@ -328,15 +328,17 @@
 (def [rev cos] Float ((x : Float) (d_dcos : Float)) (neg (mul (sin x) d_dcos)))
 (edef [Dt cos] (Tuple Float (LM Float Float)) (Float))
 
+(edef cosh Float (Float))
+
 (edef tanh Float (Float))
 (def [fwd tanh] Float ((x : Float) (dx : Float))
-     (let (tanh_x (tanh x))
-     (let (tanh_x_2 (mul tanh_x tanh_x))
-       (mul tanh_x_2 dx))))
+     (let (cosh_x (cosh x))
+     (let (cosh_x_2 (mul cosh_x cosh_x))
+       (div dx cosh_x_2))))
 (def [rev tanh] Float ((x : Float) (d_dr : Float))
-     (let (tanh_x (tanh x))
-     (let (tanh_x_2 (mul tanh_x tanh_x))
-       (mul tanh_x_2 d_dr))))
+     (let (cosh_x (cosh x))
+     (let (cosh_x_2 (mul cosh_x cosh_x))
+       (div d_dr cosh_x_2))))
 (edef [D tanh] (LM Float Float) (Float))
 (edef [Dt tanh] (Tuple Float (LM Float Float)) (Float))
 


### PR DESCRIPTION
They have been wrong since they were introduced in 1b8066522d7c4eeca93e4cc7af8a4085e5a5f92b