### PR TITLE
Delete outdated test/ksc README

### DIFF
--- a/test/ksc/README.md
+++ b/test/ksc/README.md
@@ -1,8 +1,0 @@
-
-Tests for KSC.
-
-There are two sorts of tests here.
-
-- Files such as *.ks, which are tested by running GHCI, loading src/ksc/Main.hs, and running doall "test/ksc/file.ks"
-
-- Compile test-ksc.cpp, which by default includes GMM.cpp, to run standalone tests.


### PR DESCRIPTION
Can we delete this? It is very out of date.