### PR TITLE
Generalize functions in Opt.hs to multidimensional tensors

### DIFF
--- a/src/ksc/Lang.hs
+++ b/src/ksc/Lang.hs
@@ -451,8 +451,8 @@ resVar = Simple "ksc$resVar"
 argVar :: Var
 argVar = Simple "ksc$argVar"
 
-indexTVar :: TVar
-indexTVar = TVar TypeInteger (Simple "ksc$indexTVar")
+indexTVar :: Int -> TVar
+indexTVar d = TVar (tensorIndexType d) (Simple "ksc$indexTVar")
 
 mkArgVar :: Int -> Var
 mkArgVar n = Simple ("ksc$argVar" ++ show n)

--- a/test/ksc/tensor.ks
+++ b/test/ksc/tensor.ks
@@ -11,6 +11,12 @@
 
 (def zeroTensorInAD Float (m : Tensor 2 Float) 0.0)
 
+(def constTensor2 (Tensor 2 Float) ((ignored : Float))
+    (build (tuple 3 3) (lam (ij : (Tuple Integer Integer)) 0.0)))
+
+;(def constvecInAD (Tensor 2 Float) ((v1 : Vec Float) (ignored : Integer))
+;     (constVec (tuple (size v1) (size v1)) 2.0))
+
 (def main Integer ()
     (let (vvv (build 2 (lam (i : Integer)
                   (build 4 (lam (j : Integer)


### PR DESCRIPTION
Fixes problems found while investigating #519, but does not actually fix that issue.

One test is added to `test/tensor.ks`: without the changes to Opt.hs this test still passes, but logs a warning message.