### PR TITLE
Preliminaries for supporting one-arg in ksc-mlir

### DIFF
--- a/mlir/include/Parser/AST.h
+++ b/mlir/include/Parser/AST.h
@@ -197,6 +197,8 @@ struct Signature {
     return name == that.name && argTypes == that.argTypes;
   }
   bool operator!=(Signature const& that) const { return !(*this == that); }
+
+  std::string getMangledName() const;
 };
 
 std::ostream& operator<<(std::ostream& s, Signature const& t);
@@ -379,19 +381,19 @@ private:
 /// the final IR.
 struct Declaration : public Expr {
   using Ptr = std::unique_ptr<Declaration>;
-  Declaration(StructuredName name, Type type, std::vector<Type> argTypes)
-      : Expr(type, Kind::Declaration), name(std::move(name)), argTypes(move(argTypes)) {}
+  Declaration(Signature signature, Type returnType)
+      : Expr(returnType, Kind::Declaration), signature(std::move(signature)) {}
 
-  llvm::ArrayRef<Type> getArgTypes() const { return argTypes; }
+  llvm::ArrayRef<Type> getArgTypes() const { return signature.argTypes; }
   Type getArgType(size_t idx) const {
-    assert(idx < argTypes.size() && "Offset error");
-    return argTypes[idx];
+    assert(idx < signature.argTypes.size() && "Offset error");
+    return signature.argTypes[idx];
   }
-  StructuredName const& getName() const { return name; }
+  StructuredName const& getName() const { return signature.name; }
 
-  std::string getMangledName() const;
+  std::string getMangledName() const { return signature.getMangledName(); }
 
-  size_t size() const { return argTypes.size(); }
+  size_t size() const { return signature.argTypes.size(); }
 
   std::ostream& dump(std::ostream& s, size_t tab = 0) const override;
 
@@ -401,9 +403,7 @@ struct Declaration : public Expr {
   }
 
 private:
-  // TODO: use Signature here
-  StructuredName name;
-  std::vector<Type> argTypes;   
+  Signature signature;
 };
 
 /// Call, ex: (add x 3), (neg (mul (sin x) d_dcos)))

--- a/mlir/lib/Parser/AST.cpp
+++ b/mlir/lib/Parser/AST.cpp
@@ -124,10 +124,10 @@ std::ostream& Call::dump(std::ostream& s, size_t tab) const {
 
 std::ostream& Declaration::dump(std::ostream& s, size_t tab) const {
   s << string(tab, ' ') << "Declaration:" << endl;
-  s << string(tab + 2, ' ') << "name [" << name << "]" << endl;
+  s << string(tab + 2, ' ') << "name [" << signature.name << "]" << endl;
   Expr::dump(s, tab + 2);
   s << string(tab + 2, ' ') << "Types: [ ";
-  for (auto ty : argTypes)
+  for (auto ty : signature.argTypes)
     ty.dump(s) << " ";
   return s << "]" << endl;
 }
@@ -255,7 +255,7 @@ std::string encodeName(std::string const& s)
     return ret;
 }
 
-std::string Declaration::getMangledName() const {
+std::string Signature::getMangledName() const {
   if (name.hasType())
     return name.getMangledName();
   

--- a/mlir/lib/Parser/Parser.cpp
+++ b/mlir/lib/Parser/Parser.cpp
@@ -90,7 +90,7 @@ Declaration *Parser::addExtraDecl(StructuredName const& name, std::vector<Type> 
   }
 
   // Not present, cons one up
-  decl = new Declaration(name, returnType, argTypes);
+  decl = new Declaration(sig, returnType);
   extraDecls->addOperand(Expr::Ptr(decl));
   
   return decl;
@@ -493,8 +493,9 @@ Declaration::Ptr Parser::parseDecl(const Token *tok) {
   else
     for (auto &c : args->getChildren())
       argTypes.push_back(parseType(c.get()));
-  Signature sig{ parseStructuredName(name), argTypes };
-  auto decl = make_unique<Declaration>(sig.name, type, argTypes);
+  Signature sig{ parseStructuredName(name), std::move(argTypes) };
+
+  auto decl = make_unique<Declaration>(sig, type);
   function_decls[sig] = decl.get();
   return decl;
 }
@@ -529,7 +530,7 @@ Definition::Ptr Parser::parseDef(const Token *tok) {
     argTypes.push_back(a->getType());
   }
   Signature sig{ name, argTypes };
-  auto declaration = make_unique<Declaration>(name, returnType, argTypes);
+  auto declaration = make_unique<Declaration>(sig, returnType);
   function_decls[sig] = declaration.get();
 
   // Function body is a block, create one if single expr


### PR DESCRIPTION
This PR is a refactoring which is the first step towards getting ksc-mlir to understand one-argification (see issue #681), though the changes here are intended to be improvements in their own right.