### PR TITLE
ADT for PrimFun

### DIFF
--- a/src/ksc/AD.hs
+++ b/src/ksc/AD.hs
@@ -97,7 +97,7 @@ gradE _   _ (App{})        = error "gradE of App not yet supported"
 -- Currently ignoring $inline when gradding.  Perhaps we should
 -- perform the inlining before gradding.
 gradE adp s (Call f arg)
-  | f `isThePrimFun` "$inline"
+  | f `isThePrimFun` P_inline
   = gradE adp s arg
 
 -- grad[ build (\i.e ]
@@ -105,17 +105,17 @@ gradE adp s (Call f arg)
 -- We need the Di binding in case 'i' is mentioned in
 -- grad[e], e.g. build (\i. power(x, i))
 gradE adp s (Call f (Tuple [n, Lam ti body]))
-  | f `isThePrimFun` "build"
+  | f `isThePrimFun` P_build
   = gradBuild adp s n ti body
 
 -- TODO: I'm not very happy about this rule, which effectively
 -- undoes sum (build e) --> sumbuild e
 gradE adp s (Call f (Tuple [n, body]))
-  | f `isThePrimFun` "sumbuild"
+  | f `isThePrimFun` P_sumbuild
   = gradE adp s (pSum (pBuild n body))
 
 gradE adp s (Call f (Tuple [Lam ti body, acc, v]))
-  | f `isThePrimFun` "fold"
+  | f `isThePrimFun` P_fold
   = gradFold adp s ti body acc v
 
 gradE adp s (Call f args) = gradCall adp s f args

--- a/src/ksc/CSE.hs
+++ b/src/ksc/CSE.hs
@@ -149,7 +149,7 @@ cseE cse_env@(CS { cs_subst = subst, cs_map = rev_map })
 -- See Note [CSE of assert]
 cseE cse_env@(CS { cs_map = rev_map }) (Assert cond body)
  | Call eq (Tuple [Var v1, Var v2]) <- cond'
- , eq `isThePrimFun` "eq"
+ , eq `isThePrimFun` P_eq
  , let replace_v1_with_v2 (VarPat v1') | v1' == v1 = VarPat v2
        replace_v1_with_v2 original = original
  , let cse_env' = cse_env { cs_map = M.map replace_v1_with_v2 rev_map }

--- a/src/ksc/Ksc/CatLang.hs
+++ b/src/ksc/Ksc/CatLang.hs
@@ -160,17 +160,17 @@ to_cl_call :: EnvPruned -> [TVar] -> TFun Typed -> TExpr -> CLExpr
 --   * for other calls, prune in the argument
 
 to_cl_call pruned env f e
-  | f `isThePrimFun` "build"
+  | f `isThePrimFun` P_build
   , Tuple [n, Lam tvi body] <- e
   = case pruned of
       NotPruned -> prune env call
       Pruned    -> CLBuild (toCLExpr env n) tvi (toCLExpr (tvi:env) body)
 
-  | f `isThePrimFun` "sumbuild"
+  | f `isThePrimFun` P_sumbuild
   , Tuple [n, lam] <- e
   = to_cl_expr pruned env (pSum (pBuild n lam))
 
-  | f `isThePrimFun` "fold"
+  | f `isThePrimFun` P_fold
   , Tuple [Lam t body, acc, v] <- e
   = case pruned of
       NotPruned -> prune env call
@@ -270,7 +270,7 @@ fromCLExpr is arg (CLBuild size tv elt)
     (is', tv') = notInScopeTV is tv
 
 fromCLExpr is arg (CLFold t lam acc v)
-  = mkPrimCall3 "fold"
+  = mkPrimCall3 P_fold
           (Lam t' (fromCLExpr is' (Var t' : arg) lam))
           (fromCLExpr is arg acc)
           (fromCLExpr is arg v)

--- a/src/ksc/Lang.hs
+++ b/src/ksc/Lang.hs
@@ -398,7 +398,6 @@ types.
 
 -}
 
-type PrimFun = String
 data BaseUserFun p = BaseUserFunId String (BaseUserFunT p)
 
 deriving instance Eq (BaseUserFunT p) => Eq (BaseUserFun p)
@@ -1006,10 +1005,62 @@ instance InPhase p => Pretty (BaseFun p) where
 instance Pretty funid => Pretty (DerivedFun funid) where
   ppr = pprDerivedFun ppr
 
+instance Pretty PrimFun where
+  ppr = pprPrimFun
+
 pprBaseFun :: forall p. InPhase p => BaseFun p -> SDoc
 pprBaseFun (BaseUserFun s) = pprBaseUserFun @p s
-pprBaseFun (PrimFun p ) = text p
+pprBaseFun (PrimFun p ) = pprPrimFun p
 pprBaseFun (SelFun i n) = text "get$" <> int i <> char '$' <> int n
+
+pprPrimFun :: PrimFun -> SDoc
+pprPrimFun = \case
+  P_inline -> text "$inline"
+  P_copydown -> text "$copydown"
+  P_check -> text "$check"
+  P_trace -> text "$trace"
+  P_print -> text "print"
+  P_Vec_init -> text "Vec_init"
+  P_build -> text "build"
+  P_sumbuild -> text "sumbuild"
+  P_buildFromSparse -> text "buildFromSparse"
+  P_buildFromSparseTupled -> text "buildFromSparseTupled"
+  P_fold -> text "fold"
+  P_index -> text "index"
+  P_shape -> text "shape"
+  P_size -> text "size"
+  P_sum -> text "sum"
+  P_unzip -> text "unzip"
+  P_ts_neg -> text "ts_neg"
+  P_ts_add -> text "ts_add"
+  P_ts_scale -> text "ts_scale"
+  P_ts_dot -> text "ts_dot"
+  P_eq -> text "eq"
+  P_ne -> text "ne"
+  P_delta -> text "delta"
+  P_deltaVec -> text "deltaVec"
+  P_diag -> text "diag"
+  P_constVec -> text "constVec"
+  P_lmApply -> text "lmApply"
+  P_lmApplyR -> text "lmApplyR"
+  P_lmApplyT -> text "lmApplyT"
+  P_lmVCat -> text "lmVCat"
+  P_lmHCat -> text "lmHCat"
+  P_lmVCatV -> text "lmVCatV"
+  P_lmHCatV -> text "lmHCatV"
+  P_lmCompose -> text "lmCompose"
+  P_lmAdd -> text "lmAdd"
+  P_lmScale -> text "lmScale"
+  P_lmScaleR -> text "lmScaleR"
+  P_lmDot -> text "lmDot"
+  P_lmZero -> text "lmZero"
+  P_lmOne -> text "lmOne"
+  P_lmApplyTR -> text "lmApplyTR"
+  P_lmDummyFold -> text "P_lmDummyFold"
+  P_lmFold -> text "P_lmFold"
+  P_FFold -> text "FFold"
+  P_RFold -> text "RFold"
+  P_lmVariant -> text "P_lmVariant"
 
 pprUserFun :: forall p. InPhase p => UserFun p -> SDoc
 pprUserFun = pprDerivedFun (pprBaseUserFun @p)
@@ -1383,3 +1434,95 @@ cmpExpr e1
    gos []    _ (_:_) = LT
    gos (_:_) _ []    = GT
    gos (e1:es1) subst (e2:es2) = go e1 subst e2 `thenCmp` gos es1 subst es2
+
+data PrimFun = P_inline
+             | P_copydown
+             | P_check
+             | P_trace
+             | P_print
+             | P_Vec_init
+             | P_build
+             | P_sumbuild
+             | P_buildFromSparse
+             | P_buildFromSparseTupled
+             | P_fold
+             | P_index
+             | P_shape
+             | P_size
+             | P_sum
+             | P_unzip
+             | P_ts_neg
+             | P_ts_add
+             | P_ts_scale
+             | P_ts_dot
+             | P_eq
+             | P_ne
+             | P_delta
+             | P_deltaVec
+             | P_diag
+             | P_constVec
+             | P_lmApply
+             | P_lmApplyR
+             | P_lmApplyT
+             | P_lmVCat
+             | P_lmHCat
+             | P_lmVCatV
+             | P_lmHCatV
+             | P_lmCompose
+             | P_lmAdd
+             | P_lmScale
+             | P_lmScaleR
+             | P_lmDot
+             | P_lmZero
+             | P_lmOne
+             | P_lmApplyTR
+             | P_lmFold
+             | P_FFold
+             | P_RFold
+             | P_lmDummyFold
+             | P_lmVariant
+  deriving (Show, Ord, Eq)
+
+toPrimFun :: String -> Maybe PrimFun
+toPrimFun = \case
+  "$inline" -> Just P_inline
+  "$copydown"-> Just P_copydown
+  "$check" -> Just P_check
+  "$trace" -> Just P_trace
+  "print" -> Just P_print
+  "Vec_init" -> Just P_Vec_init
+  "build" -> Just P_build
+  "sumbuild" -> Just P_sumbuild
+  "buildFromSparse" -> Just P_buildFromSparse
+  "buildFromSparseTupled" -> Just P_buildFromSparseTupled
+  "fold" -> Just P_fold
+  "index" -> Just P_index
+  "shape" -> Just P_shape
+  "size" -> Just P_size
+  "sum" -> Just P_sum
+  "unzip" -> Just P_unzip
+  "ts_neg" -> Just P_ts_neg
+  "ts_add" -> Just P_ts_add
+  "ts_scale" -> Just P_ts_scale
+  "ts_dot" -> Just P_ts_dot
+  "eq" -> Just P_eq
+  "ne" -> Just P_ne
+  "delta" -> Just P_delta
+  "deltaVec" -> Just P_deltaVec
+  "diag" -> Just P_diag
+  "constVec" -> Just P_constVec
+  "lmApply" -> Just P_lmApply
+  "lmApplyR" -> Just P_lmApplyR
+  "lmApplyT" -> Just P_lmApplyT
+  "lmVCat" -> Just P_lmVCat
+  "lmHCat" -> Just P_lmHCat
+  "lmVCatV"-> Just P_lmVCatV
+  "lmHCatV" -> Just P_lmHCatV
+  "lmCompose" -> Just P_lmCompose
+  "lmAdd" -> Just P_lmAdd
+  "lmScale" -> Just P_lmScale
+  "lmScaleR" -> Just P_lmScaleR
+  "lmDot" -> Just P_lmDot
+  "lmZero" -> Just P_lmZero
+  "lmOne" -> Just P_lmOne
+  _ -> Nothing

--- a/src/ksc/Opt.hs
+++ b/src/ksc/Opt.hs
@@ -237,7 +237,7 @@ optFun _ (SelFun i _) arg
   = Nothing
 
 -- $inline needs to look up the global symtab
-optFun env (PrimFun "$inline") arg
+optFun env (PrimFun P_inline) arg
   | Call (TFun _ fun) inner_arg <- arg
   , Just userFun <- maybeUserFun fun
   , Just fun_def <- lookupGblST userFun (optGblST env)
@@ -258,17 +258,17 @@ optPrimFun :: InScopeSet -> PrimFun -> TExpr -> Maybe TExpr
 -- TODO: match precision to target machine
 
 -- Don't try to constant-fold Vec_init
-optPrimFun _ "Vec_init" _args 
+optPrimFun _ P_Vec_init _args 
   = Nothing 
 
 optPrimFun _ op (Tuple [Konst (KFloat k1), Konst (KFloat k2)])
   = Just . Konst . KFloat $
     case op of
-      "ts_add" -> k1 + k2
-      "ts_scale" -> k1 * k2
+      P_ts_add -> k1 + k2
+      P_ts_scale -> k1 * k2
       s -> errorFor s
   where errorFor s = error $ unlines $
-          [ "Failed constant folding [" ++ s ++ "]."
+          [ "Failed constant folding [" ++ render (ppr s) ++ "]."
           , "This error exists to prompt us"
           , "to add a constant folding rule for"
           , "this operation to ksc.  See also"
@@ -279,18 +279,18 @@ optPrimFun _ op (Tuple [Konst (KFloat k1), Konst (KFloat k2)])
 -- RULE: (e1 : ()) + (e2 : ()) = ()
 -- The type () contains only one value (), which is a zero of the type
 -- We use () as the tangent type for non-differentiatable types
-optPrimFun _ "ts_add" (Tuple [e1, e2])
+optPrimFun _ P_ts_add (Tuple [e1, e2])
   | TypeTuple [] <- typeof e1
   , TypeTuple [] <- typeof e2
   = Just (Tuple [])
 
 -- RULE: (a1,a2) + (b1,b2) = (a1+a2, b1+b2)
-optPrimFun _ "ts_add" (Tuple [Tuple es1, Tuple es2])
+optPrimFun _ P_ts_add (Tuple [Tuple es1, Tuple es2])
   | length es1 == length es2
   = Just (Tuple (zipWith pAdd es1 es2))
 
 -- RULE: x+0 = 0+x = x
-optPrimFun _ "ts_add" (Tuple [x, y]) =
+optPrimFun _ P_ts_add (Tuple [x, y]) =
     if isKZero y then
       Just x
     else if isKZero x then
@@ -299,7 +299,7 @@ optPrimFun _ "ts_add" (Tuple [x, y]) =
       Nothing
 
 -- RULE: scale 0 y = 0
-optPrimFun _ "ts_scale" (Tuple [x, y])
+optPrimFun _ P_ts_scale (Tuple [x, y])
   | isKZero x || isKZero y
   -- We use the type of y because the two typing rule for scale in
   -- Prim.hs is
@@ -310,72 +310,72 @@ optPrimFun _ "ts_scale" (Tuple [x, y])
   = Nothing
 
 -- RULE: dot 0 y = 0
-optPrimFun _ "ts_dot" (Tuple [x, y])
+optPrimFun _ P_ts_dot (Tuple [x, y])
   | isKZero x || isKZero y
   = Just $ zeroFloat
   | otherwise
   = Nothing
 
 -- RULE: size (build (n, _)) = n
-optPrimFun _ "size" (Call build (Tuple [n,_]))
-  | build `isThePrimFun` "build"
+optPrimFun _ P_size (Call build (Tuple [n,_]))
+  | build `isThePrimFun` P_build
   = Just n
 
 -- RULE: size (constVec (n, _)) = n
-optPrimFun _ "size" (Call constVec (Tuple [n,_]))
-  | constVec `isThePrimFun` "constVec"
+optPrimFun _ P_size (Call constVec (Tuple [n,_]))
+  | constVec `isThePrimFun` P_constVec
   = Just n
 
 -- RULE: index ei (build ns f) = f ei
-optPrimFun _ "index" (Tuple [ ei, arr ])
+optPrimFun _ P_index (Tuple [ ei, arr ])
   | Just (_, i, e) <- isBuild_maybe arr
   = Just (mkLet i ei e)
 
 -- RULE: index js (constVec (ns, v)) = v
-optPrimFun _ "index" (Tuple [_, Call constVec (Tuple [_, v])])
-  | constVec `isThePrimFun` "constVec"
+optPrimFun _ P_index (Tuple [_, Call constVec (Tuple [_, v])])
+  | constVec `isThePrimFun` P_constVec
   = Just v
 
 -- RULE: sum (build n (\i. if (i==ej) then v else 0)
 --  = let i = ej in v
 
 -- RULE: deltaVec n i 0 = zero (build n (\i . 0))
-optPrimFun _ "deltaVec" (Tuple [n, _i, val])
+optPrimFun _ P_deltaVec (Tuple [n, _i, val])
   | isKZero val
   = Just $ pConstVec n val
 
-optPrimFun _ "sum"         arg           = optSum arg
-optPrimFun _ "build"       (Tuple [sz, Lam i e2]) = optBuild sz i e2
-optPrimFun _ "sumbuild"    (Tuple [sz, Lam i e2]) = optSumBuild sz i e2
-optPrimFun env "lmApply"   (Tuple [e1,e2])        = optLMApply env (AD BasicAD Fwd) e1 e2
-optPrimFun env "lmApplyR"  (Tuple [e1,e2])        = optLMApply env (AD BasicAD Rev) e2 e1
-optPrimFun env "lmApplyT"  (Tuple [e1,e2])        = optLMApply env (AD TupleAD Fwd) e1 e2
-optPrimFun env "lmApplyTR" (Tuple [e1,e2])        = optLMApply env (AD TupleAD Rev) e2 e1
-optPrimFun _ "lmCompose"   (Tuple [f,g])  = optLMCompose f g
+optPrimFun _ P_sum         arg           = optSum arg
+optPrimFun _ P_build       (Tuple [sz, Lam i e2]) = optBuild sz i e2
+optPrimFun _ P_sumbuild    (Tuple [sz, Lam i e2]) = optSumBuild sz i e2
+optPrimFun env P_lmApply   (Tuple [e1,e2])        = optLMApply env (AD BasicAD Fwd) e1 e2
+optPrimFun env P_lmApplyR  (Tuple [e1,e2])        = optLMApply env (AD BasicAD Rev) e2 e1
+optPrimFun env P_lmApplyT  (Tuple [e1,e2])        = optLMApply env (AD TupleAD Fwd) e1 e2
+optPrimFun env P_lmApplyTR (Tuple [e1,e2])        = optLMApply env (AD TupleAD Rev) e2 e1
+optPrimFun _ P_lmCompose   (Tuple [f,g])  = optLMCompose f g
 
-optPrimFun _ "lmVCat" (Tuple es)
+optPrimFun _ P_lmVCat (Tuple es)
   | Just prs <- mapM isLMZero_maybe es
   , (s:_, ts) <- unzip prs
   = Just $ lmZero s (Tuple ts)
 
 -- Add(0, x) = x = Add(x, 0)
-optPrimFun _ "lmAdd" (Tuple [p,q])
+optPrimFun _ P_lmAdd (Tuple [p,q])
   | isLMZero p = Just q
   | isLMZero q = Just p
 
 -- Add(Scale(x), Scale(y)) = Scale(Add(x,y))
   | Call scale1 (Tuple [t1, x]) <- p
   , Call scale2 (Tuple [t2, y]) <- q
-  , scale1 `isThePrimFun` "lmScale"
-  , scale2 `isThePrimFun` "lmScale"
+  , scale1 `isThePrimFun` P_lmScale
+  , scale2 `isThePrimFun` P_lmScale
   , typeof t1 == typeof t2
   = Just $ lmScale (typeof t1) (pAdd x y)
 
 -- Add(HCat(p1, p2, ...), HCat(q1, q2, ...)) = Hcat(Add(p1, q1), Add(p2, q2), ...)
-optPrimFun _ "lmAdd" (Tuple [ Call hcat1 (Tuple ps)
+optPrimFun _ P_lmAdd (Tuple [ Call hcat1 (Tuple ps)
                             , Call hcat2 (Tuple qs) ] )
-  | hcat1 `isThePrimFun` "lmHCat"
-  , hcat2 `isThePrimFun` "lmHCat"
+  | hcat1 `isThePrimFun` P_lmHCat
+  , hcat2 `isThePrimFun` P_lmHCat
   = Just (lmHCat (zipWith (\ pi qi -> lmAdds [pi, qi]) ps qs))
 
 optPrimFun _ _ _ = Nothing
@@ -398,27 +398,27 @@ optLMCompose f g
   -- Scale(T, x) . Scale(T, y) = Scale(T, xy )
   | Call scale1 (Tuple [t1, x]) <- f
   , Call scale2 (Tuple [t2, y]) <- g
-  , scale1 `isThePrimFun` "lmScale"
-  , scale2 `isThePrimFun` "lmScale"
+  , scale1 `isThePrimFun` P_lmScale
+  , scale2 `isThePrimFun` P_lmScale
   , typeof t1 == typeof t2
   = Just $ lmScale (typeof t1) (pMulff x y)
 
   -- (f . g) . h   =>   f . (g . h)
   | Call lmcomp (Tuple [p1,p2]) <- f
-  , lmcomp `isThePrimFun` "lmCompose"
+  , lmcomp `isThePrimFun` P_lmCompose
   = optLMCompose p1 (lmCompose p2 g)
 
   -- f . (g x h)   =>  (f . g) x (f . h)
   -- This duplicates f; we might want to take care
   | Call hcat (Tuple qs) <- g
-  , hcat `isThePrimFun` "lmHCat"
+  , hcat `isThePrimFun` P_lmHCat
   = Just (lmHCat (map (lmCompose f) qs))
 
   -- (m1 `hcat` m2) . (m3 `vcat` m4)  =>  (m1 . m3) + (m2 . m4)
   | Call hcat (Tuple ps) <- f
   , Call vcat (Tuple qs) <- g
-  , hcat `isThePrimFun` "lmHCat"
-  , vcat `isThePrimFun` "lmVCat"
+  , hcat `isThePrimFun` P_lmHCat
+  , vcat `isThePrimFun` P_lmVCat
   = traceWhenUnequal "H o V" (length ps) (length qs) $
     Just (lmAdds (zipWith lmCompose ps qs))
 
@@ -477,12 +477,12 @@ optSum e
 
 -- RULE: sum (diag sz f)  =  build sz f
 optSum (Call diag (Tuple [sz, f]))
-  | diag `isThePrimFun` "diag"
+  | diag `isThePrimFun` P_diag
   = Just $ pBuild sz f
 
 -- RULE: sum (deltaVec sz i e) = e
 optSum (Call deltaVec (Tuple [_, _, e]))
-  | deltaVec `isThePrimFun` "deltaVec"
+  | deltaVec `isThePrimFun` P_deltaVec
   = Just e
 
 optSum _ = Nothing
@@ -509,7 +509,7 @@ optBuild sz i e
 -- NB: however, i might be free in eb
 optBuild sz i e
   | Call delta (Tuple [e1,e2,eb]) <- e
-  , delta `isThePrimFun` "delta"
+  , delta `isThePrimFun` P_delta
   , Just ex <- ok_eq e1 e2
   , i `notFreeIn` ex
   = Just $ mkLet i ex $ pDeltaVec sz (Var i) eb
@@ -523,7 +523,7 @@ optBuild sz i e
 -- RULE: build sz (\i. deltaVec sz i e)   = diag sz (\i. e)
 optBuild sz i build_e
   | Call deltaVec (Tuple [sz2, Var i2, e]) <- build_e
-  , deltaVec `isThePrimFun` "deltaVec"
+  , deltaVec `isThePrimFun` P_deltaVec
   , i  == i2
   = Just $ pDiag sz sz2 (Lam i e)
 
@@ -578,7 +578,7 @@ optSumBuild sz i e
 -- RULE: sumbuild n (\i. delta i ej e)    where i is not free in ej
 --       = let i = ej in e
 optSumBuild _ i (Call delta (Tuple [Var i1, ej, e]))
-  | delta `isThePrimFun` "delta"
+  | delta `isThePrimFun` P_delta
   , i == i1
   , i `notFreeIn` ej
   = Just (mkLet i ej e)
@@ -594,7 +594,7 @@ optSumBuild _ i (Call delta (Tuple [Var i1, ej, e]))
 -- = e[i->j]
 -- = index j (build n (\i. e))
 optSumBuild n i (Call deltaVec (Tuple [_n1, Var i1, e]))
-  | deltaVec `isThePrimFun` "deltaVec"
+  | deltaVec `isThePrimFun` P_deltaVec
   , i == i1
   -- TODO n == sz
   = Just $ pBuild n (Lam i e)
@@ -670,33 +670,33 @@ optGradPrim :: HasCallStack => Type -> PrimFun -> TExpr -> Maybe TExpr
 -- (+) :: (F,F) -> f
 -- (D+) :: (F,F) -> ((dF,dF) -o dF)
 -- (D+)(x,y) :: (dF,dF) -o dF
-optGradPrim _ "ts_add" arg
+optGradPrim _ P_ts_add arg
   | Tuple arg' <- arg
   , [t1, t2] <- map typeof arg'
   = Just (lmHCat [lmOne t1, lmOne t2])
 
 -- ts_scale :: (Float, T) -> T
-optGradPrim (TypeLM _ _) "ts_scale" (Tuple [scalar, v])
+optGradPrim (TypeLM _ _) P_ts_scale (Tuple [scalar, v])
   | TypeFloat <- typeof scalar
   = Just (lmHCat [lmScaleR v, lmScale (typeof v) scalar])
 
 -- ts_dot :: (T,T) -> Float
 -- D$ts_dot :: (T,T) -> (T,T) -o Float
-optGradPrim (TypeLM _ _) "ts_dot" (Tuple [v1, v2])
+optGradPrim (TypeLM _ _) P_ts_dot (Tuple [v1, v2])
   | typeof v1 == typeof v2
   = Just (lmHCat [lmDot v2, lmDot v1])
 
-optGradPrim (TypeLM a _) "ts_neg" _
+optGradPrim (TypeLM a _) P_ts_neg _
   = Just (lmScale a (kTFloat $ -1.0))
 
-optGradPrim _ "sum" e
+optGradPrim _ P_sum e
   | TypeTensor d t <- typeof e
   = Just (lmBuildT (pSize e) (Lam (TVar (tensorIndexType d) $ Simple "sum$ii")
                              (lmOne t)))
 
-optGradPrim _ "size" e = Just $ lmZero e (mkZero (pSize e))
+optGradPrim _ P_size e = Just $ lmZero e (mkZero (pSize e))
 
-optGradPrim _ "index" (Tuple [i,v])
+optGradPrim _ P_index (Tuple [i,v])
   = Just (lmHCat [ lmZero i vi
                  , lmBuildT (pSize v) (Lam ii (lmDelta vi (Var ii) i)) ])
   where
@@ -708,11 +708,11 @@ optGradPrim _ "index" (Tuple [i,v])
 optGradPrim (TypeLM _ TypeBool) _ e
   = Just (lmZero e (Konst (KBool True)))
 
-optGradPrim (TypeLM a _) "$trace" _ = Just (lmOne a)
+optGradPrim (TypeLM a _) P_trace _ = Just (lmOne a)
 
-optGradPrim (TypeLM a _) "$copydown" _ = Just (lmOne a)
+optGradPrim (TypeLM a _) P_copydown _ = Just (lmOne a)
 
-optGradPrim _ f     a = optTrace("No opt for grad of prim " ++ f ++ " at " ++ show (typeof a)) Nothing
+optGradPrim _ f     a = optTrace("No opt for grad of prim " ++ render (ppr f) ++ " at " ++ show (typeof a)) Nothing
 
 
 -----------------------
@@ -722,21 +722,21 @@ optDrvFun _ _ _ = Nothing
 
 optDrvPrim :: HasCallStack => ADDir -> PrimFun -> TExpr -> Maybe TExpr
 
-optDrvPrim Fwd "constVec" (Tuple [n_v, dn_dv])
+optDrvPrim Fwd P_constVec (Tuple [n_v, dn_dv])
   = Just $ pConstVec (pSel 1 2 n_v) (pSel 2 2 dn_dv)
-optDrvPrim Rev "constVec" (Tuple [n_v, ddr])
+optDrvPrim Rev P_constVec (Tuple [n_v, ddr])
   = Just $ Tuple [ mkTangentZero (pSel 1 2 n_v), pSum ddr ]
 
-optDrvPrim Fwd "deltaVec" (Tuple [n_i_v, dn_di_dv])
+optDrvPrim Fwd P_deltaVec (Tuple [n_i_v, dn_di_dv])
   = Just $ pDeltaVec (pSel 1 3 n_i_v) (pSel 2 3 n_i_v) (pSel 3 3 dn_di_dv)
-optDrvPrim Rev "deltaVec" (Tuple [n_i_v, ddr])
+optDrvPrim Rev P_deltaVec (Tuple [n_i_v, ddr])
   = Just $ Tuple [ mkTangentZero (pSel 1 3 n_i_v), mkTangentZero (pSel 2 3 n_i_v), pIndex (pSel 2 3 n_i_v) ddr ]
 
-optDrvPrim Fwd "Vec_init" (Tuple [_vs, dvs])
-  = Just $ mkPrimCall "Vec_init" dvs
-optDrvPrim Rev "Vec_init" (Tuple [Tuple vs, ddr])
+optDrvPrim Fwd P_Vec_init (Tuple [_vs, dvs])
+  = Just $ mkPrimCall P_Vec_init dvs
+optDrvPrim Rev P_Vec_init (Tuple [Tuple vs, ddr])
   = Just $ Tuple (toList $ mapWithIndex (\i _ -> pIndex (kTInt $ toInteger i) ddr) $ fromList vs)
-optDrvPrim Rev "Vec_init" (Tuple [_v, ddr])
+optDrvPrim Rev P_Vec_init (Tuple [_v, ddr])
   = Just $ pIndex (kTInt 0) ddr
 
 optDrvPrim _ _ _ = Nothing
@@ -806,7 +806,7 @@ optLMApplyCall :: HasCallStack
                -> Maybe TExpr       -- :: T(t)
 
 -- (lmZero :: s -o t) `apply` (x :: T(s))  = 0 :: T(t)
-optLMApplyCall _ dir "lmZero" (Tuple [s, t]) dx
+optLMApplyCall _ dir P_lmZero (Tuple [s, t]) dx
   = traceWhenTypesUnequal "Apply lmZero" in_ty (typeof dx) $
     Just (case dir of
             Fwd -> mkTangentZero t
@@ -818,53 +818,53 @@ optLMApplyCall _ dir "lmZero" (Tuple [s, t]) dx
                Fwd -> tangent_s
                Rev -> tangent_t
 
-optLMApplyCall _ _ "lmOne" t dx
+optLMApplyCall _ _ P_lmOne t dx
   = traceWhenTypesUnequal "Apply lmOne"
              (tangentType (typeof t)) (typeof dx) $
     Just dx
 
-optLMApplyCall _ dir "lmAdd" (Tuple [f,g]) dx
+optLMApplyCall _ dir P_lmAdd (Tuple [f,g]) dx
   = Just (pAdd (lmApply_Dir dir f dx) (lmApply_Dir dir g dx))
 
-optLMApplyCall _ Fwd "lmCompose" (Tuple [f,g]) dx = Just (lmApply f (lmApply g dx))
-optLMApplyCall _ Rev "lmCompose" (Tuple [f,g]) dx = Just (lmApplyR (lmApplyR dx f) g)
+optLMApplyCall _ Fwd P_lmCompose (Tuple [f,g]) dx = Just (lmApply f (lmApply g dx))
+optLMApplyCall _ Rev P_lmCompose (Tuple [f,g]) dx = Just (lmApplyR (lmApplyR dx f) g)
 
-optLMApplyCall _ _ "lmScale" (Tuple [_ty, x]) dx
+optLMApplyCall _ _ P_lmScale (Tuple [_ty, x]) dx
   | TypeFloat == typeof x
   = Just (pScale x dx)
 
-optLMApplyCall _ Fwd "lmScaleR" v dx
+optLMApplyCall _ Fwd P_lmScaleR v dx
   | TypeFloat == typeof dx
   = Just (pScale dx v)
 
-optLMApplyCall _ Rev "lmScaleR" dr v
+optLMApplyCall _ Rev P_lmScaleR dr v
   | typeof dr == typeof v
   = Just (pDot dr v)
 
-optLMApplyCall _ Fwd "lmDot" v1 v2
+optLMApplyCall _ Fwd P_lmDot v1 v2
   | typeof v1 == typeof v2
   = Just (pDot v1 v2)
 
-optLMApplyCall _ Rev "lmDot" v r
+optLMApplyCall _ Rev P_lmDot v r
   | typeof r == TypeFloat
   = Just (pScale r v)
 
-optLMApplyCall _ Fwd "lmVCat" (Tuple es) dx = do_prod Fwd es dx
-optLMApplyCall _ Rev "lmVCat" (Tuple es) dx = do_sum  Rev es dx
-optLMApplyCall _ Fwd "lmHCat" (Tuple es) dx = do_sum  Fwd es dx
-optLMApplyCall _ Rev "lmHCat" (Tuple es) dx = do_prod Rev es dx
+optLMApplyCall _ Fwd P_lmVCat (Tuple es) dx = do_prod Fwd es dx
+optLMApplyCall _ Rev P_lmVCat (Tuple es) dx = do_sum  Rev es dx
+optLMApplyCall _ Fwd P_lmHCat (Tuple es) dx = do_sum  Fwd es dx
+optLMApplyCall _ Rev P_lmHCat (Tuple es) dx = do_prod Rev es dx
 
-optLMApplyCall env Fwd "lmVCatV" e dx = do_prod_v env Fwd e dx
-optLMApplyCall env Rev "lmVCatV" e dx = do_sum_v  env Rev e dx
-optLMApplyCall env Fwd "lmHCatV" e dx = do_sum_v  env Fwd e dx
-optLMApplyCall env Rev "lmHCatV" e dx = do_prod_v env Rev e dx
+optLMApplyCall env Fwd P_lmVCatV e dx = do_prod_v env Fwd e dx
+optLMApplyCall env Rev P_lmVCatV e dx = do_sum_v  env Rev e dx
+optLMApplyCall env Fwd P_lmHCatV e dx = do_sum_v  env Fwd e dx
+optLMApplyCall env Rev P_lmHCatV e dx = do_prod_v env Rev e dx
 
-optLMApplyCall _ dir "lmFold" (Tuple [sZero, Lam i m, Lam i' m', acc, v]) dx =
+optLMApplyCall _ dir P_lmFold (Tuple [sZero, Lam i m, Lam i' m', acc, v]) dx =
   do_fold dir sZero i m i' m' acc v dx
 
 optLMApplyCall _ _ fun e arg
   = optTrace ("No opt for LM apply of " ++
-              render (parens (text fun 
+              render (parens (ppr fun 
                       <+> parens (ppr e <+> text ":" <+> ppr (typeof e))
                       <+> text "to" 
                       <+> parens (ppr arg <+> text ":" <+> ppr (typeof arg)))))
@@ -980,7 +980,7 @@ hspec :: Spec
 hspec = do
     describe "optLM tests" $ do
       it "lmAdd(S(x),S(y)) -> S(x+y)" $
-        optPrimFun emptyInScopeSet "lmAdd"
+        optPrimFun emptyInScopeSet P_lmAdd
             (Tuple [lmScale TypeFloat (kTFloat 1.3), lmScale TypeFloat (kTFloat 0.4)])
         `shouldBe`
         Just (lmScale TypeFloat (pAdd (kTFloat 1.3) (kTFloat 0.4)))

--- a/src/ksc/Parse.hs
+++ b/src/ksc/Parse.hs
@@ -98,7 +98,6 @@ Notes:
 
 
 import Lang hiding (parens, brackets)
-import Prim
 
 import Text.Parsec( (<|>), try, many, parse, eof, manyTill, ParseError, unexpected )
 import Text.Parsec.Char
@@ -333,9 +332,9 @@ pIsUserFun fun = case maybeUserFun fun of
 
 pPrimFun :: Parser (BaseFun p)
 pPrimFun = try $ do { f <- pIdentifier
-                    ; when (not (isPrimFun f))
-                           (unexpected (f ++ " is not a PrimFun"))
-                    ; pure (PrimFun f)
+                    ; case toPrimFun f of
+                        Just pf -> pure (PrimFun pf)
+                        Nothing -> unexpected (f ++ " is not a PrimFun")
                     }
 
 pSelFun :: Parser (BaseFun p)

--- a/src/ksc/Prim.hs
+++ b/src/ksc/Prim.hs
@@ -138,7 +138,7 @@ zero value.  Painful, but possible.
 type Shape = TExpr
 
 lmZero :: Shape -> Shape -> TExpr
-lmZero s t = mkPrimCall1 "lmZero" (Tuple [s, t])
+lmZero s t = mkPrimCall1 P_lmZero (Tuple [s, t])
 
 lmZero_Dir :: ADDir -> TExpr -> TExpr -> TExpr
 lmZero_Dir Fwd s t = lmZero s t
@@ -146,27 +146,27 @@ lmZero_Dir Rev s t = lmZero t s
 
 -- lmOne S :: S -o S
 lmOne :: Type -> TExpr
-lmOne s = mkPrimCall1 "lmOne" (mkDummy s)
+lmOne s = mkPrimCall1 P_lmOne (mkDummy s)
 
 -- lmScale S :: Float -> (S -o S)
 -- lmApply (lmScale S r) s = ts_scale r s
 lmScale :: HasCallStack => Type -> TExpr -> TExpr
-lmScale s r = mkPrimCall1 "lmScale" (Tuple [mkDummy s, r])
+lmScale s r = mkPrimCall1 P_lmScale (Tuple [mkDummy s, r])
 
 -- lmScaleR :: S -> (Float -o S)
 -- lmScaleR S :: Float -o S
 -- lmApply (lmScaleR S) r = ts_scale r s
 lmScaleR :: HasCallStack => TExpr -> TExpr
-lmScaleR v = mkPrimCall1 "lmScaleR" v
+lmScaleR v = mkPrimCall1 P_lmScaleR v
 
 -- lmDot :: S -> (S -o Float)
 -- lmDot s :: S -o Float
 -- lmApply (lmDot s) s' = ts_dot (s,s')
 lmDot :: HasCallStack => TExpr -> TExpr
-lmDot s = mkPrimCall1 "lmDot" s
+lmDot s = mkPrimCall1 P_lmDot s
 
 lmAdd :: HasCallStack => TExpr -> TExpr -> TExpr
-lmAdd = mkPrimCall2 "lmAdd"
+lmAdd = mkPrimCall2 P_lmAdd
 
 lmAdds :: HasCallStack => [TExpr]-> TExpr
 lmAdds [] = error "lmAdds of empty list (perhaps this should return lmZero?)"
@@ -175,10 +175,10 @@ lmAdds (x:xs) = lmAdd x (lmAdds xs)
 
 lmHCat :: HasCallStack => [TExpr] -> TExpr
 lmHCat [e] = e
-lmHCat es  = mkPrimCall "lmHCat" (Tuple es)
+lmHCat es  = mkPrimCall P_lmHCat (Tuple es)
 
 lmHCatV :: HasCallStack => TExpr -> TExpr
-lmHCatV e  = mkPrimCall1 "lmHCatV" e
+lmHCatV e  = mkPrimCall1 P_lmHCatV e
 
 -- The argument tuple to ksc's primitive function lmVCat must have two
 -- or more components.  The Haskell function Prim.lmVCat therefore
@@ -188,19 +188,19 @@ lmHCatV e  = mkPrimCall1 "lmHCatV" e
 -- Prim.primFunCallResultTy_maybe.
 lmVCat :: HasCallStack => TExpr -> [TExpr] -> TExpr
 lmVCat s []  = lmZero s (Tuple [])
-lmVCat _ es  = mkPrimCall1 "lmVCat" (Tuple es)
+lmVCat _ es  = mkPrimCall1 P_lmVCat (Tuple es)
 
 lmVCatV :: HasCallStack => TExpr -> TExpr
-lmVCatV e  = mkPrimCall1 "lmVCatV" e
+lmVCatV e  = mkPrimCall1 P_lmVCatV e
 
 lmCompose :: TExpr -> TExpr -> TExpr
-lmCompose = mkPrimCall2 "lmCompose"
+lmCompose = mkPrimCall2 P_lmCompose
 
 lmApply :: HasCallStack => TExpr -> TExpr -> TExpr
-lmApply = mkPrimCall2 "lmApply"
+lmApply = mkPrimCall2 P_lmApply
 
 lmApplyR :: HasCallStack => TExpr -> TExpr -> TExpr
-lmApplyR = mkPrimCall2 "lmApplyR"
+lmApplyR = mkPrimCall2 P_lmApplyR
 
 lmApply_AD :: HasCallStack => ADMode -> TExpr -> TExpr -> TExpr
 lmApply_AD (AD BasicAD dir) = lmApply_Dir  dir
@@ -211,8 +211,8 @@ lmApply_Dir Fwd e ds = lmApply  e ds
 lmApply_Dir Rev e dt = lmApplyR dt e
 
 lmApplyT_Dir :: HasCallStack => ADDir -> TExpr -> TExpr -> TExpr
-lmApplyT_Dir Fwd e ds = mkPrimCall1 "lmApplyT"  (Tuple [e, ds])
-lmApplyT_Dir Rev e dt = mkPrimCall1 "lmApplyTR" (Tuple [dt, e])
+lmApplyT_Dir Fwd e ds = mkPrimCall1 P_lmApplyT  (Tuple [e, ds])
+lmApplyT_Dir Rev e dt = mkPrimCall1 P_lmApplyTR (Tuple [dt, e])
 
 lmBuild :: HasCallStack => TExpr -> TExpr -> TExpr
 lmBuild n b = lmVCatV (pBuild n b)
@@ -221,16 +221,16 @@ lmBuildT :: HasCallStack => TExpr -> TExpr -> TExpr
 lmBuildT n b = lmHCatV (pBuild n b)
 
 lmFold :: HasCallStack => TExpr -> TExpr -> TExpr -> TExpr -> TExpr -> TExpr
-lmFold = mkPrimCall5 "lmFold"
+lmFold = mkPrimCall5 P_lmFold
 
 pFFold :: HasCallStack => TExpr -> TExpr -> TExpr -> TExpr -> TExpr -> TExpr -> TExpr
-pFFold = mkPrimCall6 "FFold"
+pFFold = mkPrimCall6 P_FFold
 
 pRFold :: HasCallStack => Type -> TExpr -> TExpr -> TExpr -> TExpr -> TExpr -> TExpr -> TExpr
-pRFold = mkPrimCall7 "RFold" . mkDummy
+pRFold = mkPrimCall7 P_RFold . mkDummy
 
 lmDummyFold :: HasCallStack => Type -> TExpr
-lmDummyFold = mkPrimCall1 "lmDummyFold" . mkDummy
+lmDummyFold = mkPrimCall1 P_lmDummyFold . mkDummy
 
 lmBuild_Dir :: ADDir -> TExpr -> TExpr -> TExpr
 lmBuild_Dir Fwd = lmBuild
@@ -249,7 +249,7 @@ isThePrimFun (TFun _ (Fun (PrimFun f1))) f2 = f1 == f2
 isThePrimFun _ _ = False
 
 isLMOne :: TExpr -> Bool
-isLMOne (Call f _) = f `isThePrimFun` "lmOne"
+isLMOne (Call f _) = f `isThePrimFun` P_lmOne
 isLMOne _ = False
 
 isLMZero :: TExpr -> Bool
@@ -258,7 +258,7 @@ isLMZero = isJust . isLMZero_maybe
 isLMZero_maybe :: TExpr -> Maybe (TExpr, TExpr)
 -- Just (a,b) means that the input was indeed (lmZero (a,b))
 isLMZero_maybe (Call f args)
-  | f `isThePrimFun` "lmZero"
+  | f `isThePrimFun` P_lmZero
   , (Tuple [a,b]) <- args
   = Just (a,b)
 isLMZero_maybe _ = Nothing
@@ -268,18 +268,18 @@ isKZero = \case
   Konst (KInteger 0  ) -> True
   Konst (KFloat   0.0) -> True
   Tuple ts -> all isKZero ts
-  Call f (Tuple [_,v]) | f `isThePrimFun` "constVec" -> isKZero v
+  Call f (Tuple [_,v]) | f `isThePrimFun` P_constVec -> isKZero v
   _ -> False
 
 isBuild_maybe :: TExpr -> Maybe (TExpr, TVar, TExpr)
 isBuild_maybe (Call f (Tuple [n,Lam i e]))
-  | f `isThePrimFun` "build"
+  | f `isThePrimFun` P_build
   = Just (n, i, e)
 isBuild_maybe _ = Nothing
 
 isConstVec_maybe :: TExpr -> Maybe (TExpr, TExpr)
 isConstVec_maybe (Call f (Tuple [n, v]))
-  | f `isThePrimFun` "constVec"
+  | f `isThePrimFun` P_constVec
   = Just (n, v)
 isConstVec_maybe _ = Nothing
 
@@ -290,7 +290,7 @@ lmDelta t i j = If (pEqual i j) (lmOne ty) (lmZero t t)
 
 isEqualityCall :: TExpr -> Maybe (TExpr, TExpr)
 isEqualityCall (Call f (Tuple [e1,e2]))
-  | f `isThePrimFun` "eq" = Just (e1,e2)
+  | f `isThePrimFun` P_eq = Just (e1,e2)
 isEqualityCall _          = Nothing
 
 -----------------------
@@ -298,53 +298,53 @@ isEqualityCall _          = Nothing
 
 pDelta :: TExpr -> TExpr -> TExpr -> TExpr
 -- delta i j e  =  if i==j then e else zero
-pDelta i j e = mkPrimCall1 "delta" (Tuple [i, j, e])
+pDelta i j e = mkPrimCall1 P_delta (Tuple [i, j, e])
 
 pDeltaVec :: TExpr -> TExpr -> TExpr -> TExpr
 -- deltaVec size i e = build size (\j. delta i j e)
 -- Returns a size-vector with e at index i, and zeros elsewhere
-pDeltaVec sz i e = mkPrimCall1 "deltaVec" (Tuple [sz, i, e])
+pDeltaVec sz i e = mkPrimCall1 P_deltaVec (Tuple [sz, i, e])
 
 pConstVec :: TExpr -> TExpr -> TExpr
 -- constVec size e = build size (\_. e)
-pConstVec = mkPrimCall2 "constVec"
+pConstVec = mkPrimCall2 P_constVec
 
 pDiag :: TExpr -> TExpr -> TExpr -> TExpr
 -- diag rows cols (\i. e) = build row (\i. deltaVec cols i e)
-pDiag = mkPrimCall3 "diag"
+pDiag = mkPrimCall3 P_diag
 
 ---------------------------
 -- "User-defined" functions
 ---------------------------
 pAdd, pEqual, pScale, pDot :: HasCallStack => TExpr -> TExpr -> TExpr
-pAdd   = mkPrimCall2 "ts_add"
-pEqual = mkPrimCall2 "eq"
-pScale = mkPrimCall2 "ts_scale"
-pDot   = mkPrimCall2 "ts_dot"
+pAdd   = mkPrimCall2 P_ts_add
+pEqual = mkPrimCall2 P_eq
+pScale = mkPrimCall2 P_ts_scale
+pDot   = mkPrimCall2 P_ts_dot
 
 pNeg :: HasCallStack => TExpr -> TExpr
-pNeg = mkPrimCall1 "ts_neg"
+pNeg = mkPrimCall1 P_ts_neg
 
 pBuild :: TExpr -> TExpr -> TExpr
-pBuild = mkPrimCall2 "build"
+pBuild = mkPrimCall2 P_build
 
 pIndex :: TExpr -> TExpr -> TExpr
-pIndex = mkPrimCall2 "index"
+pIndex = mkPrimCall2 P_index
 
 pSum :: TExpr -> TExpr
-pSum = mkPrimCall1 "sum"
+pSum = mkPrimCall1 P_sum
 
 pSumBuild :: TExpr -> TExpr -> TExpr
-pSumBuild = mkPrimCall2 "sumbuild"
+pSumBuild = mkPrimCall2 P_sumbuild
 
 pUnzip :: TExpr -> TExpr
-pUnzip = mkPrimCall1 "unzip"
+pUnzip = mkPrimCall1 P_unzip
 
 pShape :: TExpr -> TExpr
-pShape = mkPrimCall1 "shape"
+pShape = mkPrimCall1 P_shape
 
 pSize :: TExpr -> TExpr
-pSize e = mkPrimCall1 "size" e
+pSize e = mkPrimCall1 P_size e
 
 pToFloat :: TExpr -> TExpr
 pToFloat from = userCall "to_float" TypeFloat from
@@ -418,7 +418,7 @@ primFunCallResultTy fun args
   = case primFunCallResultTy_maybe fun (typeof args) of
       Just res_ty -> res_ty
       Nothing -> pprTrace "primCallResultTy: Could not determine result type for"
-                          (vcat [ text fun <+> ppr args
+                          (vcat [ ppr fun <+> ppr args
                                 , ppr (typeof args)])
                  TypeUnknown
 
@@ -442,14 +442,14 @@ baseFunArgTy_maybe derivedFun derivedFunArgTy
 
 primFunCallResultTy_maybe :: PrimFun -> Type -> Maybe Type
 
-primFunCallResultTy_maybe "fold" args
+primFunCallResultTy_maybe P_fold args
   | TypeTuple [f,acc,v] <- args
   , TypeLam (TypeTuple [a1, b1]) a2 <- f
   , TypeTensor 1 b2 <- v
   , b1 `eqType` b2
   = eqTypes a1 [a2, acc]
 
-primFunCallResultTy_maybe "lmFold" args
+primFunCallResultTy_maybe P_lmFold args
   | TypeTuple [ds_zero,f,f',acc,v] <- args
   , TypeLam t1 a1 <- f
   , TypeLam t2 (TypeLM (TypeTuple [s1, t3]) a2) <- f'
@@ -466,7 +466,7 @@ primFunCallResultTy_maybe "lmFold" args
 --- RFold through reverse applying to an lmFold, and we assume that is
 --- done correctly.  We could add more comprehensive type checking
 --- later if we want.
-primFunCallResultTy_maybe "RFold" args
+primFunCallResultTy_maybe P_RFold args
   | TypeTuple [_ty_dv,ty_in,_f,_f',acc,v,_dr] <- args
   = Just (TypeTuple [ ty_in
                     , TypeTuple [ tangentType acc
@@ -477,31 +477,31 @@ primFunCallResultTy_maybe "RFold" args
 --- FFold through forward applying to an lmFold, and we assume that is
 --- done correctly.  We could add more comprehensive type checking
 --- later if we want.
-primFunCallResultTy_maybe "FFold" args
+primFunCallResultTy_maybe P_FFold args
   | TypeTuple [_f,_acc,_v,_df,dacc,_dv] <- args
   = Just dacc
   | otherwise = Nothing
 
-primFunCallResultTy_maybe "lmDummyFold" args
+primFunCallResultTy_maybe P_lmDummyFold args
   = Just args
 
 primFunCallResultTy_maybe fun args
   = case (fun, args) of
-      ("lmZero"   , TypeTuple [s, t])                      -> Just (TypeLM s t)
-      ("lmOne"    , t)                                     -> Just (TypeLM t t)
-      ("lmScale"  , TypeTuple [t, TypeFloat])              -> Just (TypeLM t t)
-      ("lmScaleR" , t)                                     -> Just (TypeLM TypeFloat t)
-      ("lmDot"    , t)                                     -> Just (TypeLM t TypeFloat)
+      (P_lmZero   , TypeTuple [s, t])                      -> Just (TypeLM s t)
+      (P_lmOne    , t)                                     -> Just (TypeLM t t)
+      (P_lmScale  , TypeTuple [t, TypeFloat])              -> Just (TypeLM t t)
+      (P_lmScaleR , t)                                     -> Just (TypeLM TypeFloat t)
+      (P_lmDot    , t)                                     -> Just (TypeLM t TypeFloat)
 
-      ("lmCompose", TypeTuple [TypeLM _ c, TypeLM a _])    -> Just (TypeLM a c)
-      ("lmAdd"    , TypeTuple [TypeLM s1 t1, TypeLM _ _])  -> Just (TypeLM s1 t1)
+      (P_lmCompose, TypeTuple [TypeLM _ c, TypeLM a _])    -> Just (TypeLM a c)
+      (P_lmAdd    , TypeTuple [TypeLM s1 t1, TypeLM _ _])  -> Just (TypeLM s1 t1)
 
-      ("lmApply"  , TypeTuple [TypeLM s1 t, s2]) | tangentType s1 `eqType` s2 -> Just (tangentType t)
+      (P_lmApply  , TypeTuple [TypeLM s1 t, s2]) | tangentType s1 `eqType` s2 -> Just (tangentType t)
            -- Linar map apply:  lmApply :: (s -o t) -> ds -> dt
-      ("lmApplyR" , TypeTuple [t1, TypeLM s t2]) | t1 `eqType` tangentType t2 -> Just (tangentType s)
+      (P_lmApplyR , TypeTuple [t1, TypeLM s t2]) | t1 `eqType` tangentType t2 -> Just (tangentType s)
            -- Reverse apply:  lmApplyR :: dt -> (s -o t) -> ds
 
-      ("lmApplyT" , TypeTuple [TypeTuple [_, TypeLM s1 t], s2])
+      (P_lmApplyT , TypeTuple [TypeTuple [_, TypeLM s1 t], s2])
                                 | tangentType s1 `eqType` s2 -> Just (tangentType t)
            -- Tupled version:  lmApplyT :: (r, s -o t) -> ds -> dt
 
@@ -513,22 +513,22 @@ primFunCallResultTy_maybe fun args
       --
       -- but we don't have polymorphism in ksc.)  See also
       -- Prim.lmVCat.
-      ("lmVCat"   , TypeTuple tys) | Just (ss,ts) <- unzipLMTypes tys
+      (P_lmVCat   , TypeTuple tys) | Just (ss,ts) <- unzipLMTypes tys
                                      , (s1:ss1) <- ss
                                      , all (== s1) ss1     -> Just (TypeLM s1 (TypeTuple ts))
-      ("lmVCatV"  , TypeTensor d (TypeLM s t))             -> Just (TypeLM s (TypeTensor d t))
-      ("lmHCat"   , TypeTuple tys) | Just (ss,ts) <- unzipLMTypes tys
+      (P_lmVCatV  , TypeTensor d (TypeLM s t))             -> Just (TypeLM s (TypeTensor d t))
+      (P_lmHCat   , TypeTuple tys) | Just (ss,ts) <- unzipLMTypes tys
                                      , (t1:ts1) <- ts
                                      , all (== t1) ts1     -> Just (TypeLM (TypeTuple ss) t1)
-      ("lmHCatV"  , TypeTensor d (TypeLM t s))             -> Just (TypeLM (TypeTensor d t) s)
+      (P_lmHCatV  , TypeTensor d (TypeLM t s))             -> Just (TypeLM (TypeTensor d t) s)
 
       -- ($inline f args) forces f to be inlined here
-      ("$inline"  , t)                                     -> Just t
+      (P_inline   , t)                                     -> Just t
 
       -- ($copydown e) requests a copydown of the result of e, in order to reduce memory
       -- usage as far as possible. (In particular, this should reclaim any memory allocated
       -- for temporary variables during the evaluation of e.)
-      ("$copydown", t)                                     -> Just t
+      (P_copydown, t)                                     -> Just t
 
       -- ($check f rev$f s s' ds dt) verifies the derivatives rev$f at s in directions ds,dt.
       -- That is, ds and dt should be near-zero elements of the domain and range tangent spaces
@@ -536,7 +536,7 @@ primFunCallResultTy_maybe fun args
       --
       -- NB s and s' should be equal, except if s' is not a tuple, in
       -- which case s should be (tuple s')
-      ("$check"   , TypeTuple
+      (P_check    , TypeTuple
                       [ TypeLam s t
                       , TypeLam s_dt ds, s', s'0, ds', dt])
                       | s `eqType` case s' of TypeTuple [s'1] -> s'1
@@ -548,69 +548,69 @@ primFunCallResultTy_maybe fun args
                        -> Just TypeFloat
 
       -- ($trace e) emits its argument's value to stdout and returns it
-      ("$trace"   , t)                                       -> Just t
+      (P_trace    , t)                                       -> Just t
 
-      ("constVec" , TypeTuple [sizeType, t])                 -> tensorTypeFromIndexType_maybe sizeType t
-      ("deltaVec" , TypeTuple [sizeType, indexType, t])
+      (P_constVec , TypeTuple [sizeType, t])                 -> tensorTypeFromIndexType_maybe sizeType t
+      (P_deltaVec , TypeTuple [sizeType, indexType, t])
         | sizeType `eqType` indexType
         -> tensorTypeFromIndexType_maybe indexType t
-      ("diag"     , TypeTuple [TypeInteger,
+      (P_diag     , TypeTuple [TypeInteger,
                                 TypeInteger,
                                 TypeLam TypeInteger t])      -> Just (TypeTensor 1 (TypeTensor 1 t))
 
-      ("Vec_init" , TypeTuple vals)
+      (P_Vec_init , TypeTuple vals)
         | (s1:ss) <- vals
         , all (== s1) ss                                   -> Just (TypeTensor 1 s1)
-      ("Vec_init" , t)                                     -> Just (TypeTensor 1 t)
-      ("build"    , TypeTuple
+      (P_Vec_init , t)                                     -> Just (TypeTensor 1 t)
+      (P_build    , TypeTuple
                      [sizeType, TypeLam indexType t])
         | sizeType `eqType` indexType
         -> tensorTypeFromIndexType_maybe indexType t
 
       -- (print a b c) prints its arguments to stdout with no separators
-      ("print"    , _)                                     -> Just TypeInteger
-      ("sumbuild" , TypeTuple
+      (P_print    , _)                                     -> Just TypeInteger
+      (P_sumbuild , TypeTuple
                      [sizeType, TypeLam indexType t])
         | sizeType `eqType` indexType
         , isTensorIndexType indexType
         -> Just t
-      ("buildFromSparse", TypeTuple
+      (P_buildFromSparse, TypeTuple
                          [resultShapeType@TypeTensor{}, loopSizeType, TypeLam loopIndexType t])
         | loopSizeType `eqType` loopIndexType
         , isTensorIndexType loopIndexType
         -> buildFromSparseResultTy_maybe resultShapeType t
-      ("buildFromSparseTupled", TypeTuple
+      (P_buildFromSparseTupled, TypeTuple
                          [resultShapeType@TypeTuple{}, loopSizeType, TypeLam loopIndexType t])
         | loopSizeType `eqType` loopIndexType
         , isTensorIndexType loopIndexType
         , TypeTuple shapes <- resultShapeType
         , TypeTuple lamty <- t
         -> fmap TypeTuple (zipWithM buildFromSparseResultTy_maybe shapes lamty)
-      ("index"    , TypeTuple [indexType, TypeTensor d t])
+      (P_index    , TypeTuple [indexType, TypeTensor d t])
         | indexType `eqType` tensorIndexType d
         -> Just t
-      ("shape"    , t)                                     -> Just (shapeType t)
-      ("size"     , TypeTensor d _)                        -> Just (tensorIndexType d)
-      ("sum"      , TypeTensor _ t)                        -> Just t
+      (P_shape    , t)                                     -> Just (shapeType t)
+      (P_size     , TypeTensor d _)                        -> Just (tensorIndexType d)
+      (P_sum      , TypeTensor _ t)                        -> Just t
 
-      ("unzip"    , TypeTensor d (TypeTuple ts))           -> Just (TypeTuple (map (TypeTensor d) ts))
+      (P_unzip    , TypeTensor d (TypeTuple ts))           -> Just (TypeTuple (map (TypeTensor d) ts))
 
-      ("ts_scale" , TypeTuple [TypeFloat,   t]           ) -> Just t
-      ("ts_dot"   , TypeTuple [t1, t2])
+      (P_ts_scale , TypeTuple [TypeFloat,   t]           ) -> Just t
+      (P_ts_dot   , TypeTuple [t1, t2])
         | t1 `eqType` t2                                   -> Just TypeFloat
-      ("ts_add"   , TypeTuple [t, dt]                    ) -> if dt == tangentType t
+      (P_ts_add   , TypeTuple [t, dt]                    ) -> if dt == tangentType t
                                                                 then Just t
                                                                 else Nothing
-      ("ts_neg"   , t                                    ) -> Just t
+      (P_ts_neg   , t                                    ) -> Just t
       -- For eq and ne we check that the two arguments have the same type
-      ("eq"       , TypeTuple [t1, t2]                   )
+      (P_eq       , TypeTuple [t1, t2]                   )
         | t1 `eqType` t2 -> Just TypeBool
         | otherwise      -> Nothing
-      ("ne"       , TypeTuple [t1, t2]                   )
+      (P_ne       , TypeTuple [t1, t2]                   )
         | t1 `eqType` t2 -> Just TypeBool
         | otherwise      -> Nothing
 
-      ("delta"    , TypeTuple [t1, t2, tret]             )
+      (P_delta    , TypeTuple [t1, t2, tret]             )
         | t1 `eqType` t2
         , isTensorIndexType t1
         -> Just tret
@@ -623,32 +623,3 @@ buildFromSparseResultTy_maybe (TypeTensor d elemshapety) (TypeTuple [indexty, el
   , elemshapety `eqType` shapeType elemty
   = Just (TypeTensor d elemty)
 buildFromSparseResultTy_maybe _ _ = Nothing
-
-isPrimFun :: String -> Bool
-isPrimFun f = f `elem` [ "$inline"  -- ($inline f args...)        Force inline f at args
-                       , "$copydown"-- ($copydown e)              Requests copydown of e
-                       , "$check"   -- ($check f rev$f x dx df)   Derivative check df' * D$f * dx
-                       , "$trace"   -- ($trace f args)            Print and return (f args)
-                       , "print"    -- (print "msg" 3)            Print "msg3"
-                       , "Vec_init" -- (Vec_init v1 ... vn)       Vector literal
-                       , "build"    -- (build N f)                Build vector [(f i) for i = 1..n]
-                       , "sumbuild" -- (sumbuild N f)             (sum (build N f))
-                       , "buildFromSparse" -- generalization of build
-                       , "buildFromSparseTupled" -- builds multiple tensors with a single loop
-                       , "fold"     -- (fold f z v)               (Left) fold over v
-                       , "index"
-                       , "shape"
-                       , "size"
-                       , "sum"      -- (sum t)                    Sum all elements in tensor
-                       , "unzip"    -- Takes a vector of tuples to a tuple of vectors
-                       , "ts_neg"
-                       , "ts_add"
-                       , "ts_scale"
-                       , "ts_dot"
-                       , "eq", "ne"
-                       , "delta", "deltaVec", "diag", "constVec"
-                       , "lmApply", "lmApplyR", "lmApplyT", "lmVCat", "lmHCat"
-                       , "lmVCatV", "lmHCatV"
-                       , "lmCompose", "lmAdd", "lmScale", "lmScaleR", "lmDot"
-                       , "lmZero", "lmOne"
-                       ]

--- a/src/ksc/Shapes.hs
+++ b/src/ksc/Shapes.hs
@@ -90,19 +90,19 @@ shapeCall (TFun ty f) e
 shapeCall tf e = pShape (Call tf e)  -- Fall back to calling the original function and evaluating the shape of the returned object
 
 shapeCallPrim :: HasCallStack => PrimFun -> TExpr -> Maybe TExpr
-shapeCallPrim "index" (Tuple [i, n]) = Just $ pIndex i (shapeE n)
-shapeCallPrim "build" (Tuple [sz, Lam i e2]) = Just $ pBuild sz (Lam i (shapeE e2))
-shapeCallPrim "sumbuild" (Tuple [sz, Lam i e2]) = Just $ mkLet i (mkZero sz) (shapeE e2)
-shapeCallPrim "sum" v = Just $ pIndex (mkZero (pSize v)) (shapeE v)
-shapeCallPrim "constVec" (Tuple [sz, v]) = Just $ pConstVec sz (shapeE v)
-shapeCallPrim "deltaVec" (Tuple [sz, _i, v]) = Just $ pConstVec sz (shapeE v)
-shapeCallPrim "ts_add" (Tuple [lhs, _]) = Just $ shapeE lhs
-shapeCallPrim "ts_scale" (Tuple [_, v]) = Just $ shapeE v
-shapeCallPrim "ts_neg" v = Just $ shapeE v
-shapeCallPrim "delta" (Tuple [_, _, v]) = Just $ shapeE v
-shapeCallPrim "unzip" v = Just $ pUnzip (shapeE v)
-shapeCallPrim "$trace" v = Just $ shapeE v
-shapeCallPrim "$copydown" v = Just $ shapeE v
+shapeCallPrim P_index (Tuple [i, n]) = Just $ pIndex i (shapeE n)
+shapeCallPrim P_build (Tuple [sz, Lam i e2]) = Just $ pBuild sz (Lam i (shapeE e2))
+shapeCallPrim P_sumbuild (Tuple [sz, Lam i e2]) = Just $ mkLet i (mkZero sz) (shapeE e2)
+shapeCallPrim P_sum v = Just $ pIndex (mkZero (pSize v)) (shapeE v)
+shapeCallPrim P_constVec (Tuple [sz, v]) = Just $ pConstVec sz (shapeE v)
+shapeCallPrim P_deltaVec (Tuple [sz, _i, v]) = Just $ pConstVec sz (shapeE v)
+shapeCallPrim P_ts_add (Tuple [lhs, _]) = Just $ shapeE lhs
+shapeCallPrim P_ts_scale (Tuple [_, v]) = Just $ shapeE v
+shapeCallPrim P_ts_neg v = Just $ shapeE v
+shapeCallPrim P_delta (Tuple [_, _, v]) = Just $ shapeE v
+shapeCallPrim P_unzip v = Just $ pUnzip (shapeE v)
+shapeCallPrim P_trace v = Just $ shapeE v
+shapeCallPrim P_copydown v = Just $ shapeE v
 shapeCallPrim _ _ = Nothing
 
 -- Given a Type t, determines whether (shapeType t) is a unit type;


### PR DESCRIPTION
Prior to this PR our set of PrimFuns is defined implicitly by various parts of the code that happen to conjure up names for them or expect to see certain names for them. In theory `Prim.isPrimFun` was supposed to be the definitive source of truth about what is a PrimFun but in practice there were PrimFuns that weren't mentioned there.

This PR presents an alternative: use an ADT to specify what exactly the PrimFuns are. This way every part of the codebase will be in agreement. If we add a PrimFun we will be able to clearly see so. Likewise if we remove (hooray!) a PrimFun.

It also gives us two future possibilities for `SelFun`:

1. Fold it into `PrimFun`
2. Delete it completely. Users can use tuple pattern matching instead.

@awf has wanted to delete the size argument to `SelFun` for quite some time. If we don't choose option 2 then we can do that too.