### PR TITLE
Add new header knossos-pybind.h with common code from python tests

### DIFF
--- a/src/runtime/knossos-pybind.h
+++ b/src/runtime/knossos-pybind.h
@@ -1,0 +1,19 @@
+#include <cstdint>
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/operators.h>
+
+namespace py = pybind11;
+
+#include "knossos.h"
+
+ks::allocator g_alloc{ 1'000'000'000 };
+
+// Convert functor to one which takes a first argument g_alloc 
+template<typename RetType, typename... ParamTypes>
+auto with_ks_allocator(RetType(*f)(ks::allocator*, ParamTypes...)) {
+  return [f](ParamTypes... params) {
+    return f(&g_alloc, params...);
+  };
+}

--- a/test/ksc/adbench-lstmpy.cpp
+++ b/test/ksc/adbench-lstmpy.cpp
@@ -1,18 +1,7 @@
-/* There's a lot of duplication between this and mnistcnnpy.cpp, but
- * we will follow the Rule of Three
- *
- *    https://en.wikipedia.org/wiki/Rule_of_three_(computer_programming)
- */
 
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-#include <pybind11/operators.h>
-
-namespace py = pybind11;
+#include "knossos-pybind.h"
 
 #include "adbench-lstm.cpp"
-
-ks::allocator g_alloc{ 1'000'000'000 };
 
 template<typename T>
 void declare_vec(py::module &m, std::string typestr) {
@@ -25,11 +14,6 @@ void declare_vec(py::module &m, std::string typestr) {
 	return a[b];
       })
     .def("__len__", [](const ks::vec<T> &a) { return a.size(); });
-}
-
-template<typename RetType, typename... ParamTypes>
-auto withGlobalAllocator(RetType(*f)(ks::allocator*, ParamTypes...)) {
-  return [f](ParamTypes... params) { return f(&g_alloc, params...); };
 }
 
 // In the future it might make more sense to move the vec type
@@ -48,9 +32,9 @@ PYBIND11_MODULE(PYTHON_MODULE_NAME, m) {
   declare_vec<ks::vec<ks::vec<double> > >(m, std::string("vec_vec_double"));
   declare_vec<ks::vec<ks::vec<ks::vec<double> > > >(m, std::string("vec_vec_vec_double"));
   declare_vec<ks::vec<ks::vec<ks::vec<ks::vec<double> > > > >(m, std::string("vec_vec_vec_vec_double"));
-  m.def("sigmoid", withGlobalAllocator(&ks::sigmoid$af));
-  m.def("logsumexp", withGlobalAllocator(&ks::logsumexp$aT1f));
-  m.def("lstm_model", withGlobalAllocator(&ks::lstm_model$aT1fT1fT1fT1fT1fT1fT1fT1fT1fT1fT1f));
-  m.def("lstm_predict", withGlobalAllocator(&ks::lstm_predict$aT1$dT1fT1fT1fT1fT1fT1fT1fT1fT1fT1f$bT1fT1fT1fT1f));
-  m.def("lstm_objective", withGlobalAllocator(&ks::lstm_objective$aT1$dT1fT1fT1fT1fT1fT1fT1fT1fT1fT1f$bT1fT1fT1fT1$dT1fT1f$b));
+  m.def("sigmoid", with_ks_allocator(&ks::sigmoid$af));
+  m.def("logsumexp", with_ks_allocator(&ks::logsumexp$aT1f));
+  m.def("lstm_model", with_ks_allocator(&ks::lstm_model$aT1fT1fT1fT1fT1fT1fT1fT1fT1fT1fT1f));
+  m.def("lstm_predict", with_ks_allocator(&ks::lstm_predict$aT1$dT1fT1fT1fT1fT1fT1fT1fT1fT1fT1f$bT1fT1fT1fT1f));
+  m.def("lstm_objective", with_ks_allocator(&ks::lstm_objective$aT1$dT1fT1fT1fT1fT1fT1fT1fT1fT1fT1f$bT1fT1fT1fT1$dT1fT1f$b));
 }

--- a/test/ksc/gmmpy.cpp
+++ b/test/ksc/gmmpy.cpp
@@ -1,18 +1,7 @@
-/* There's a lot of duplication between this and mnistcnnpy.cpp, but
- * we will follow the Rule of Three
- *
- *    https://en.wikipedia.org/wiki/Rule_of_three_(computer_programming)
- */
 
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-#include <pybind11/operators.h>
-
-namespace py = pybind11;
+#include "knossos-pybind.h"
 
 #include "gmm.cpp"
-
-ks::allocator g_alloc{ 1'000'000'000 };
 
 template<typename T>
 void declare_vec(py::module &m, std::string typestr) {
@@ -25,11 +14,6 @@ void declare_vec(py::module &m, std::string typestr) {
 	return a[b];
       })
     .def("__len__", [](const ks::vec<T> &a) { return a.size(); });
-}
-
-template<typename RetType, typename... ParamTypes>
-auto withGlobalAllocator(RetType(*f)(ks::allocator*, ParamTypes...)) {
-  return [f](ParamTypes... params) { return f(&g_alloc, params...); };
 }
 
 // In the future it might make more sense to move the vec type
@@ -48,6 +32,6 @@ PYBIND11_MODULE(PYTHON_MODULE_NAME, m) {
   declare_vec<ks::vec<ks::vec<double> > >(m, std::string("vec_vec_double"));
   declare_vec<ks::vec<ks::vec<ks::vec<double> > > >(m, std::string("vec_vec_vec_double"));
   declare_vec<ks::vec<ks::vec<ks::vec<ks::vec<double> > > > >(m, std::string("vec_vec_vec_vec_double"));
-  m.def("gmm_knossos_gmm_objective", withGlobalAllocator(&ks::gmm_knossos_gmm_objective$aT1T1fT1fT1T1fT1T1fT1T1f$dfi$b));
-  m.def("rev_gmm_knossos_gmm_objective", withGlobalAllocator(&ks::rev$gmm_knossos_gmm_objective$aT1T1fT1fT1T1fT1T1fT1T1f$dfi$b));
+  m.def("gmm_knossos_gmm_objective", with_ks_allocator(&ks::gmm_knossos_gmm_objective$aT1T1fT1fT1T1fT1T1fT1T1f$dfi$b));
+  m.def("rev_gmm_knossos_gmm_objective", with_ks_allocator(&ks::rev$gmm_knossos_gmm_objective$aT1T1fT1fT1T1fT1T1fT1T1f$dfi$b));
 }

--- a/test/ksc/mnistcnnpy.cpp
+++ b/test/ksc/mnistcnnpy.cpp
@@ -1,12 +1,7 @@
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-#include <pybind11/operators.h>
 
-namespace py = pybind11;
+#include "knossos-pybind.h"
 
 #include "mnistcnn.cpp"
-
-ks::allocator g_alloc{ 1'000'000'000 };
 
 template<typename T>
 void declare_vec(py::module &m, std::string typestr) {
@@ -21,11 +16,6 @@ void declare_vec(py::module &m, std::string typestr) {
     .def("__len__", [](const ks::vec<T> &a) { return a.size(); });
 }
 
-template<typename RetType, typename... ParamTypes>
-auto withGlobalAllocator(RetType(*f)(ks::allocator*, ParamTypes...)) {
-  return [f](ParamTypes... params) { return f(&g_alloc, params...); };
-}
-
 // In the future it might make more sense to move the vec type
 // definitions to a general Knossos CPP types Python module.
 PYBIND11_MODULE(PYTHON_MODULE_NAME, m) {
@@ -34,6 +24,6 @@ PYBIND11_MODULE(PYTHON_MODULE_NAME, m) {
   declare_vec<ks::vec<ks::vec<double> > >(m, std::string("vec_vec_double"));
   declare_vec<ks::vec<ks::vec<ks::vec<double> > > >(m, std::string("vec_vec_vec_double"));
   declare_vec<ks::vec<ks::vec<ks::vec<ks::vec<double> > > > >(m, std::string("vec_vec_vec_vec_double"));
-  m.def("conv2d", withGlobalAllocator(&ks::conv2d$aT1T1T1T1fT1fT1T1T1f));
-  m.def("mnist", withGlobalAllocator(&ks::mnist$aT1T1T1fT1T1T1T1fT1fT1T1T1T1fT1fT1T1T1T1fT1fT1T1fT1f));
+  m.def("conv2d", with_ks_allocator(&ks::conv2d$aT1T1T1T1fT1fT1T1T1f));
+  m.def("mnist", with_ks_allocator(&ks::mnist$aT1T1T1fT1T1T1T1fT1fT1T1T1T1fT1fT1T1T1T1fT1fT1T1fT1f));
 }


### PR DESCRIPTION
This PR pulls out `knossos-pybind.h` from #550, and updates the python tests in `test/ksc` to use this. I've pulled this out as a separate PR because it's also the first step towards fixing #549 (where these tests are currently broken).

I've removed the functions `declare_tensor_N` for the time being. We'll want to merge them somehow with the `declare_vec` used in these tests, but because the two implementations are currently incompatible it wasn't obvious to me how best to do this.