### PR TITLE
On Windows, skip test_conv_2d_no_bias due to Jax dependency

### DIFF
--- a/test/python/test_tracing_nn.py
+++ b/test/python/test_tracing_nn.py
@@ -4,8 +4,10 @@ import numpy as np
 import ksc
 from ksc.tracing.functions import math, nn
 from ksc.shape import Shape, TensorShape, ScalarShape
+import sys
 
-
+# https://github.com/google/jax/issues/5795
+@pytest.mark.skipif(sys.platform == 'win32', reason="Jaxlib builds not currently supplied for Windows")
 @pytest.mark.parametrize(
     "kernel_size,strides,padding,expected_shape", [
         ((3, 3), (1, 1), "SAME", (1, 64, 56, 56)),


### PR DESCRIPTION
https://github.com/microsoft/knossos-ksc/blob/34f498a49895bce0dec234848ad6c17273a38df9/src/python/ksc/backends/jax.py#L34-L43

https://github.com/google/jax/issues/5795

It looks like we could build Jax ourselves on Windows if needed.