### PR TITLE
Use explict path to chocolatey-installed tools

### DIFF
--- a/test/builds/build_and_test.yml
+++ b/test/builds/build_and_test.yml
@@ -114,7 +114,7 @@ jobs:
   - script: call test\builds\install_windows.bat || sleep 30 && call test\builds\install_windows.bat || sleep 30 && call test\builds\install_windows.bat
     displayName: 'Install dependencies [userInstall]'
 
-  - script: refreshenv && cabal v2-install --installdir=build/bin --overwrite-policy=always --install-method=copy
+  - script: refreshenv && C:/ProgramData/chocolatey/lib/cabal/tools/cabal-3.0.0.0/cabal v2-install --with-ghc=C:/ProgramData/chocolatey/lib/ghc/tools/ghc-8.4.4/bin/ghc --installdir=build/bin --overwrite-policy=always --install-method=copy
     displayName: 'GHC compile src/ksc/Main.hs [userTest]'
 
   - script: build\bin\ksc --test-windows --fs-test obj\test\out.ks

--- a/test/builds/install_windows.bat
+++ b/test/builds/install_windows.bat
@@ -7,5 +7,5 @@ echo ----- install ghc -----
 choco install cabal --allow-downgrade --version 3.0.0.0 -y || exit /b
 choco install ghc --allow-downgrade --version 8.4.4 -y || exit /b
 echo ----- cabal install -----
-refreshenv && cabal new-update || exit /b
+refreshenv && C:/ProgramData/chocolatey/lib/cabal/tools/cabal-3.0.0.0/cabal new-update || exit /b
 echo ----- installation done -----


### PR DESCRIPTION
I'm finding it rather hard to arrange for the version of ghc and cabal
we install to be the foremost in the PATH. The versions installed by
default on the ADO build host seem to dominate. Being explicit solves
the problem, and is probably good practice anyway.
