### PR TITLE
Store initializer separately from acc_x parameter in Fold

### DIFF
--- a/mlir/include/Parser/AST.h
+++ b/mlir/include/Parser/AST.h
@@ -622,13 +622,17 @@ private:
 /// Then return (acc).
 struct Fold : public Expr {
   using Ptr = std::unique_ptr<Fold>;
-  Fold(Type type, Expr::Ptr body, Expr::Ptr acc, Expr::Ptr vector)
-      : Expr(type, Kind::Fold), body(std::move(body)),
-      acc(std::move(acc)), vector(std::move(vector)) {}
+  Fold(Type type, Variable::Ptr lambdaParameter, Expr::Ptr body, Expr::Ptr init, Expr::Ptr vector)
+      : Expr(type, Kind::Fold),
+      lambdaParameter(std::move(lambdaParameter)),
+      body(std::move(body)),
+      init(std::move(init)),
+      vector(std::move(vector)) {}
 
-  Expr *getVector() const { return vector.get(); }
-  Expr *getAcc() const { return acc.get(); }
+  Variable *getLambdaParameter() const { return lambdaParameter.get(); }
   Expr *getBody() const { return body.get(); }
+  Expr *getInit() const { return init.get(); }
+  Expr *getVector() const { return vector.get(); }
 
   std::ostream& dump(std::ostream& s, size_t tab = 0) const override;
 
@@ -636,8 +640,9 @@ struct Fold : public Expr {
   static bool classof(const Expr *c) { return c->kind == Kind::Fold; }
 
 private:
+  Variable::Ptr lambdaParameter;
   Expr::Ptr body;
-  Expr::Ptr acc;
+  Expr::Ptr init;
   Expr::Ptr vector;
 };
 

--- a/mlir/ksc-mlir/test.cpp
+++ b/mlir/ksc-mlir/test.cpp
@@ -493,22 +493,17 @@ void test_parser_fold() {
   assert(vec->getType() == Type::Vector);
   assert(vec->getType().getSubType() == Type::Float);
   assert(vec->getName() == "v");
-  // Accumulator
-  Variable* acc = llvm::dyn_cast<Variable>(fold->getAcc());
-  assert(acc);
-  assert(acc->getType() == Type::Tuple);
-  assert(acc->getType().getSubType(0) == Type::Float);
-  assert(acc->getType().getSubType(1) == Type::Float);
-  Tuple* init = llvm::dyn_cast<Tuple>(acc->getInit());
+  // Lambda parameter
+  Variable* acc_x = fold->getLambdaParameter();
+  assert(acc_x);
+  assert(acc_x->getType() == Type::Tuple);
+  assert(acc_x->getType().getSubType(0) == Type::Float);
+  assert(acc_x->getType().getSubType(1) == Type::Float);
+  // Init
+  Literal* init = llvm::dyn_cast<Literal>(fold->getInit());
   assert(init);
-  Literal* init0 = llvm::dyn_cast<Literal>(init->getElement(0));
-  assert(init0);
-  assert(init0->getType() == Type::Float);
-  assert(init0->getValue() == "1.0");
-  Literal* init1 = llvm::dyn_cast<Literal>(init->getElement(1));
-  assert(init1);
-  assert(init1->getType() == Type::Float);
-  assert(init1->getValue() == "0.0");
+  assert(init->getType() == Type::Float);
+  assert(init->getValue() == "1.0");
   // Lambda variables
   Let* let = llvm::dyn_cast<Let>(fold->getBody());
   assert(let);

--- a/mlir/lib/Parser/AST.cpp
+++ b/mlir/lib/Parser/AST.cpp
@@ -186,10 +186,12 @@ std::ostream& Get::dump(std::ostream& s, size_t tab) const {
 std::ostream& Fold::dump(std::ostream& s, size_t tab) const {
   s << string(tab, ' ') << "Fold:" << endl;
   Expr::dump(s, tab + 2);
+  s << string(tab + 2, ' ') << "Accumulator:" << endl;
+  lambdaParameter->dump(s, tab + 4);
   s << string(tab + 2, ' ') << "Lambda:" << endl;
   body->dump(s, tab + 4);
-  s << string(tab + 2, ' ') << "Accumulator:" << endl;
-  acc->dump(s, tab + 4);
+  s << string(tab + 2, ' ') << "Init: " << endl;
+  init->dump(s, tab + 4);
   s << string(tab + 2, ' ') << "Vector:" << endl;
   vector->dump(s, tab + 4);
   return s;

--- a/mlir/test/Ksc/fold.ks
+++ b/mlir/test/Ksc/fold.ks
@@ -13,7 +13,6 @@
            v
      )
 ; MLIR:   %c1{{.*}} = constant 1 : i64
-; MLIR:   %c0{{.*}} = constant 0 : i64
 ; MLIR:   %[[DI:[0-9]+]] = dim %arg0, %c0 : memref<?xi64>
 ; MLIR:   %[[dim:[0-9]+]] = index_cast %[[DI]] : index to i64
 ; MLIR:   %c0{{.*}} = constant 0 : i64


### PR DESCRIPTION
This is the first of a series of PRs aiming at support for tuple-unpacking lets in ksc-mlir.

Currently `AST::Variable` has an optional initializer. I'd like to split up the usages, so that `Variable` does not have an initializer, and a new struct `AST::Binding` represents a variable with an initializer. But this is complicated by the fact that the implementations of `build` and `fold` currently use the "init" field of their lambda parameter, even though the initialization of this parameter is not explicit in our IR.

This PR changes the `fold` implementation so that the initial value of the accumulator is stored separately.

Note that, in the previous code, in order to give the lambda parameter an initializer of the correct type, we had to conjure up `(tuple init 0)` rather than just storing `init`. The new code avoids the need for creating the zero: this means that the MLIR output changes slightly, by avoiding the declaration of this redundant constant.