### PR TITLE
Avoid redundancy in Cgen of Let

### DIFF
--- a/src/ksc/Cgen.hs
+++ b/src/ksc/Cgen.hs
@@ -212,12 +212,48 @@ allocatorUsageOfCType = \case
 --        "v12_t v12 = v12_t::mk(a,b);"]
 --       "v12",      -- this is what we use at the occurrence
 --       LMHCat [LMVCat [LMOne, LMZero], LMZero])
-data CGenResult = CG [String] String CType AllocatorUsage -- TODO: rename CG CGenResult
+data CGenResult = CG [String] CGenResultExpression CType AllocatorUsage -- TODO: rename CG CGenResult
+
+-- The "C expression" of a CGenResult can only be "trivial".  The
+-- CGenResultExpression type structurally enforces that condition.  In
+-- particular, the C expression can't contain arbitrary computation.
+-- If it could then we would have to be very careful not to duplicate
+-- it.
+--
+-- On the other hand, allowing arbitrary expressions could lead to
+-- nicer-looking C++ code.  For example, we could generate
+--
+--     g(f1(x1), f2(x2))
+--
+-- instead of
+--
+--     float fresh1 = f1(x1);
+--     float fresh2 = f2(x2);
+--     g(fresh1, freshf2);
+--
+-- Therefore if in the future we decide that we want nicer looking C++
+-- then we can revisit the restriction.
+data CGenResultExpression = CGREDummy CType
+                          | CGREKonst Konst
+                          | CGREVar Var
+                          | CGRETuple [CGenResultExpression]
+
+generateCGRE :: CGenResultExpression -> String
+generateCGRE = \case
+  CGREDummy cty -> cgenType cty ++ "{}"
+  CGREKonst k   -> cgenKonst k
+  CGREVar v     -> cgenVar v
+  CGRETuple rs  -> "std::make_tuple("
+                   ++ intercalate "," (map generateCGRE rs)
+                   ++ ")"
+
+cgreVar :: String -> CGenResultExpression
+cgreVar = CGREVar . Simple
 
 getDecl :: CGenResult -> [String]
 getDecl (CG dc _ _ _) = dc
 
-getExpr :: CGenResult -> String
+getExpr :: CGenResult -> CGenResultExpression
 getExpr (CG _ ex _ _) = ex
 
 getType :: CGenResult -> CType
@@ -318,7 +354,7 @@ cgenDefE env (Def { def_fun = f, def_pat = param
       (params, withPackedParams) = params_withPackedParamsPat param
       CG cbodydecl cbodyexpr cbodytype _callocusage =
         runM $ cgenExpr env (withPackedParams body)
-      cbody       = cbodydecl ++ [ "return (" ++ cbodyexpr ++ ");" ]
+      cbody       = cbodydecl ++ [ "return (" ++ generateCGRE cbodyexpr ++ ");" ]
       cvars       = map mkCTypedVar params
       cftypealias = "ty$" ++ cf
       cparams     = "ks::allocator * " ++ allocatorParameterName ++ concatMap (", " ++) cvars
@@ -355,10 +391,10 @@ cgenWrapWithMarkReset x = return x
 
 cgenExprWithoutResettingAlloc :: HasCallStack => CST -> TExpr -> M CGenResult
 cgenExprWithoutResettingAlloc env = \case
-  Konst k -> return $ CG [] (cgenKonst k) (mkCType $ typeofKonst k) DoesNotUseAllocator
+  Konst k -> return $ CG [] (CGREKonst k) (mkCType $ typeofKonst k) DoesNotUseAllocator
   Dummy ty ->
-    let cty = mkCType ty in return $ CG [] (cgenType cty ++ "{}") cty DoesNotUseAllocator
-  Var (TVar ty v)               -> return $ CG [] (cgenVar v) (mkCType ty) DoesNotUseAllocator
+    let cty = mkCType ty in return $ CG [] (CGREDummy cty) cty DoesNotUseAllocator
+  Var (TVar ty v)               -> return $ CG [] (CGREVar v) (mkCType ty) DoesNotUseAllocator
 
   -- Special case for copydown. Mark the allocator before evaluating the
   -- expression, then copydown the result to the marked position.
@@ -370,9 +406,9 @@ cgenExprWithoutResettingAlloc env = \case
         (  [ cComment "Explicitly-requested copydown",
              markAllocator bumpmark allocatorParameterName ]
         ++ cdecl
-        ++ [ cgenType ctype ++ " " ++ ret ++ " = ks::copydown(" ++ allocatorParameterName ++ ", " ++ bumpmark ++ ", " ++ cexpr ++ ");" ]
+        ++ [ cgenType ctype ++ " " ++ ret ++ " = ks::copydown(" ++ allocatorParameterName ++ ", " ++ bumpmark ++ ", " ++ generateCGRE cexpr ++ ");" ]
         )
-        ret
+        (CGREVar (Simple ret))
         ctype
         (allocatorUsageOfCType ctype <> UsesAndResetsAllocator)
 
@@ -395,9 +431,9 @@ cgenExprWithoutResettingAlloc env = \case
     return $ CG
       (  concat cdecls
       ++ [ cgenType cftype ++ " " ++ v ++ " = "
-                ++ cf ++ "(" ++ cgenArgList tf (map getExpr cgvs) ++ ");" ]
+                ++ cf ++ "(" ++ cgenArgList tf (map (generateCGRE . getExpr) cgvs) ++ ");" ]
       )
-      v
+      (cgreVar v)
       cftype
       (funAllocatorUsage tf cftype <> callocusage)
 
@@ -422,15 +458,15 @@ cgenExprWithoutResettingAlloc env = \case
                   -- argument lists unpacked!
                   (True, cexpr, TypeTuple ts)
                     -> (flip map [0..length ts - 1] $ \i ->
-                           "std::get<" ++ show i ++ ">(" ++ cexpr ++ ")")
-                  (_, cexpr, _) -> [cexpr]
+                           "std::get<" ++ show i ++ ">(" ++ generateCGRE cexpr ++ ")")
+                  (_, cexpr, _) -> [generateCGRE cexpr]
 
     return $ CG
       (  cdecls
       ++ [  cgenType cftype ++ " " ++ v ++ " = "
               ++ cf ++ "(" ++ cgenArgList tf cargs ++ ");" ]
       )
-      v
+      (cgreVar v)
       cftype
       (funAllocatorUsage tf cftype <> callocusage)
 
@@ -449,7 +485,7 @@ cgenExprWithoutResettingAlloc env = \case
 
     return $ CG
       (  decle1
-      ++ [ cgenType_ ++ " " ++ cgenBinder ++ " = " ++ ve1 ++ ";" ]
+      ++ [ cgenType_ ++ " " ++ cgenBinder ++ " = " ++ generateCGRE ve1 ++ ";" ]
       ++ declbody
       )
       vbody
@@ -465,7 +501,7 @@ cgenExprWithoutResettingAlloc env = \case
     let ctype  = CTuple ctypes
 
     return $ CG (concat cdecls)
-                ("std::make_tuple(" ++ intercalate "," cexprs ++ ")")
+                (CGRETuple cexprs)
                 ctype
                 callocusage
 
@@ -480,11 +516,11 @@ cgenExprWithoutResettingAlloc env = \case
               ++ concatMap ((", " ++) . mkCTypedVar) params
               ++ ") {" ]
       ++ indent (  cdecl
-                ++ [ "return (" ++ cexpr ++ ");" ]
+                ++ [ "return (" ++ generateCGRE cexpr ++ ");" ]
                 )
       ++ [ "};" ]
       )
-      lvar
+      (cgreVar lvar)
       (CFunction vtype ctype)
       DoesNotUseAllocator
 
@@ -503,15 +539,15 @@ cgenExprWithoutResettingAlloc env = \case
     return $ CG
       (  declc -- emit condition generation
       ++ [ cgenType crettype `spc` cret ++ ";", -- emit decl for "return" type
-           "if (" ++ vc ++ ") {" ]
+           "if (" ++ generateCGRE vc ++ ") {" ]
       ++ indent (  declt  -- compute true value
-                ++ [ cret ++ dotv ++ " = (" ++ vt ++ ");" ]) -- assign to "return"
+                ++ [ cret ++ dotv ++ " = (" ++ generateCGRE vt ++ ");" ]) -- assign to "return"
       ++ [ "} else {" ]
       ++ indent (  declf  -- compute false value
-                ++ [ cret ++ dotv ++ " = (" ++ vf ++ ");" ]) -- assign to "return"
+                ++ [ cret ++ dotv ++ " = (" ++ generateCGRE vf ++ ");" ]) -- assign to "return"
       ++ [ "}" ]
       )
-      cret
+      (cgreVar cret)
       crettype
       (auc <> aut <> auf)
 
@@ -521,7 +557,7 @@ cgenExprWithoutResettingAlloc env = \case
                    _              -> error "tycond was not TypeBool"
     (CG declbody vbody tybody aubody) <- cgenExprR env body
     return $ CG (  makeBlock (  declcond
-                             ++ [ "KS_ASSERT(" ++ vcond ++ ");" ]
+                             ++ [ "KS_ASSERT(" ++ generateCGRE vcond ++ ");" ]
                              )
                 ++ declbody
                 )


### PR DESCRIPTION
Avoid proliferation of redundant variables and redundant copying: instead of declaring a new variable and binding the result of a let body to it, just use the result of the let body.

It's always a little bit risky doing this kind of thing because if the result were a non-trivial expression we could be unintentionally duplicating it and doing more work that expected. Therefore I also enforced a structural invariant that the expression is indeed trivial.

See below for before and after.  The redundancy that this PR removes was added a couple of years ago in 27d446351fbe53e5a9c1fed6aab0047d88265477. I'm not sure what the rationale for introducing the redundancy was but because it was specifically introduced we might want to think carefully about whether this PR is actually a correct change.


### Before

```c++
typedef tuple<double,double,double,double> ty$g$af;
ty$g$af g$af(ks::allocator * $alloc, double x) {
  /* Let */tuple<double,double,double,double> c$10;
  {
  double c$0 = add$aff($alloc, 1.0, x);
  double c$1 = lgamma$af($alloc, c$0);
  double x1 = c$1;
  /* Let */tuple<double,double,double,double> c$9;
  {
  double c$2 = add$aff($alloc, 2.0, x1);
  double c$3 = lgamma$af($alloc, c$2);
  double x2 = c$3;
  /* Let */tuple<double,double,double,double> c$8;
  {
  double c$4 = add$aff($alloc, 3.0, x2);
  double c$5 = lgamma$af($alloc, c$4);
  double x3 = c$5;
  double c$6 = add$aff($alloc, 4.0, x3);
  double c$7 = lgamma$af($alloc, c$6);
  c$8 = std::make_tuple(x1,x2,x3,c$7);
  }
  c$9 = c$8;
  }
  c$10 = c$9;
  }
  return (c$10);
}
```

### After

```c++
typedef tuple<double,double,double,double> ty$g$af;
ty$g$af g$af(ks::allocator * $alloc, double x) {
  double c$0 = add$aff($alloc, 1.0, x);
  double c$1 = lgamma$af($alloc, c$0);
  double x1 = c$1;
  double c$2 = add$aff($alloc, 2.0, x1);
  double c$3 = lgamma$af($alloc, c$2);
  double x2 = c$3;
  double c$4 = add$aff($alloc, 3.0, x2);
  double c$5 = lgamma$af($alloc, c$4);
  double x3 = c$5;
  double c$6 = add$aff($alloc, 4.0, x3);
  double c$7 = lgamma$af($alloc, c$6);
  return (std::make_tuple(x1,x2,x3,c$7));
}
