### PR TITLE
Binders must be used *exactly* once

### DIFF
--- a/doc/AD.tex
+++ b/doc/AD.tex
@@ -2069,7 +2069,7 @@ $$
 
   \fbox{\begin{minipage}{\textwidth}
       This figure assumes the single-use dialect of \ksc{},
-      in which every binder is used at most once.
+      in which every binder is used exactly once.
 $$
 \begin{codearray}{ll}
   \mbox{\bf Original function}   & f : S \to T \\


### PR DESCRIPTION
For a variable x in the original function, the only Reverse BOG rule
that causes \gradf{x} to be bound is the variable rule.  Therefore
unless x is used \gradf{x} will not be bound, violating the stated
condition that Reverse BOG should satisfy.

I think this is correct, isn't it?