### PR TITLE
Represent lambdas in the ksc-mlir AST

### DIFF
--- a/mlir/include/Parser/Parser.h
+++ b/mlir/include/Parser/Parser.h
@@ -91,6 +91,7 @@ class Parser {
   Definition::Ptr parseDef(const Token *tok);
   Rule::Ptr parseRule(const Token *tok);
   Condition::Ptr parseCond(const Token *tok);
+  Lambda::Ptr parseLambda(const Token *tok);
   Build::Ptr parseBuild(const Token *tok);
   Tuple::Ptr parseTuple(const Token *tok);
   Get::Ptr parseGet(const Token *tok);

--- a/mlir/lib/Parser/AST.cpp
+++ b/mlir/lib/Parser/AST.cpp
@@ -154,15 +154,22 @@ std::ostream& Condition::dump(std::ostream& s, size_t tab) const {
   return s;
 }
 
+std::ostream& Lambda::dump(std::ostream& s, size_t tab) const {
+  s << string(tab, ' ') << "Lambda:" << endl;
+  s << string(tab + 2, ' ') << "Parameter:" << endl;
+  var->dump(s, tab + 4);
+  s << string(tab + 2, ' ') << "Body: " << endl;
+  body->dump(s, tab + 4);
+  return s;
+}
+
 std::ostream& Build::dump(std::ostream& s, size_t tab) const {
   s << string(tab, ' ') << "Build:" << endl;
   Expr::dump(s, tab + 2);
   s << string(tab + 2, ' ') << "Range:" << endl;
   range->dump(s, tab + 4);
-  s << string(tab + 2, ' ') << "Induction:" << endl;
-  var->dump(s, tab + 4);
-  s << string(tab + 2, ' ') << "Body:" << endl;
-  return expr->dump(s, tab + 4);
+  lam->dump(s, tab + 2);
+  return s;
 }
 
 std::ostream& Tuple::dump(std::ostream& s, size_t tab) const {
@@ -186,10 +193,7 @@ std::ostream& Get::dump(std::ostream& s, size_t tab) const {
 std::ostream& Fold::dump(std::ostream& s, size_t tab) const {
   s << string(tab, ' ') << "Fold:" << endl;
   Expr::dump(s, tab + 2);
-  s << string(tab + 2, ' ') << "Accumulator:" << endl;
-  lambdaParameter->dump(s, tab + 4);
-  s << string(tab + 2, ' ') << "Lambda:" << endl;
-  body->dump(s, tab + 4);
+  lam->dump(s, tab + 2);
   s << string(tab + 2, ' ') << "Init: " << endl;
   init->dump(s, tab + 4);
   s << string(tab + 2, ' ') << "Vector:" << endl;


### PR DESCRIPTION
This PR is a pure refactoring, avoiding some duplication between `build` and `fold` by creating an explicit AST representation for lambdas. This relies on PRs #672 and #674 (because previously `build` and `fold` had separate logic for constructing a value to use as the initialization for the lambda parameter).

For the moment I've avoiding making `Lambda` an `Expr` (not needed because lambdas can only occur in these two specific contexts), but this could be done later. We'd then need a corresponding `Type`.