### PR TITLE
Rename oneArgify... to noTupPatify...

### DIFF
--- a/src/ksc/AD.hs
+++ b/src/ksc/AD.hs
@@ -41,10 +41,10 @@ gradTVar adp s (TVar ty v) = mkGradTVar adp (typeof s) (gradV adp v) ty
 gradDefs :: HasCallStack => ADPlan -> [TDef] -> [TDef]
 gradDefs adp = mapMaybe (gradDef adp)
 
--- We oneArgifyDef before gradDef.  See Note [Replacing TupPat with
+-- We noTupPatifyDef before gradDef.  See Note [Replacing TupPat with
 -- nested Let].
 gradDef :: HasCallStack => ADPlan -> TDef -> Maybe TDef
-gradDef adp = gradDefInner adp . oneArgifyDef
+gradDef adp = gradDefInner adp . noTupPatifyDef
 
 gradDefInner :: HasCallStack => ADPlan -> TDef -> Maybe TDef
 gradDefInner adp
@@ -287,7 +287,7 @@ lmVCat_AD TupleAD ms = Tuple [ Tuple  (map pFst ms)
 applyD :: ADDir -> TDef -> TDef
 
 applyD dir def@(Def { def_pat = TupPat {} })
-  = applyD dir (oneArgifyDef def)
+  = applyD dir (noTupPatifyDef def)
 
 -- Forward
 --   D$f  :: S1 S2       -> ((S1,S2) -o T)

--- a/src/ksc/Ksc/CatLang.hs
+++ b/src/ksc/Ksc/CatLang.hs
@@ -122,7 +122,7 @@ data EnvPruned = Pruned | NotPruned
 -- CatLang doesn't support tuple patterns in lets yet, but it could
 -- and if we do anything serious with CatLang then it *should*.
 toCLExpr :: [TVar] -> TExpr -> CLExpr
-toCLExpr env = to_cl_expr NotPruned env . oneArgifyExpr (mkInScopeSet env)
+toCLExpr env = to_cl_expr NotPruned env . noTupPatifyExpr (mkInScopeSet env)
 
 to_cl_expr :: EnvPruned -> [TVar] -> TExpr -> CLExpr
 

--- a/src/ksc/Ksc/Futhark.hs
+++ b/src/ksc/Ksc/Futhark.hs
@@ -382,7 +382,7 @@ toCall f@(L.TFun _ L.ShapeFun{}) args =
   Call (Var (toTypedName f (L.typeof args))) [toFutharkExp args]
 
 toFuthark :: L.TDef -> Def
-toFuthark d = case LU.oneArgifyDef d of {
+toFuthark d = case LU.noTupPatifyDef d of {
   L.Def f (L.VarPat args) res_ty (L.UserRhs e) ->
   DefFun entry fname []
   [param] res_ty' (toFutharkExp e)

--- a/src/ksc/Shapes.hs
+++ b/src/ksc/Shapes.hs
@@ -10,7 +10,7 @@ import GHC.Stack
 import Data.Maybe(mapMaybe)
 
 shapeDefs :: HasCallStack => [TDef] -> [TDef]
-shapeDefs = mapMaybe (shapeDef . oneArgifyDef)
+shapeDefs = mapMaybe (shapeDef . noTupPatifyDef)
 
 shapeDef :: HasCallStack => TDef -> Maybe TDef
 


### PR DESCRIPTION
because the latter more accurately describes what it does.  The name "oneArgify..." was causing confusion about whether were are *actually* one-arg (we are).