### PR TITLE
lmDot is a PrimFun

### DIFF
--- a/src/ksc/Prim.hs
+++ b/src/ksc/Prim.hs
@@ -653,6 +653,6 @@ isPrimFun f = f `elem` [ "$inline"  -- ($inline f args...)        Force inline f
                        , "delta", "deltaVec", "diag", "constVec"
                        , "lmApply", "lmApplyR", "lmApplyT", "lmVCat", "lmHCat", "lmTranspose"
                        , "lmVCatV", "lmHCatV"
-                       , "lmCompose", "lmAdd", "lmScale", "lmScaleR"
+                       , "lmCompose", "lmAdd", "lmScale", "lmScaleR", "lmDot"
                        , "lmZero", "lmOne"
                        ]


### PR DESCRIPTION
`lmDot` is used as a `PrimFun` but didn't occur in this list. It should.