### PR TITLE
Fix pretty printing for Dummy

### DIFF
--- a/src/ksc/Lang.hs
+++ b/src/ksc/Lang.hs
@@ -1086,7 +1086,7 @@ pprTVar (TVar ty v) = ppr v <+> text ":" <+> ppr ty
 
 pprExpr :: forall phase. InPhase phase => Prec -> ExprX phase -> SDoc
 pprExpr _ (Var   v ) = pprVar @phase v
-pprExpr _ (Dummy ty) = parens $ text "$dummy" <+> ppr ty
+pprExpr _ (Dummy ty) = parens $ text "$dummy" <+> pprParendType ty
 pprExpr p (Konst k ) = pprPrec p k
 pprExpr p (Call f e) = pprCall p f e
 pprExpr _ (Tuple es) = mode (parens $ text "tuple" <+> rest) (parens rest)

--- a/test/ksc/dummy.ks
+++ b/test/ksc/dummy.ks
@@ -1,0 +1,5 @@
+(def f Float (x : Float)
+     (let (d ($dummy (Vec Integer)))
+       0.0))
+
+(def main Integer () 0)


### PR DESCRIPTION
It used to print the type without parens, which breaks on types that
need them (e.g. `(Vec Integer)`)