### PR TITLE
Optimise tuple-unpacking let of literal tuple

### DIFF
--- a/src/ksc/Opt.hs
+++ b/src/ksc/Opt.hs
@@ -130,6 +130,8 @@ optE env
     go (Lam tv e)         = Lam tv' (optE env' e)
        where
          (tv', env') = optSubstBndr tv env
+    go (Let (TupPat p) (Tuple t) body) =
+      go (foldr (\(v, e) -> Let (VarPat v) e) body (zip p t))
     go (Let tv rhs body)  = Let tv' (go rhs) (optE env' body)
        where
          (tv', env') = traverseState optSubstBndr tv env


### PR DESCRIPTION
This rewrites

```
let (a, b) = (x, y)
```

to

```
let a = x
    b = y
```

Subsequent optimisation passes can then take advantage of those bindings having been separated. I wrote this as part of https://github.com/microsoft/knossos-ksc/pull/565/ but I think it may as well go in on its own.