### PR TITLE
Fix warning in tensor constructor

### DIFF
--- a/src/runtime/knossos.h
+++ b/src/runtime/knossos.h
@@ -442,7 +442,7 @@ namespace ks
                 // allocate and copy because we have no guarantee
                 // that the std::vector will not mutate or vanish
                 // beneath our feet.
-		tensor(allocator_base * alloc, std::vector<T> const& that) : tensor{ alloc, that.size() }
+		tensor(allocator_base * alloc, std::vector<T> const& that) : tensor(alloc, static_cast<int>(that.size()))
 		{
 			static_assert(Dim == 1);
 			// Copying from std vector - allocate.


### PR DESCRIPTION
Fix warning relating to a conversion from `size_t` to `int`