### PR TITLE
Remove unnecessary initializer for induction variable in AST

### DIFF
--- a/mlir/include/Parser/AST.h
+++ b/mlir/include/Parser/AST.h
@@ -516,14 +516,14 @@ private:
 /// Loops over range N using lambda L
 struct Build : public Expr {
   using Ptr = std::unique_ptr<Build>;
-  Build(Expr::Ptr range, Expr::Ptr var, Expr::Ptr expr)
+  Build(Expr::Ptr range, Variable::Ptr var, Expr::Ptr expr)
       : Expr(Type::makeVector(expr->getType()), Kind::Build), 
         range(std::move(range)),
         var(std::move(var)), 
         expr(std::move(expr)) {}
 
   Expr *getRange() const { return range.get(); }
-  Expr *getVariable() const { return var.get(); }
+  Variable *getVariable() const { return var.get(); }
   Expr *getExpr() const { return expr.get(); }
 
   std::ostream& dump(std::ostream& s, size_t tab = 0) const override;
@@ -533,7 +533,7 @@ struct Build : public Expr {
 
 private:
   Expr::Ptr range;
-  Expr::Ptr var;
+  Variable::Ptr var;
   Expr::Ptr expr;
 };
 

--- a/mlir/lib/Parser/MLIR.cpp
+++ b/mlir/lib/Parser/MLIR.cpp
@@ -497,8 +497,8 @@ Values Generator::buildBuild(const AST::Build* b) {
   builder.setInsertionPointToEnd(bodyBlock);
   auto bodyIv = bodyBlock->getArgument(0);
   // Declare the local induction variable before using in body
-  auto var = llvm::dyn_cast<AST::Variable>(b->getVariable());
-  declareVariable(var);
+  auto var = b->getVariable();
+  declareVariable(var, {zero});
   variables[var->getName()] = {bodyIv};
   // Build body and store result (no vector of tuples supported)
   auto expr = Single(buildNode(b->getExpr()));

--- a/mlir/lib/Parser/Parser.cpp
+++ b/mlir/lib/Parser/Parser.cpp
@@ -65,21 +65,6 @@ static llvm::StringRef unquote(llvm::StringRef original) {
   return original.substr(start, len);
 }
 
-static Literal::Ptr getZero(Type type) {
-  switch (type.getValidType()) {
-  case Type::Integer:
-    return make_unique<Literal>("0", Type::Integer);
-  case Type::Float:
-    return make_unique<Literal>("0.0", Type::Float);
-  case Type::Bool:
-    return make_unique<Literal>("false", Type::Bool);
-  case Type::String:
-    return make_unique<Literal>("", Type::String);
-  default:
-    ASSERT(0) << "Invalid zero type [" << type << "]";
-  }
-}
-
 //
 Declaration *Parser::addExtraDecl(StructuredName const& name, std::vector<Type> argTypes, Type returnType) {
   Signature sig {name, argTypes};
@@ -569,7 +554,6 @@ Build::Ptr Parser::parseBuild(const Token *tok) {
   auto var = parseVariable(bond);
   PARSE_ASSERT(var->kind == Expr::Kind::Variable);
   PARSE_ASSERT(var->getType() == AST::Type::Integer);
-  llvm::dyn_cast<Variable>(var.get())->setInit(getZero(Type(Type::Integer)));
   auto body = parseToken(expr);
   return make_unique<Build>(move(range), move(var), move(body));
 }

--- a/mlir/test/Ksc/build.ks
+++ b/mlir/test/Ksc/build.ks
@@ -75,7 +75,6 @@
 ; MLIR:   %[[cond:[0-9]+]] = cmpi "slt", %[[ivHead]], %[[ten]] : i64
 ; MLIR:   cond_br %[[cond]], ^[[bodyBB]](%[[ivHead]] : i64), ^[[tailBB:bb[0-9]+]]
 ; MLIR: ^[[bodyBB]](%[[ivBody:[0-9]+]]: i64):	// pred: ^[[headBB]]
-; MLIR:   %[[zero2:[ci_0-9]+]] = constant 0 : i64
 ; MLIR:   %[[expr:[0-9]+]] = addi %[[ivBody]], %c7_i64 : i64
 ; MLIR:   %[[idxW:[0-9]+]] = index_cast %[[ivBody]] : i64 to index
 ; MLIR:   store %[[expr]], %[[vec]][%[[idxW]]] : memref<?xi64>


### PR DESCRIPTION
Similar to #672, this PR removes the phony initializer stored in the AST for a `build`.