### PR TITLE
MSVC compatibility adjustments

### DIFF
--- a/src/runtime/knossos-pybind.h
+++ b/src/runtime/knossos-pybind.h
@@ -92,20 +92,21 @@ static void check_valid_pointer(std::uintptr_t v)
 template<typename T>
 void declare_tensor_2(py::module &m, char const* name) {
   // Wrap ks_tensor<Dim, T> to point to supplied python memory
+  static constexpr size_t Dim = 2;
   py::class_<ks::tensor<2, T>>(m, name, py::buffer_protocol(), py::module_local())
     .def(py::init([](std::uintptr_t v, size_t m, size_t n) {
         check_valid_pointer(v);
-        ks::tensor_dimension<2>::index_type size {m,n};
-        return ks::tensor<2, T>(size, reinterpret_cast<T*>(v)); // Reference to caller's data
+        ks::tensor_dimension<Dim>::index_type size {int(m),int(n)};
+        return ks::tensor<Dim, T>(size, reinterpret_cast<T*>(v)); // Reference to caller's data
     }))
     // And describe buffer shape to Python
     // Returned tensors will be living on g_alloc, so will become invalid after allocator_reset()
-    .def_buffer([](ks::tensor<2, T> &t) -> py::buffer_info {
+    .def_buffer([](ks::tensor<Dim, T> &t) -> py::buffer_info {
         return py::buffer_info(
             t.data(),                               /* Pointer to buffer */
             sizeof(T),                              /* Size of one scalar */
             py::format_descriptor<T>::format(),     /* Python struct-style format descriptor */
-            2,                                      /* Number of dimensions */
+            Dim,                                      /* Number of dimensions */
             { ks::get_dimension<0>(t.size()), ks::get_dimension<1>(t.size()) },         /* Buffer dimensions */
             { sizeof(T) * ks::get_dimension<1>(t.size()),             /* Strides (in bytes) for each index */
                sizeof(T) }
@@ -117,11 +118,11 @@ void declare_tensor_2(py::module &m, char const* name) {
 template<typename T>
 void declare_tensor_1(py::module &m, char const* name) {
   // Wrap ks_tensor<1, T> to point to supplied python memory
-  constexpr int Dim = 1;
+  static constexpr size_t Dim = 1;
   py::class_<ks::tensor<Dim, T>>(m, name, py::buffer_protocol(), py::module_local())
     .def(py::init([](std::uintptr_t v, size_t n) {
         check_valid_pointer(v);
-        ks::tensor_dimension<Dim>::index_type size {n};
+        ks::tensor_dimension<Dim>::index_type size {int(n)};
         return ks::tensor<Dim, T>(size, reinterpret_cast<T*>(v)); // Reference to caller's data
     }))
     // And describe buffer shape to Python


### PR DESCRIPTION
Make Dim constexpr static, seems to be required for msvc. It's not clear to me if GCC or MSVC are correct, but adding static is a pretty common:

https://stackoverflow.com/questions/55136414/constexpr-variable-captured-inside-lambda-loses-its-constexpr-ness

Make declare_tensor_2 consistent with declare_tensor_1
Cast indices to int, msvc is more bothered by narrowing conversions

This is a step towards #598