### PR TITLE
Emit nested lets rather than lists of bindings

### DIFF
--- a/src/ksc/Lang.hs
+++ b/src/ksc/Lang.hs
@@ -1200,14 +1200,9 @@ pprCall prec f e = mode
 
 pprLetSexp :: forall p. InPhase p
            => PatG (LetBndrX p) -> ExprX p -> ExprX p -> SDoc
-pprLetSexp v e =
-      go [(v,e)]
-    where
-      go binds (Let v1 e1 body) = go ((v1,e1):binds) body
-      go binds body =
-            parens $ sep [text "let", parens $ vcat (map parenBind $ reverse binds),
-                        ppr body]
-      parenBind (v,e) = parens $ pprPatLetBndr @p v <+> ppr e
+pprLetSexp v e body =
+      parens $ vcat [ text "let" <+> (parens $ pprPatLetBndr @p v <+> ppr e),
+                      ppr body]
 
 
 parensIf :: Prec -> Prec -> SDoc -> SDoc


### PR DESCRIPTION
We've previously noted that there's a parsing ambiguity in `(let ((a b) (c d)) e)`. Here `a` and `c` could be variables, with initializers `b` and `d`; or `c` could be a function returning a 2-tuple which is unpacked into elements `a` and `b`.

Previously there was a suggestion that we might drop the support for sequences of bindings completely, so that you'd have to write `(let (a b) (let (c d) e))` if that's the indended meaning. If we're planning to do this, it would be helpful to get it done now, so that ksc-mlir and other parsers don't have to worry about the ambiguity when adding support for tuple-unpacking lets. This PR would change the _output_ of ksc to match this format.

There's an alternative way to resolve the ambiguity, which is to say that any tuple-unpacking let must be written as part of a _sequence_ of bindings, ie. require an extra set of brackets: `(let (((a b) (c d))) e)`. This is actually what ksc is emitting at the moment, but I'm not sure whether it's formally part of our specification?

Alternatively we could say that each parser should understand how to resolve this ambiguity; but I don't know what the intended resolution is and I'd prefer not to have this logic in more than one place.