### PR TITLE
Distinguish variables from bindings in ksc-mlir AST

### DIFF
--- a/mlir/include/Parser/AST.h
+++ b/mlir/include/Parser/AST.h
@@ -311,27 +311,14 @@ private:
 /// Named variables, ex:
 ///   str in (let (str "Hello") (print str))
 ///     x in (def a (x : Float) x)
-///
-/// Variables have a contextual name (scope::name) and an optional
-/// initialisation expression.
 struct Variable : public Expr {
   using Ptr = std::unique_ptr<Variable>;
   /// Definition: (x 10) in ( let (x 10) (expr) )
   /// Declaration: (x : Integer) in ( def name Type (x : Integer) (expr) )
   /// We need to bind first, then assign to allow nested lets
   Variable(llvm::StringRef name, Type type=Type(Type::None))
-      : Expr(type, Kind::Variable), name(name), init(nullptr) {}
+      : Expr(type, Kind::Variable), name(name) {}
 
-  void setInit(Expr::Ptr &&expr) {
-    assert(!init);
-    init = std::move(expr);
-    if (!type.isNone())
-      assert(type == init->getType());
-    else
-      type = init->getType();
-  }
-  /// No value == nullptr
-  Expr *getInit() const { return init.get(); }
   std::string const& getName() const { return name; }
 
   std::ostream& dump(std::ostream& s, size_t tab = 0) const override;
@@ -341,6 +328,23 @@ struct Variable : public Expr {
 
 private:
   std::string name;
+};
+
+/// A variable with an initialisation expression
+struct Binding {
+  Binding(Variable::Ptr var, Expr::Ptr init)
+    : var(std::move(var)), init(std::move(init)) {
+    assert(this->var != nullptr);
+    assert(this->init != nullptr);
+  }
+
+  Variable *getVariable() const { return var.get(); }
+  Expr *getInit() const { return init.get(); }
+
+  std::ostream& dump(std::ostream& s, size_t tab = 0) const;
+
+private:
+  Variable::Ptr var;
   Expr::Ptr init;
 };
 
@@ -349,20 +353,17 @@ private:
 /// Defines a variable.
 struct Let : public Expr {
   using Ptr = std::unique_ptr<Let>;
-  Let(std::vector<Expr::Ptr> &&vars)
-      : Expr(Kind::Let), vars(std::move(vars)),
-      expr(nullptr) {}
-  Let(std::vector<Expr::Ptr> &&vars, Expr::Ptr expr)
-      : Expr(expr->getType(), Kind::Let), vars(std::move(vars)),
+  Let(std::vector<Binding> && bindings, Expr::Ptr expr)
+      : Expr(expr->getType(), Kind::Let), bindings(std::move(bindings)),
         expr(std::move(expr)) {}
 
-  llvm::ArrayRef<Expr::Ptr> getVariables() const { return vars; }
-  Expr *getVariable(size_t idx) const {
-    assert(idx < vars.size() && "Offset error");
-    return vars[idx].get();
+  llvm::ArrayRef<Binding> getBindings() const { return bindings; }
+  Binding const& getBinding(size_t idx) const {
+    assert(idx < bindings.size() && "Offset error");
+    return bindings[idx];
   }
   Expr *getExpr() const { return expr.get(); }
-  size_t size() const { return vars.size(); }
+  size_t size() const { return bindings.size(); }
 
   std::ostream& dump(std::ostream& s, size_t tab = 0) const override;
 
@@ -370,7 +371,7 @@ struct Let : public Expr {
   static bool classof(const Expr *c) { return c->kind == Kind::Let; }
 
 private:
-  std::vector<Expr::Ptr> vars;  // TODO: make a vector of vars
+  std::vector<Binding> bindings;
   Expr::Ptr expr;
 };
 

--- a/mlir/include/Parser/MLIR.h
+++ b/mlir/include/Parser/MLIR.h
@@ -66,7 +66,6 @@ class Generator {
 
   // Variables
   void declareVariable(std::string const& name, Values vals);
-  void declareVariable(const AST::Variable* var, Values vals = {});
 
   // Argument serialisation (tuples)
   void serialiseArgs(const AST::Definition *def, mlir::Block &entry);

--- a/mlir/include/Parser/Parser.h
+++ b/mlir/include/Parser/Parser.h
@@ -85,7 +85,8 @@ class Parser {
   Block::Ptr parseBlock(const Token *tok);
   Expr::Ptr parseValue(const Token *tok);  // Literal or Variable use
   Call::Ptr parseCall(const Token *tok);
-  Variable::Ptr parseVariable(const Token *tok);
+  Variable::Ptr parseVariableWithType(const Token *tok);
+  Binding parseBinding(const Token *tok);
   Let::Ptr parseLet(const Token *tok);
   Declaration::Ptr parseDecl(const Token *tok);
   Definition::Ptr parseDef(const Token *tok);

--- a/mlir/ksc-mlir/test.cpp
+++ b/mlir/ksc-mlir/test.cpp
@@ -116,7 +116,7 @@ void test_parser_let() {
   assert(def);
   // Let has two parts: variable definitions and expression
   assert(def->getType() == Type::Integer);
-  Variable* x = llvm::dyn_cast<Variable>(def->getVariable(0));
+  Variable* x = def->getBinding(0).getVariable();
   assert(x->getType() == Type::Integer);
   Call* expr = llvm::dyn_cast<Call>(def->getExpr());
   assert(expr);
@@ -508,16 +508,18 @@ void test_parser_fold() {
   Let* let = llvm::dyn_cast<Let>(fold->getBody());
   assert(let);
   assert(let->getType() == Type::Float);
-  Variable* letAcc = llvm::dyn_cast<Variable>(let->getVariable(0));
+  Binding const& letAccBinding = let->getBinding(0);
+  Variable* letAcc = letAccBinding.getVariable();
   assert(letAcc);
   assert(letAcc->getType() == Type::Float);
   assert(letAcc->getName() == "acc");
-  assert(Get::classof(letAcc->getInit()));
-  Variable* letX = llvm::dyn_cast<Variable>(let->getVariable(1));
+  assert(Get::classof(letAccBinding.getInit()));
+  Binding const& letXBinding = let->getBinding(1);
+  Variable* letX = letXBinding.getVariable();
   assert(letX);
   assert(letX->getType() == Type::Float);
   assert(letX->getName() == "x");
-  assert(Get::classof(letX->getInit()));
+  assert(Get::classof(letXBinding.getInit()));
   // Lambda operation
   Call* op = llvm::dyn_cast<Call>(let->getExpr());
   assert(op);

--- a/mlir/lib/Parser/AST.cpp
+++ b/mlir/lib/Parser/AST.cpp
@@ -98,16 +98,22 @@ std::ostream& Variable::dump(std::ostream& s, size_t tab) const {
   s << string(tab, ' ') << "Variable:" << endl;
   s << string(tab + 2, ' ') << "name [" << name << "]" << endl;
   Expr::dump(s, tab + 2);
-  if (init)
-    init->dump(s, tab + 2);
+  return s;
+}
+
+std::ostream& Binding::dump(std::ostream& s, size_t tab) const {
+  s << string(tab, ' ') << "Binding:" << endl;
+  s << string(tab + 2, ' ') << "name [" << var->getName() << "]" << endl;
+  var->Expr::dump(s, tab + 2);
+  init->dump(s, tab + 2);
   return s;
 }
 
 std::ostream&  Let::dump(std::ostream& s, size_t tab) const {
   s << string(tab, ' ') << "Let:" << endl;
   Expr::dump(s, tab + 2);
-  for (auto &v: vars)
-    v->dump(s, tab + 2);
+  for (auto &b: bindings)
+    b.dump(s, tab + 2);
   if (expr)
     expr->dump(s, tab + 2);
   return s;


### PR DESCRIPTION
Previously an `AST::Variable` had an optional initialization expression. This PR removes the initialization expression from `Variable`, and adds a new structure `AST::Binding` which represents a variable which has an initializer.

(Depends on #672 and #674)