### PR TITLE
Reorder knossos.h

### DIFF
--- a/src/runtime/knossos.h
+++ b/src/runtime/knossos.h
@@ -1,6 +1,21 @@
 // C++ "runtime" for Knossos
 #pragma once
 
+/*
+Contents:
+- Utils
+- Allocator
+- Tensor class
+- Shape
+- Inflated deep copy
+- Copydown
+- Zero
+- Inplace add
+- Tangent-space arithmetic
+- Build, Sumbuild, Fold
+- Other primitives
+*/
+
 #include <type_traits>
 #include <utility>
 #include <variant>
@@ -33,8 +48,6 @@ namespace ks {
 		throw expr;
 	}
 };
-
-// ======================== Extra math =====================
 
 namespace ks
 {


### PR DESCRIPTION
Reorder various parts of knossos.h, in particular moving `tensor` and `shape` earlier in the file, and tidying up by moving similar things together.

New ordering is:
- utils
- allocator
- tensor
- shape
- inflated_deep_copy
- copydown
- zero
- inplace_add
- ts_add, ts_scale, ts_neg
- build, sumbuild, fold
- other primitives