### PR TITLE
Better messages when a function isn't found in the GST

### DIFF
--- a/knossos.cabal
+++ b/knossos.cabal
@@ -34,5 +34,6 @@ executable ksc
                  parsec >= 3.1,
                  containers >= 0.5,
                  process >= 1.4,
-                 directory >= 1.3
+                 directory >= 1.3,
+                 edit-distance == 0.2.2.1
   ghc-options: -Werror -Wall -Wno-name-shadowing -Wno-unticked-promoted-constructors -Wno-type-defaults -Wno-unused-do-bind -Wincomplete-uni-patterns -Wincomplete-record-updates


### PR DESCRIPTION
Fixes https://github.com/microsoft/knossos-ksc/issues/513

Previously:

```
--------------------------
Type errors in Type checking
  Not in scope: userCall: gmm_knossos_gmm_objectivex ((Vec (Vec Float)),
                                                      (Vec Float),
                                                      (Vec (Vec Float)),
                                                      (Vec (Vec Float)),
                                                      (Vec (Vec Float)),
                                                      (Float, Integer))
  {($ranhashdoub, Integer) :-> (edef $ranhashdoub Float (Integer)),
   (R$dot, ((Vec Float), (Vec Float))) :-> (edef
                                            R$dot
                                            (LM Float ((Vec Float), (Vec Float)))
                                            (((Vec Float), (Vec Float)))),
   (abs, Float) :-> (edef abs Float (Float)),
   (add, (Integer, Integer)) :-> (edef
                                  add
                                  Integer
                                  ((Integer, Integer))),
   (add, (Float, Float)) :-> (edef add Float ((Float, Float))),
   (and, (Bool, Bool)) :-> (edef and Bool ((Bool, Bool))),
   (cos, Float) :-> (edef cos Float (Float)),
   (div, (Integer, Integer)) :-> (edef
                                  div
                                  Integer
                                  ((Integer, Integer))),
   (div, (Float, Float)) :-> (edef div Float ((Float, Float))),
   (dot, ((Vec Float), (Vec Float))) :-> (edef
...
<pages and pages of env>
...
```

Now:

```
--------------------------
Type errors in Type checking
  Not in scope: userCall: gmm_knossos_gmm_objectivex ((Vec (Vec Float)),
                                                      (Vec Float),
                                                      (Vec (Vec Float)),
                                                      (Vec (Vec Float)),
                                                      (Vec (Vec Float)),
                                                      (Float, Integer))
  Did you mean one of these:
  [(gmm_knossos_gmm_objective,
    ((Vec (Vec Float)),
     (Vec Float),
     (Vec (Vec Float)),
     (Vec (Vec Float)),
     (Vec (Vec Float)),
     (Float, Integer))),
   (D$gmm_knossos_gmm_objective,
    ((Vec (Vec Float)),
     (Vec Float),
     (Vec (Vec Float)),
     (Vec (Vec Float)),
     (Vec (Vec Float)),
     (Float, Integer))),
   (Dt$gmm_knossos_gmm_objective,
    ((Vec (Vec Float)),
     (Vec Float),
     (Vec (Vec Float)),
     (Vec (Vec Float)),
     (Vec (Vec Float)),
     (Float, Integer))),
   (fwd$gmm_knossos_gmm_objective,
    (((Vec (Vec Float)),
      (Vec Float),
      (Vec (Vec Float)),
      (Vec (Vec Float)),
      (Vec (Vec Float)),
      (Float, Integer)),
     ((Vec (Vec Float)),
      (Vec Float),
      (Vec (Vec Float)),
      (Vec (Vec Float)),
      (Vec (Vec Float)),
      (Float, ())))),
   (rev$gmm_knossos_gmm_objective,
    (((Vec (Vec Float)),
      (Vec Float),
      (Vec (Vec Float)),
      (Vec (Vec Float)),
      (Vec (Vec Float)),
      (Float, Integer)),
     Float))]
    In a call of: gmm_knossos_gmm_objectivex (Fun (UserFun "gmm_knossos_gmm_objectivex"))
     Arg types: ((Vec (Vec Float)),
                 (Vec Float),
                 (Vec (Vec Float)),
                 (Vec (Vec Float)),
                 (Vec (Vec Float)),
                 (Float, Integer))
     Args: (x, alphas, mus, qs, ls, wishart)
    ST lookup: Nothing
  In the rhs of the binding for: gmm_at_theta
  In the definition of main
End of type errors
--------------------------
```