### PR TITLE
TorchScript to Knossos v2

### DIFF
--- a/src/onnx2ks/onnx2ks.py
+++ b/src/onnx2ks/onnx2ks.py
@@ -75,13 +75,7 @@ def onnxAttrType_to_Type(ty):
     assert isinstance(ty, OpSchema.AttrType)
     return ATTR_TYPE_TO_KS_TYPE[ty]
 
-
-# See https://github.com/onnx/onnx/blob/master/onnx/mapping.py
-TENSOR_TYPE_TO_KS_TYPE = {
-    int(TensorProto.FLOAT): Type.Float,
-    int(TensorProto.UINT8): Type.Integer,
     int(TensorProto.INT8): Type.Integer,
-    int(TensorProto.UINT16): Type.Integer,
     int(TensorProto.INT16): Type.Integer,
     int(TensorProto.INT32): Type.Integer,
     int(TensorProto.INT64): Type.Integer,

--- a/src/python/ksc/ks_function.py
+++ b/src/python/ksc/ks_function.py
@@ -63,4 +63,28 @@ class KsFunction:
         if hasattr(self._py_mod, "defs"):
             return self._py_mod.defs[name_to_call](*args)
         else:
-            return self._py_mod.main(*args)
+            return self._py_mod.entry(*args)
+
+
+import torch # TODO: move somewhere torch specific
+
+class KscFunction:
+    """
+    Compiled KS function
+    """
+    def __init__(self, py_mod):
+        self._py_mod = py_mod
+
+    @property
+    def rev(self):
+        return self._py_mod.rev_entry
+
+    def __call__(self, *args):
+        return self._py_mod.entry(*args)
+
+    def adapt(self, val):
+        if isinstance(val, torch.Tensor):
+            if len(val.shape) == 2 and val.dtype == torch.float64:
+                return self._py_mod.Tensor_2_Float(val.data_ptr(), *val.shape)
+        
+        raise NotImplementedError

--- a/src/runtime/knossos.h
+++ b/src/runtime/knossos.h
@@ -1083,13 +1083,12 @@ namespace ks {
 	tensor<Dim, T> ts_scale(allocator * alloc, double val, tensor<Dim, T> const& t)
 	{
 		auto ret = tensor<Dim, T>::create(alloc, t.size());
-		T const* tdata = t.data();
 		T* retdata = ret.data();
+		T const* tdata = t.data();
 		for (int i = 0, ne = t.num_elements(); i != ne; ++i)
 			retdata[i] = ts_scale(alloc, val, tdata[i]);
 		return ret;
 	}
-
 
 	inline int ts_neg(allocator *, int d) { return -d; }
 
@@ -1242,6 +1241,18 @@ namespace ks {
 		return sumbuild_t<Dim>::template do_sumbuild<T>(alloc, size, f);
 	}
 
+	// Elementwise map
+	template <size_t Dim, class T, class F>
+	tensor<Dim, T> elementwise_map(allocator * alloc, tensor<Dim, T> const& t, F f)
+	{
+		auto ret = tensor<Dim, T>::create(alloc, t.size());
+		T const* tdata = t.data();
+		T* retdata = ret.data();
+		for (int i = 0, ne = t.num_elements(); i != ne; ++i)
+			retdata[i] = f(tdata[i]);
+		return ret;
+	}
+	
 	// =============================== BuildFromSparse ==================================
 
 	template<size_t Dim>
@@ -1695,3 +1706,7 @@ namespace ks {
 #include "knossos-lm.h"
 
 #include "knossos-prelude.h"
+
+#ifdef KS_INCLUDE_ATEN
+#include "prelude-aten.cpp"
+#endif

--- a/src/runtime/prelude-aten.cpp
+++ b/src/runtime/prelude-aten.cpp
@@ -1,0 +1,48 @@
+
+#include "knossos.h"
+
+#include <cmath>
+
+namespace ks {
+
+tensor<1, double> 
+aten$8$8matmul$aT2fT1f(allocator * alloc, tensor<2,double> const& M, tensor<1,double> const& v)
+{
+	auto [r,c] = size(M);
+    KS_ASSERT(c == size(v));
+	tensor<1,double> ret(alloc, r);
+	for(int i = 0; i < r; ++i)
+		ret[i] = ts_dot(M[i], v);
+	return ret;
+}
+
+template <size_t Dim, class T>
+tensor<Dim, T>
+aten$8$8pow$aT2fi(allocator * alloc, tensor<Dim,T> const& a, int const& i)
+{
+	return elementwise_map(alloc, a, [i](T const& v) { return std::pow(v, i); });
+}
+
+tuple<tensor<2,double>,tensor<1,double>> 
+rev$aten$8$8matmul$a$dT2fT1f$bT1f(allocator * alloc, std::tuple<tensor<2,double>, tensor<1,double>> const& M_v, tensor<1,double> const& dr)
+{
+    auto [M, v] = M_v;
+	auto [r, c] = size(M);
+	KS_ASSERT(c == size(v));
+
+	tensor<2,double> retM(alloc, size(M));
+	for(int i = 0; i < r; ++i)
+		retM[i] = ts_scale(alloc, dr[i], v);
+
+	tensor<1,double> retv(alloc, c);
+	for(int i = 0; i < c; ++i) {
+		double retvi = 0;
+		for(int j = 0; j < r; ++j)
+			retvi += M[j][i] * dr[j];
+		retv[i] = retvi;
+	}
+
+	return {retM,retv};
+}
+
+}

--- a/src/runtime/prelude-aten.ks
+++ b/src/runtime/prelude-aten.ks
@@ -1,0 +1,130 @@
+;; Definitions for aten functions
+;; edefs will go in prelude-aten.cpp
+
+(def aten::lt Bool ((a : Float) (b : Float))
+    (lt a b))
+
+(def aten::lt Bool ((a : Integer) (b : Float))
+    (lt (to_float a) b))
+
+
+;; mul
+(def aten::mul Float ((a : Float) (b : Float))
+    (mul a b))
+
+(def aten::mul (Tensor 1 Float) ((a : Tensor 1 Float) (b : Float))
+    (ts_scale b a))
+
+(def aten::mul (Tensor 2 Float) ((a : Tensor 2 Float) (b : Float))
+    (ts_scale b a))
+
+(def aten::mul (Tensor 2 Float) ((a : Tensor 2 Float) (b : Tensor 2 Float))
+    (build (size a) (lam (inds : Tuple Integer Integer)
+        (mul (index inds a) (index inds b)))))
+
+(def aten::add Float ((a : Float) (b : Float))
+    (add a b))
+
+(def aten::neg Float (a : Float)
+    (neg a))
+
+(def aten::sin Float (a : Float)
+    (sin a))
+
+(def aten::Float Float (a : Integer)
+    (to_float a))
+(def aten::Float Float (a : Float)
+    a)
+
+(def aten::Bool Bool (a : Bool)
+    a)
+(def aten::Bool Bool (a : Float)
+    (not (eq a 0.0)))
+
+(def aten::sin (Tensor 2 Float) (a : Tensor 2 Float)
+    (build (size a) (lam (ij : Tuple Integer Integer)
+        (sin (index ij a)))))
+
+;; a^n
+(edef aten::pow (Tensor 2 Float) ((Tensor 2 Float) Integer))
+(def [shape aten::pow] (Tensor 2 (Tuple)) ((a : Tensor 2 Float) (n : Integer))
+    (shape a))
+(edef [D aten::pow] (LM (Tuple (Tensor 2 Float) Integer) (Tensor 2 Float)) ((Tensor 2 Float) Integer))
+(edef [Dt aten::pow] (Tuple (Tensor 2 Float) (LM (Tuple (Tensor 2 Float) Integer) (Tensor 2 Float))) ((Tensor 2 Float) Integer))
+
+;; n*a^(n - 1) * dr
+(def [rev aten::pow] (Tuple (Tensor 2 Float) (Tuple)) ((a_n : Tuple (Tensor 2 Float) Integer) (dr : Tensor 2 Float))
+    (let ((a n) a_n)
+    (let (nanm1 (ts_scale (to_float n) (aten::pow a (sub n 1))))
+    (tuple (aten::mul nanm1 dr)
+       (tuple)))))
+
+(def [fwd aten::pow] (Tensor 2 Float) ((a_n : Tuple (Tensor 2 Float) Integer) (da_n : (Tuple (Tensor 2 Float) (Tuple))))
+    (let ((a n) a_n)
+    (let ((da dn) da_n)
+    (let (nanm1 (ts_scale (to_float n) (aten::pow a (sub n 1))))
+    (aten::mul nanm1 da)))))
+
+(def aten::prod Float (a : Tuple Float Float)
+    (mul (get$1$2 a) (get$2$2 a)))
+
+(def aten::prod Integer (a : Tuple Integer Integer)
+    (mul (get$1$2 a) (get$2$2 a)))
+
+(def aten::sum Float (a : Tensor 2 Float)
+    (sumbuild (size a) (lam (ij : Tuple Integer Integer)
+            (index ij a))))
+
+(def aten::mean Float ((a : Tensor 2 Float) (opt_dtype : Float))
+    (div (aten::sum a) (aten::Float (aten::prod (size a)))))
+
+(def Tensor_init (Tensor 2 Float) ((a : Vec (Vec Float)))
+    (let (m (size a))
+    (let (n (size (index 0 a)))
+    (build (tuple m n) (lam (ij : Tuple Integer Integer)
+        (let ((i j) ij)
+            (index j (index i a))))))))
+
+(def VecVec_init (Vec (Vec Float)) (a : Tensor 2 Float)
+    (let ((m n) (size a))
+    (build m (lam (i : Integer)
+        (build n (lam (j : Integer)
+            (index (tuple i j) a)))))))
+
+(def xrev$Tensor_init (Vec (Vec Float)) ((a : Vec (Vec Float)) (dr : Tensor 2 Float))
+    (VecVec_init dr))
+   
+(def aten::tensor (Tensor 2 Float) ((a : Vec (Vec Float)) (x1 : Float) (x2 : Float) (x3 : Float) )
+    (Tensor_init a))
+
+(def aten::tensor (Tensor 1 Float) ((a : Vec Float) (x1 : Float) (x2 : Float) (x3 : Float) )
+    a)
+
+; mul Mat Vec
+(edef aten::matmul (Tensor 1 Float) ((Tensor 2 Float) (Tensor 1 Float)))
+(def [shape aten::matmul] (Tensor 1 (Tuple)) ((m : (Tensor 2 Float)) (v : (Tensor 1 Float)))
+          (constVec (size v) (tuple)))
+
+(edef [D aten::matmul] (LM (Tuple (Tensor 2 Float) (Tensor  1 Float)) (Tensor  1 Float))
+          ((Tensor 2 Float) (Tensor  1 Float)))
+(edef [Dt aten::matmul] (Tuple (Tensor  1 Float) (LM (Tuple (Tensor 2 Float) (Tensor  1 Float)) (Tensor  1 Float)))
+          ((Tensor 2 Float) (Tensor  1 Float)))
+
+(def [fwd aten::matmul] (Tensor 1 Float)
+          ((M_v : (Tuple (Tensor 2 Float) (Tensor  1 Float))) (dM_dv : (Tuple (Tensor 2 Float) (Tensor  1 Float))))
+     (let ((M v) M_v)
+     (let ((dM dv) dM_dv)
+        (ts_add (aten::matmul dM v) (aten::matmul M dv)))))
+
+(edef [rev aten::matmul] (Tuple (Tensor 2 Float) (Tensor  1 Float))
+          ((Tuple (Tensor 2 Float) (Tensor  1 Float)) (Tensor  1 Float)))
+
+
+(def aten::dot Float ((a : Tensor 1 Float) (b : Tensor 1 Float))
+    (ts_dot a b))
+
+(def aten::size (Tuple Integer Integer) (a : Tensor 2 Float)
+    (size a))
+
+(def aten::len Integer (a : Tuple Integer Integer)
+    2)

--- a/src/ts2k/ts2ks/__init__.py
+++ b/src/ts2k/ts2ks/__init__.py
@@ -1,1 +1,1 @@
-from ts2ks.ts2ks import ts2ks, ts2ks_fromgraph
+from ts2ks.ts2ks import ts2ks, ts2ks_fromgraph, ts2mod

--- a/src/ts2k/ts2ks/ts2ks.py
+++ b/src/ts2k/ts2ks/ts2ks.py
@@ -1,5 +1,28 @@
-import sexpdata
+from typing import List, Tuple
+
 import functools
+import numpy
+import torch
+import torch.onnx
+
+from ksc import utils
+from ksc.ks_function import KscFunction
+from ksc.parse_ks import parse_ks_filename
+
+from ksc.type import Type
+from ksc.expr import Expr, Def, EDef, Rule, Const, Var, Lam, Call, Let, If, Assert
+
+from ksc.type_propagate import type_propagate_decls
+
+# Importing prettyprint to get the decorated printers for Expression and Type
+import ksc.prettyprint # pylint: disable=unused-import
+
+# Import the prettyprinter routines we use explicitly in this file
+from prettyprinter import cpprint, pformat
+
+# Needed this in order to see the error messages when pprint fails
+import warnings
+warnings.filterwarnings("always")
 
 # Background reading
 # https://github.com/pytorch/pytorch/blob/master/torch/csrc/jit/OVERVIEW.md
@@ -10,64 +33,77 @@ import functools
 nl = "\n"
 tab = "\t"
 
-add_edef = "(edef addATEN (Vec (Vec Float)) ((Vec (Vec Float)) Float))"
-
 # CallMethod resolution:
 # https://github.com/pytorch/pytorch/blob/b6bb644e41b3928b5a515330ad35c8b447fcb876/torch/csrc/jit/serialization/python_print.cpp#L984-L1004
 
+Type_Tensor = Type.Tensor(-1, Type.Float)  # float vs integer? also determine rank instead of hardcode
 symbolLook = {
-    "Tensor": [
-        sexpdata.Symbol("Vec"),
-        [sexpdata.Symbol("Vec"), sexpdata.Symbol("Float")],
-    ],  # float vs integer? also determine rank instead of hardcode
-    "int": [sexpdata.Symbol("Integer")],
-    "float": [sexpdata.Symbol("Float")],
-    "Optional[Tensor]": [  # Just say optionals are required for now. TODO: don't do this!
-        sexpdata.Symbol("Vec"),
-        [sexpdata.Symbol("Vec"), sexpdata.Symbol("Float")],
-    ],  # float vs integer? also determine rank instead of hardcode
-    "Optional[bool]": [  # Just say optionals are required for now. TODO: don't do this!
-        sexpdata.Symbol("Bool")
-    ],
+    "Optional[bool]": Type.Bool,  # Just say optionals are required for now. TODO: don't do this!
 }
 
 # We're going to have to break out the data structure at some point, for now, hardcode
 # No recursive literals
-symbolLook["Tuple[int, Tensor]"] = [
-    sexpdata.Symbol("Tuple"),
-    symbolLook["int"],
-    symbolLook["Tensor"],
-]
+symbolLook["Tuple[int, Tensor]"] = Type.Tuple(Type.Integer, Type_Tensor)
 
 # hardcoding BertScriptableForQuestionAnswering TODO: getting urgent now to break up the return type and transform
 symbolLook[
     "Tuple[Optional[Tensor], Tensor, Tensor, Optional[List[Tensor]], Optional[List[Tensor]]]"
-] = [
-    sexpdata.Symbol("Tuple"),
-    symbolLook["Tensor"],
-    symbolLook["Tensor"],
-    sexpdata.Symbol("Vec"),
-    [symbolLook["Tensor"]],
-    sexpdata.Symbol("Vec"),
-    [symbolLook["Tensor"]],
-]
+] = Type.Tuple(
+        Type_Tensor,
+        Type_Tensor,
+        Type_Tensor,
+        Type.Tensor(1, Type_Tensor),
+        Type.Tensor(1, Type_Tensor)
+    )
+
 #
 
 
-def mangleDebugName(name):
-    return "_" + name.replace(".", "_")
+def mangled_name(node):
+    return "_" + utils.encode_name(node.debugName())
 
+def from_torch_dtype(t):
+    if t == torch.int64:
+        return Type.Integer
 
-def make_arg(input):
-    type_lookup = str(input.type())
+    if t == torch.float64:
+        return Type.Float
+
+    raise NotImplementedError
+
+def from_torch_type(t):
+    if type(t) == torch._C.IntType:
+        return Type.Integer
+
+    if type(t) == torch._C.FloatType:
+        return Type.Float
+
+    if type(t) == torch._C.TensorType:
+        if t.scalarType() is not None:
+            return Type.Tensor(-1, from_torch_type(t.scalarType()))
+        else:
+            print("Assuming Tensor type is float")
+            return Type.Tensor(-1, Type.Float)
+
+    type_lookup = str(t)
+
     if "Optional" in type_lookup:
-        print("WARNING: treated as required:" + type_lookup)
-    return [
-        sexpdata.Symbol(mangleDebugName(input.debugName())),
-        sexpdata.Symbol(":"),
-        symbolLook[type_lookup],
-    ]
+        print("WARNING: Optional argument treated as required:" + type_lookup)
 
+    return symbolLook[type_lookup]
+
+def type_from_value(x):
+    if isinstance(x, torch.Tensor):
+        return Type.Tensor(len(x.size()), from_torch_dtype(x.dtype))
+
+    return Type.fromValue(x)
+
+def make_arg(input, example_input):
+    input_type = type_from_value(example_input)
+    input_type_2 = from_torch_type(input.type())
+    assert input_type.kind == input_type_2.kind
+    name = mangled_name(input)
+    return Var(name, input_type, decl=True)
 
 def make_constant(node):
 
@@ -84,161 +120,101 @@ def make_constant(node):
     except RuntimeError:
         literal = "FUNCTIONCALL"
 
-    return [sexpdata.Symbol("\n"), sexpdata.Symbol("_" + value.debugName()), literal]
-
-
-def make_print(node):
-    mangled_id = mangleDebugName(node.inputsAt(0).debugName())
-    return sexpdata.Symbol("print"), sexpdata.Symbol(mangled_id)
-
-
-def make_list_init_inner(values, i, rescue):
-    value = values[0]
-    rhs = [sexpdata.Symbol("assert"), sexpdata.Symbol("false"), sexpdata.Symbol(rescue)]
-    if len(values) > 1:
-        rhs = make_list_init_inner(values[1:], i + 1, rescue)
-    return [
-        sexpdata.Symbol("if"),
-        [sexpdata.Symbol("eq"), sexpdata.Symbol("ni"), i],
-        sexpdata.Symbol(mangleDebugName(value.debugName())),
-        rhs,
-    ]
-
-
-def make_list_init(values):
-    # We may switch to vector literals later: https://github.com/microsoft/knossos-ksc/issues/310
-    # in the meantime here's a quick-and-dirty translation to chained if
-    # CAUTION: if it goes out of range it uses the first value!
-    return make_list_init_inner(values, 0, mangleDebugName(values[0].debugName()))
+    return Var("_" + value.debugName()), Const(literal)
 
 
 def make_list(node):
     value = node.outputsAt(0)
-
-    list_size = sum(1 for _ in node.inputs())
-    if list_size == 0:
-        return (
-            []
-        )  # may not be very practical on the Knossos side, some of the TorchScript workarounds currently mutates in place
-    else:
-        return [
-            sexpdata.Symbol("\n"),
-            sexpdata.Symbol("_" + value.debugName()),
-            [
-                sexpdata.Symbol("build"),
-                sexpdata.Symbol(str(list_size)),
-                [
-                    sexpdata.Symbol("lam"),
-                    [
-                        sexpdata.Symbol("ni"),
-                        sexpdata.Symbol(":"),
-                        sexpdata.Symbol("Integer"),
-                    ],
-                    make_list_init(list(node.inputs())),
-                ],
-            ],
-        ]
+    return Var(mangled_name(value)), Call("Vec_init", [Var(mangled_name(i)) for i in node.inputs()])
 
 
 def make_tensor(node):
     # tensors aren't explicitly modelled in Knossos yet, leave them as identity over a (jagged) list for now
     value = node.outputsAt(0)
 
-    return [
-        sexpdata.Symbol("\n"),
-        sexpdata.Symbol(mangleDebugName(value.debugName())),
-        sexpdata.Symbol(mangleDebugName(node.inputsAt(0).debugName())),
-    ]
+    return Var(mangled_name(value)), Var(mangled_name(node.inputsAt(0)))
 
 
 def make_aten_function(node, value, function_name):
-    return [
-        sexpdata.Symbol("\n"),
-        sexpdata.Symbol(mangleDebugName(value.debugName())),
-        [
-            sexpdata.Symbol(function_name),
-            sexpdata.Symbol(mangleDebugName(node.inputsAt(0).debugName())),
-            sexpdata.Symbol(mangleDebugName(node.inputsAt(1).debugName())),
-        ],
-    ]
-
-
-def make_builtin_function(node, value, function_name):
-    return [
-        sexpdata.Symbol("\n"),
-        sexpdata.Symbol(mangleDebugName(value.debugName())),
-        [
-            sexpdata.Symbol(function_name),
-            sexpdata.Symbol(
-                mangleDebugName(node.inputsAt(0).debugName())
-            ),  # Assum arity 2, enoygh for now
-            sexpdata.Symbol(mangleDebugName(node.inputsAt(1).debugName())),
-        ],
-    ]
-
-
-def make_add(generate_edef, node):
-    value = node.outputsAt(0)
-    if generate_edef:
-        return make_aten_function(node, value, "addATEN")
-    else:
-        print(
-            "WARNING: aten::add built-in just returns unmodified tensor, consider using --generate_edef"
-        )
-        return [
-            sexpdata.Symbol("\n"),
-            sexpdata.Symbol(mangleDebugName(value.debugName())),
-            sexpdata.Symbol(mangleDebugName(node.inputsAt(0).debugName())),
-        ]
-
-
-def make_lt(generate_edef, node):
-    value = node.outputsAt(0)
-    if generate_edef:
-        return make_aten_function(node, value, "ltATEN")
-    else:
-        return make_builtin_function(node, value, "lt")  # Assume floats, enough for now
-
-
-def make_mul(generate_edef, node):
-    value = node.outputsAt(0)
-    if generate_edef:
-        return make_aten_function(node, value, "mulATEN")
-    else:
-        return make_builtin_function(
-            node, value, "mul"
-        )  # Assume floats, enough for now
+    return Var(mangled_name(value)), Call(function_name, [Var(mangled_name(i)) for i in node.inputs()])
 
 
 def make_return(node):
-    mangled_id = mangleDebugName(node.inputsAt(0).debugName())
-    return sexpdata.Symbol(mangled_id)
+    mangled_id = mangled_name(node.inputsAt(0))
+    return Var(mangled_id)
 
 
 def make_callfunction(node):
     value = node.outputsAt(0)
+    assert len(list(node.outputs())) == 1 # Assemble into tuple for multiple outputs
     function_name_constant = node.inputsAt(0).node()
-    input1 = node.inputsAt(
-        1
-    )  # TODO: get all inputs instead of just first, 0th is function name itself
     function_name = function_name_constant.s("name")
-    return [
-        sexpdata.Symbol("\n"),
-        sexpdata.Symbol(mangleDebugName(value.debugName())),
-        [  # get a function call - brackets are escaped by sexpdata
-            sexpdata.Symbol(function_name),
-            sexpdata.Symbol(mangleDebugName(input1.debugName())),
-        ],
-    ]
+    return (Var(mangled_name(value)), 
+            Call(function_name, [Var(mangled_name(i)) for i in node.inputs()]))
 
+def make_lets(bindings, body) -> Expr:
+    for (v,rhs) in reversed(bindings):
+        body = Let(v, rhs, body)
+    return body
+
+def make_loop(make_binds, node):
+    # https://github.com/pytorch/pytorch/blob/master/torch/csrc/jit/OVERVIEW.md#loops
+    # %y_1, ..., %y_r = prim::Loop(%max_trip_count, %initial_condition, %x_1, ..., %x_r)
+    #                     block0(%i, %a_1, ..., %a_r):
+    #                         %b_1, ..., %b_m = some::node(%a_value_from_outer_block, %a_1)
+    #                         %iter_condition = some::other_node(%a_2)
+    #                         -> (%iter_condition, %b_1, ..., %b_r)
+    
+    # def foofilter_comp(xs: Tensor) -> Tensor:
+    #     _0 = annotate(List[Tensor], [])
+    #     _1 = ops.prim.min([9223372036854775807, torch.len(xs)])
+    #     for n in range(_1):
+    #         x = torch.select(xs, 0, n)
+    #         if bool(torch.lt(x, 0.)):
+    #             _2 = torch.mul(x, -0.125)
+    #         else:
+    #             _3 = torch.div(1, n)
+    #             _2 = torch.mul(torch.pow(x, 2), _3)
+    #         _4 = torch.append(_0, _2)
+    #     t = torch.tensor(_0, dtype=None, device=None, requires_grad=False)
+    #     _5 = torch.mean(torch.mul(torch.sin(t), t), dtype=None)
+    #     return _5
+
+    max_trip_count, initial_condition, *x_nodes = node.inputs()
+    y_nodes = tuple(node.outputs())
+    block0, = node.blocks()
+    i,*a_nodes = block0.inputs()
+    iter_condition, *b_nodes = block0.outputs()
+
+    # For now, match only the for loop version
+    assert make_constant(iter_condition.node())[1] == Const(True)
+    assert make_constant(initial_condition.node())[1] == Const(True)
+    assert len(x_nodes) == 0
+    assert len(a_nodes) == 0
+    assert len(b_nodes) == 0
+    assert len(y_nodes) == 0
+
+    body_nodes = list(block0.nodes())
+    last = body_nodes[-1]
+    assert last.kind() == 'aten::append', str(last.kind())
+    l,item = last.inputs()
+    assert l.node().kind() == 'prim::ListConstruct'
+
+    def v(n):
+        return Var(mangled_name(n)) 
+
+    binds = make_binds(body_nodes[:-1])
+    lam_body = make_lets(binds, v(item))
+
+    lam = Lam(Var(mangled_name(i), Type.Integer), lam_body)
+
+    return v(l), Call("build", [v(max_trip_count), lam])
 
 def make_if(make_binds, node):
     def make_branch(block):
         binds = make_binds(block.nodes())
-        if len(binds) > 0:
-            return [sexpdata.Symbol("let")] + binds + [make_return(block.returnNode())]
-        else:
-            return make_return(block.returnNode())
+        body = make_return(block.returnNode())
+        return make_lets(binds, body)
 
     identifier = None
     if node.outputsSize() == 0:
@@ -253,7 +229,7 @@ def make_if(make_binds, node):
             "Only support conditionals with 1 input, this one had: " + str(inputs_size)
         )
 
-    conditional = mangleDebugName(node.inputsAt(0).debugName())
+    conditional = mangled_name(node.inputsAt(0))
 
     blocks = list(
         node.blocks()
@@ -262,64 +238,47 @@ def make_if(make_binds, node):
     success_branch = make_branch(blocks[0])
     failure_branch = make_branch(blocks[1])
 
-    return [
-        sexpdata.Symbol("\n"),
-        sexpdata.Symbol(identifier),
-        [
-            sexpdata.Symbol("if"),
-            sexpdata.Symbol(conditional),
-            sexpdata.Symbol("\n\t"),
-            success_branch,
-            sexpdata.Symbol("\n\t"),
-            failure_branch,
-            sexpdata.Symbol("\n"),
-        ],
-    ]
+    return Var(identifier), If(Var(conditional), 
+                               success_branch,
+                               failure_branch)
 
+def ts2ks_fromgraph(generate_edefs, name, graph, example_inputs):
 
-def make_default(node):
-    print("WARNING, unimplmented node kind: " + node.kind())
-    return sexpdata.Symbol("")
-
-
-def write_edefs(output):
-    output.write(add_edef)
-    output.write("\n")
-    output.write("\n")
-
-
-def ts2ks_fromgraph(output, generate_edefs, name, graph):
-
-    all_nodes = list(graph.nodes())
-
-    def translate_node(make_binds, node):
+    def translate_node(make_binds, node) -> Tuple[Var, Expr]:
         lookups = {
             "prim::Constant": make_constant,
-            "prim::Print": make_print,
             "prim::ListConstruct": make_list,
-            "aten::tensor": make_tensor,
-            "aten::add": functools.partial(make_add, generate_edef=generate_edefs),
-            "aten::lt": functools.partial(make_lt, generate_edef=generate_edefs),
-            "aten::mul": functools.partial(make_mul, generate_edef=generate_edefs),
             "prim::Return": make_return,
             "prim::CallFunction": make_callfunction,
+            "prim::Loop": functools.partial(make_loop, make_binds=make_binds),
             "prim::If": functools.partial(make_if, make_binds=make_binds),
         }
 
-        return lookups.get(node.kind(), make_default)(node=node)
+        kind = node.kind()
+        if kind in lookups:
+            return lookups[kind](node=node)
 
-    def make_binds(nodes):
+        if kind.startswith("aten::"):
+            return make_aten_function(node, node.outputsAt(0), kind)
+
+        print("WARNING, unimplmented node kind: " + node.kind())
+        return Var("ERR"), Var(node.kind())
+
+
+    def make_binds(nodes) -> List[Tuple[Var, Expr]]:
         return [
             translate_node(make_binds, node)
             for node in nodes
             if node.kind() != "prim::Print"
         ]
 
+    all_nodes = list(graph.nodes())
+
     binds = make_binds(all_nodes)
 
     args = [
-        make_arg(input)
-        for input in graph.inputs()
+        make_arg(input, example)
+        for input,example in zip(graph.inputs(), example_inputs)
         if (not input.type().str().startswith("__torch__.transformers"))
     ]  # filtering self, TODO: look for better way
 
@@ -333,7 +292,7 @@ def ts2ks_fromgraph(output, generate_edefs, name, graph):
                 "WARNING: multiple print statements used, only final one currently translated"
             )
         op = translate_node(make_binds, all_nodes[-1])
-        return_type = sexpdata.Symbol("Integer")
+        return_type = Type.Integer
     else:
         if print_count > 0:
             print(
@@ -341,23 +300,169 @@ def ts2ks_fromgraph(output, generate_edefs, name, graph):
             )
         return_node = graph.return_node()
         op = translate_node(make_binds, return_node)
-        return_type = symbolLook[str(return_node.inputsAt(0).type())]
+        return_type = None #Infer return type in type propagation from_torch_type(return_node.inputsAt(0).type())
 
-    body = [
-        sexpdata.Symbol("\n"),
-        sexpdata.Symbol("let"),
-        binds,
-        sexpdata.Symbol("\n"),
-        op,
-    ]
+    body = make_lets(binds, op)
 
-    name_as_symbol = sexpdata.Symbol(name)
-
-    whole_exp = [sexpdata.Symbol("def"), name_as_symbol, return_type, args, body]
-
-    output.write(sexpdata.dumps(whole_exp))
+    return Def(name, return_type, args, body)
 
 
 # TODO: make an configuration named tuple rather than passing flags
-def ts2ks(output, generate_edefs, function):
-    ts2ks_fromgraph(output, generate_edefs, function.name, function.graph)
+def ts2ks(output, generate_edefs, function, example_inputs):
+    s = ts2ks_fromgraph(generate_edefs, function.name, function.graph, example_inputs)
+    output.write(pformat(s))
+
+def ts2mod(function, example_inputs):
+    fn = torch.jit.script(function)
+    ksc_def = ts2ks_fromgraph(False, fn.name, fn.graph, example_inputs)
+
+    if True:
+        symtab = dict()
+        decls_prelude = list(parse_ks_filename("src/runtime/prelude.ks"))
+        type_propagate_decls(decls_prelude, symtab)
+        decls_prelude_aten = list(parse_ks_filename("src/runtime/prelude-aten.ks"))
+        type_propagate_decls(decls_prelude_aten, symtab)
+
+        type_propagate_decls([ksc_def], symtab)
+
+    ks_str = pformat(ksc_def)
+    arg_types = [arg.type_ for arg in ksc_def.args]
+    return_type = ksc_def.return_type
+    mod = utils.generate_and_compile_cpp_from_ks(ks_str, fn.name, arg_types, 
+                                return_type=return_type, generate_derivatives=True, use_aten=True)
+
+    return KscFunction(mod)
+
+
+if __name__ == "__main__":
+    from math import sin
+    torch.set_default_dtype(torch.float64)
+    
+    def bar(a : int, x : float):
+        M = torch.tensor([[1.1, -x], [x+2.1, 2.2]])
+        v = torch.tensor([2.2,3.3])
+
+        Mv = torch.matmul(M, v)
+
+        b = torch.dot(Mv, v)
+
+        if a < 0:
+            t = -0.125*x
+        else:
+            t = 1/2 * x * float(b)
+        return sin(t) * t
+
+    def foofilter(xs : torch.Tensor):
+        t = torch.zeros(xs.shape)
+        for n,x in enumerate(xs):
+            if x < 0:
+                t[n] = -0.125*x 
+            else:
+                t[n] = 1/(n+1) * x ** 2
+
+        return torch.mean(torch.sin(t)*t)
+
+    def foofilter_comp(xs : torch.Tensor):
+        t = torch.tensor([(
+                 -0.125*x          if x < 0.0 
+            else  1/(n+1) * x ** 2).item()
+            for n,x in enumerate(xs)
+        ])
+        return torch.mean(torch.sin(t)*t)
+
+    def foofilter_mask(x : torch.Tensor):
+        mask = x < 0
+        t = mask *(-0.125*x) + (1-mask) * 1/2 * x ** 2
+        return torch.mean(torch.sin(t)*t)
+
+    x_example = torch.rand((23,))
+
+    fn = torch.jit.script(foofilter_comp)
+    print(fn.code)
+    # print(fn(x_example))
+
+    # #AWF: TODO: check "training" attribute -- does that enable faster AD?
+    # with open("/tmp/t.onnx", "w") as temp:
+    #     torch.onnx.export(model=fn, 
+    #                   args=x_example, 
+    #                   example_outputs=fn(x_example),
+    #                   f=temp, 
+    #                   verbose=True)
+    ks_str = ts2ks_fromgraph(False, fn.name, fn.graph, (x_example,))
+    print(pformat(ks_str))
+
+
+
+    print('\n\n*************************\n\n')
+
+    def foo(x : torch.Tensor):
+        y = torch.mean(x)
+        if y < 0:
+            t = -0.125*x
+        else:
+            t = 1/2 * x ** 2
+        return torch.mean(torch.sin(t)*t)
+
+
+    # Compile function and gradients for example input of ones(2,3)
+    x_example = torch.ones((2,3))
+
+    fn = torch.jit.script(foo)
+    print(fn.code)
+    ks_str = ts2ks_fromgraph(False, fn.name, fn.graph, (x_example,))
+    cpprint(ks_str)
+
+    # Compile function and gradients for example input of ones(2,3)
+    x_example = torch.ones((2,3))
+    ks_fun = ts2mod(foo, example_inputs=(x_example,))
+
+    # Call the function at different, interesting inputs
+    x = torch.rand((4,4)) # TODO: check non-square
+
+    ans = foo(x) 
+    print("Python answer = ", ans.numpy())
+
+    ts_foo = torch.jit.script(foo)
+    print("TorchScript answer = ", ts_foo(x).numpy())
+
+    kx = ks_fun.adapt(x)
+    ans = ks_fun(kx)
+    print("Knossos answer = ", ans)
+
+    # Compute the gradient
+    ans = ks_fun.rev(kx, 1.0)
+    ansnp = numpy.array(ans, copy=False)
+    print("Knossos gradient = \n", ansnp)
+
+    # Compute the gradient using torch
+    xtrace = x.clone().detach().requires_grad_(True)
+    y = foo(xtrace)
+    dy = torch.autograd.grad(y, xtrace)
+    print("Torch gradient = \n", dy[0].numpy())
+
+    print("Gradient diff = \n", ansnp - dy[0].numpy())
+
+    #print(f"Knossos mem: {ks_fun._py_mod.allocator_top()}/{ks_fun._py_mod.allocator_peak()}")
+    import timeit
+    def time_ks(n):
+        x = torch.rand((n,n)) 
+        ks_fun._py_mod.reset_allocator()
+        kx = ks_fun.adapt(x)
+        ans = ks_fun.rev(kx, 1.0)
+        #print(numpy.array(ans, copy=False))
+
+    def time_pytorch(n):
+        x = torch.rand((n,n)) 
+        x.requires_grad_(True)
+        y = ts_foo(x)
+        dy = torch.autograd.grad(y, x)
+        #print(dy)
+
+    size = 4
+    ntimes = 10000
+    print("time_ks= ", timeit.timeit(lambda: time_ks(size), number=ntimes))
+    print("time_pt= ", timeit.timeit(lambda: time_pytorch(size), number=ntimes))
+
+
+    # Next:
+    #  - foofilter

--- a/test/builds/build_and_test_mnistcnn.sh
+++ b/test/builds/build_and_test_mnistcnn.sh
@@ -9,5 +9,9 @@ CPP_FILE=$KNOSSOS/test/ksc/mnistcnnpy.cpp
 
 build_pybind11_module $KNOSSOS $PYBIND11 $MODULE_NAME $CPP_FILE
 
+echo Installing JAX...
+
+python3 -m pip install jax==0.1.57 jaxlib==0.1.37
+
 KSCPY=$KNOSSOS/src/python
 PYTHONPATH=$OBJ:$KSCPY python3 -m ksc.mnist.test

--- a/test/builds/test_pytest.sh
+++ b/test/builds/test_pytest.sh
@@ -1,8 +1,7 @@
 set -e
 
 echo Installing dependencies...
-python3 -m pip install pytest numpy jax==0.1.57 jaxlib==0.1.37
-
+python3 -m pip install pytest numpy torch jax==0.1.57 jaxlib==0.1.37
 
 echo Installing ksc...
 cd ./src/python
@@ -11,6 +10,14 @@ cd ../..
 
 echo Running pytest
 python3 -m pytest test/python
+
+echo Installing TS2KS...
+cd ./src/ts2k
+python3 -m pip install --editable .
+cd ../..
+
+echo Running pytest on ts2k
+python3 -m pytest test/ts2k
 
 echo Running pytest using cpp backend
 python3 -m pytest test/python/test_tracing_core.py --backend cpp

--- a/test/ts2k/test_ts2k.py
+++ b/test/ts2k/test_ts2k.py
@@ -1,0 +1,126 @@
+import pytest
+
+import math
+import torch
+
+torch.set_default_dtype(torch.float64)
+
+from ksc import utils
+from ksc.type import Type
+from ts2ks import ts2mod
+
+
+def bar1(a : int, x : float, b : str):
+    if a < 0:
+        t = -0.125*x
+    else:
+        t = 1/2 * x ** 2
+    return torch.sin(t)*t
+
+def grad_bar1(a : int, x : float, b : str):
+    """
+    Hand-written gradient of bar1, used to test AD
+    """
+    if a < 0:
+        t = -0.125*x
+        dtdx = -0.125
+    else:
+        t = 1/2 * x ** 2
+        dtdx = x
+    return torch.sin(t) + t*torch.cos(t)
+
+def relux(x: float):
+    if x < 0.0:
+        return 0.1*x
+    else:
+        return x * x
+
+def grad_relux(x: float):
+    """
+    Hand-written gradient of relux, used to test AD
+    """
+    if x < 0.0:
+        return 0.1
+    else:
+        return 2 * x
+
+def f(x : float):
+    r1 = relux(x)
+    r2 = relux(-r1)
+    return r2
+
+ks_relux = None
+def compile_relux():
+    global ks_relux
+    if ks_relux is None:
+        print("Compiling relux")
+        ks_relux = ts2mod(relux, (1.0,))
+
+def test_ts2k_relux():
+    compile_relux()
+    assert ks_relux(2.0) == relux(2.0)
+
+@pytest.mark.skip(reason="no way of currently testing this")
+def test_ts2k_relux_grad():
+    compile_relux()
+    assert ks_relux.rev(1.3, 1.0) == grad_relux(1.3)
+
+def bar(a : int, x : float):
+    y = torch.tensor([[1.1, -1.2], [2.1, 2.2]])
+
+    b = len(y.size())
+    if a < 0:
+        t = -0.125*x
+    else:
+        t = 1/2 * x * float(b)
+    return math.sin(t)*t
+
+def grad_bar(a : int, x : float):
+    """
+    Hand-written gradient of bar, used to test AD
+    """
+    b = 2
+    if a < 0:
+        t = -0.125*x
+        dtdx = -0.125
+    else:
+        t = 1/2 * x * float(b)
+        dtdx = float(b)/2
+    dda = ()
+    ddx = math.sin(t) + t*math.cos(t)
+    return dda,ddx
+
+@pytest.mark.skip(reason="no way of currently testing this")
+def test_bar():
+    a,x = 1,12.34
+    ks_bar = ts2mod(bar, (a,x))
+    ks_ans = ks_bar(a,x)
+    ans = bar(a,x)
+    assert ans == ks_ans
+
+    assert ks_bar.rev((a,x),1.0) == grad_bar(a,x)
+
+def far(x : torch.Tensor):
+    y = torch.mean(x)
+    if y < 0:
+        t = -0.125*x
+    else:
+        t = 1/2 * x ** 2
+    return torch.mean(torch.sin(t)*t)
+
+@pytest.mark.skip(reason="no way of currently testing this")
+def test_far():
+    x = torch.randn(2,3)
+    ks_far = ts2mod(far, (x,))
+    ks_ans = ks_far(ks_far.adapt(x))
+    ans = far(x)
+    assert pytest.approx(ks_ans, 1e-8) == ans.item()
+
+
+    #assert ks_far.rev((a,x),1.0) == grad_far(a,x)
+
+# def test_Vec_init():
+#     def f(x : float):
+#         return torch.tensor([x, 2.2])
+
+#     ts2mod(f, [Type.Float], Type.Vec(Type.Float))


### PR DESCRIPTION
Rollup of TorchScript interop.  Introduces ``ts2mod``, which takes a python function, runs it through TorchScript parsing, constructs Knossos IR, emits to KSC to compile to dll, loads, and runs.  The work of many people, notable @cgravill and @ryotatomioka.
Still a little drafty, but part of a chain of work so rebasing onto master.

To use: we define a python function
```python
def foo(x : torch.Tensor):
    y = torch.mean(x)
    if y < 0:
        t = -0.125*x
    else:
        t = 1/2 * x ** 2
    return torch.mean(torch.sin(t)*t)
```

And then compile it using ``ts2mod`` (a better name might be an idea):
```python
ks_foo = ts2mod(foo, example_inputs=(torch.ones(2,3),))
```

And then call it at other inputs.
```python
x = torch.rand((4,4))

foo(x)  # Calls the python foo

ks_foo(ks_foo.adapt(x)) # Calls the C++ foo

# Compute the gradient using torch tracing and interpretation
xtrace = x.clone().detach().requires_grad_(True)
y = foo(xtrace)
dy = torch.autograd.grad(y, xtrace)

# Compute the gradient in C++
ks_fun.rev(kx, 1.0)
```
