### PR TITLE
Use C++ boolean literals in Cgen

### DIFF
--- a/src/ksc/Cgen.hs
+++ b/src/ksc/Cgen.hs
@@ -767,7 +767,7 @@ cgenKonst = \case
   KInteger i -> show i
   KFloat   f -> show f
   KString  s -> show s
-  KBool    b -> if b then "1 " ++ cComment "TRUE" else "0 " ++ cComment "FALSE"
+  KBool    b -> if b then "true" else "false"
 
 cgenVar :: Var -> String
 cgenVar = render . ppr


### PR DESCRIPTION
Avoids unnecessary use of implicit conversions.

Converting from `int` to `bool` isn't a problem in itself. But we're generating code such as `make_tuple(0 /* FALSE */, ...)`, which therefore relies on the implicit conversion from `std::tuple<Ts...>` to `std::tuple<Us...>`. That's more of a problem because:
- Other `tuple` implementations might not implement that implicit conversion;
- The implicit conversion is another of those things that we _hope_ the compiler will optimize away, but it might not actually manage in practice.