### PR TITLE
Add noreturn attribute in assertion implementation

### DIFF
--- a/src/runtime/knossos.h
+++ b/src/runtime/knossos.h
@@ -44,7 +44,7 @@ Contents:
         ks::fail(__FILE__, __LINE__, #expr);
 
 namespace ks {
-	inline void fail(char const* file, int line, char const* expr)
+	inline void fail [[noreturn]] (char const* file, int line, char const* expr)
 	{
 		std::cerr << file << ":" << line << ":Assert failed [" << expr << "]\n";
 		throw expr;


### PR DESCRIPTION
This prevents compiler warnings about uses of `KS_ASSERT(false)` in functions with a non-void return type.