### PR TITLE
Remove ksc-mlir support for lets with lists of bindings

### DIFF
--- a/mlir/include/Parser/AST.h
+++ b/mlir/include/Parser/AST.h
@@ -353,17 +353,12 @@ private:
 /// Defines a variable.
 struct Let : public Expr {
   using Ptr = std::unique_ptr<Let>;
-  Let(std::vector<Binding> && bindings, Expr::Ptr expr)
-      : Expr(expr->getType(), Kind::Let), bindings(std::move(bindings)),
+  Let(Binding binding, Expr::Ptr expr)
+      : Expr(expr->getType(), Kind::Let), binding(std::move(binding)),
         expr(std::move(expr)) {}
 
-  llvm::ArrayRef<Binding> getBindings() const { return bindings; }
-  Binding const& getBinding(size_t idx) const {
-    assert(idx < bindings.size() && "Offset error");
-    return bindings[idx];
-  }
+  Binding const& getBinding() const { return binding; }
   Expr *getExpr() const { return expr.get(); }
-  size_t size() const { return bindings.size(); }
 
   std::ostream& dump(std::ostream& s, size_t tab = 0) const override;
 
@@ -371,7 +366,7 @@ struct Let : public Expr {
   static bool classof(const Expr *c) { return c->kind == Kind::Let; }
 
 private:
-  std::vector<Binding> bindings;
+  Binding binding;
   Expr::Ptr expr;
 };
 

--- a/mlir/lib/Parser/AST.cpp
+++ b/mlir/lib/Parser/AST.cpp
@@ -112,8 +112,7 @@ std::ostream& Binding::dump(std::ostream& s, size_t tab) const {
 std::ostream&  Let::dump(std::ostream& s, size_t tab) const {
   s << string(tab, ' ') << "Let:" << endl;
   Expr::dump(s, tab + 2);
-  for (auto &b: bindings)
-    b.dump(s, tab + 2);
+  binding.dump(s, tab + 2);
   if (expr)
     expr->dump(s, tab + 2);
   return s;

--- a/mlir/lib/Parser/MLIR.cpp
+++ b/mlir/lib/Parser/MLIR.cpp
@@ -412,8 +412,8 @@ Values Generator::buildCall(const AST::Call* call) {
 // Builds variable declarations
 Values Generator::buildLet(const AST::Let* let) {
   // Bind the variable to an expression
-  for (auto &binding: let->getBindings())
-      declareVariable(binding.getVariable()->getName(), buildNode(binding.getInit()));
+  AST::Binding const& binding = let->getBinding();
+  declareVariable(binding.getVariable()->getName(), buildNode(binding.getInit()));
   // Lower the body, using the variable
   return buildNode(let->getExpr());
 }

--- a/mlir/lib/Parser/Parser.cpp
+++ b/mlir/lib/Parser/Parser.cpp
@@ -433,21 +433,9 @@ Let::Ptr Parser::parseLet(const Token *tok) {
   PARSE_ENTER;
 
   PARSE_ASSERT(tok->size() == 3);
-  const Token *bond = tok->getChild(1);
-  PARSE_ASSERT2(!bond->isValue, bond);
-  vector<Binding> bindings;
-  // Single variable binding
-  if (bond->getChild(0)->isValue) {
-    PARSE_ASSERT2(bond->size() == 2, bond) << "Binding (v val), not [" << bond << "]";
-    bindings.push_back(parseBinding(bond));
-    // Multiple variables
-  } else {
-    for (auto &c: bond->getChildren())
-      bindings.push_back(parseBinding(c.get()));
-  }
-
+  auto binding = parseBinding(tok->getChild(1));
   auto body = parseToken(tok->getChild(2));
-  return make_unique<Let>(move(bindings), move(body));
+  return make_unique<Let>(move(binding), move(body));
 }
 
 // Declares a function (and add it to symbol table)

--- a/mlir/test/Ksc/condition.ks
+++ b/mlir/test/Ksc/condition.ks
@@ -8,18 +8,17 @@
 ; MLIR: func @main() -> i64 {
 ; LLVM: define i64 @main() {
 
-  (let (
 ; All literals, LLVM does not support, so we only lower the right block
-        (a (if true 10 20))
+  (let (a (if true 10 20))
 ; MLIR:    %c10{{.*}} = constant 10 : i64
 ; LLVM optimises constants away
 
-        (b (if false 10 20))
+  (let (b (if false 10 20))
 ; MLIR:    %c20{{.*}} = constant 20 : i64
 ; LLVM optimises constants away
 
 ; All constant expressions
-        (c (if (eq 10 20) (foo 30) (bar 40)))
+  (let (c (if (eq 10 20) (foo 30) (bar 40)))
 ; MLIR-DAG: %c30{{.*}} = constant 30 : i64
 ; MLIR-DAG: %[[foo1:[0-9]+]] = call @foo$ai(%c30{{.*}}) : (i64) -> i64
 ; MLIR-DAG: %c40{{.*}} = constant 40 : i64
@@ -35,7 +34,7 @@
 
 
 ; Inside let, with variables
-        (d (let (x (foo 50)) (if (eq x 60) (foo 70) (bar 80))))
+  (let (d (let (x (foo 50)) (if (eq x 60) (foo 70) (bar 80))))
 ; MLIR: %c50{{.*}} = constant 50 : i64
 ; MLIR: %[[foo_cond:[0-9]+]] = call @foo$ai(%c50{{.*}}) : (i64) -> i64
 ; MLIR: %c70{{.*}} = constant 70 : i64
@@ -52,7 +51,7 @@
 ; LLVM: %[[eq2:[0-9]+]] = icmp eq i64 %[[foo_cond]], 60
 ; LLVM: %[[sel2:[0-9]+]] = select i1 %[[eq2]], i64 %[[foo2]], i64 %[[bar2]]
 
-      ) d)
+   d))))
 ; MLIR: return %[[sel2]] : i64
 ; LLVM: ret i64 %[[sel2]]
 ))

--- a/mlir/test/Ksc/fold.ks
+++ b/mlir/test/Ksc/fold.ks
@@ -6,9 +6,9 @@
 ; LLVM: define i64 @"prod_fold$avii"(i64* %0, i64* %1, i64 %2, i64 %3, i64 %4, i64 %5) {
 
      (fold (lam (acc_x : (Tuple Integer Integer))
-                (let ((acc (get$1$2 acc_x))
-                      (x   (get$2$2 acc_x)))
-                  (mul (add acc x) closure)))
+                (let (acc (get$1$2 acc_x))
+                (let (x   (get$2$2 acc_x))
+                  (mul (add acc x) closure))))
            1
            v
      )
@@ -69,9 +69,9 @@
 ; MLIR: func @main() -> i64 {
 ; LLVM: define i64 @main() {
 
-  (let ((vec (build 10 (lam (i : Integer) (add i i))))
-        (m   (prod_fold vec 2)))
-    m)
+  (let (vec (build 10 (lam (i : Integer) (add i i))))
+  (let (m   (prod_fold vec 2))
+    m))
 
 ; We are not interested in the build construct, just the call and return
 ; MLIR:  %c10{{.*}} = constant 10 : i64

--- a/mlir/test/Ksc/functions.ks
+++ b/mlir/test/Ksc/functions.ks
@@ -68,8 +68,8 @@
 (def main Integer () (
 ; MLIR: func @main() -> i64 {
 ; LLVM: define i64 @main() {
-  (let ((f (foo 10.0))
-       (b (bar (fun 30)))) b)
+  (let (f (foo 10.0))
+  (let (b (bar (fun 30))) b))
 ; MLIR: %cst = constant 1.000000e+01 : f64
 ; MLIR: call @foo$af(%cst) : (f64) -> f64
 ; MLIR:  %c30{{.*}} = constant 30 : i64

--- a/mlir/test/Ksc/let.ks
+++ b/mlir/test/Ksc/let.ks
@@ -73,19 +73,3 @@
 ; LLVM: %[[ret:[0-9]+]] = mul i64 %[[mul]], %[[add]]
 ; LLVM: ret i64 %[[ret]]
 ))
-
-; Multiple bind lets
-(def fun6 Integer (argc : Integer) (
-; MLIR: func @fun6$ai(%arg0: i64) -> i64 {
-; LLVM: define i64 @"fun6$ai"(i64 %0) {
-  (let ((i argc) (j 20) (k 30)) (add (mul i j) k))
-; MLIR: %c20{{.*}} = constant 20 : i64
-; MLIR: %c30{{.*}} = constant 30 : i64
-; MLIR: %[[ij:[0-9]+]] = muli %arg0, %c20{{.*}} : i64
-; MLIR: %[[ret:[0-9]+]] = addi %[[ij]], %c30{{.*}} : i64
-; MLIR: return %[[ret]] : i64
-
-; LLVM: %[[ij:[0-9]+]] = mul i64 %0, 20
-; LLVM: %[[ret:[0-9]+]] = add i64 %[[ij]], 30
-; LLVM: ret i64 %[[ret]]
-))

--- a/mlir/test/Ksc/print.ks
+++ b/mlir/test/Ksc/print.ks
@@ -25,6 +25,6 @@
 ; LLVM:   ret i64 4
 
 (def main Integer ()
-   (let ((argc 4)
-         (argv (build argc (lam (i : Integer) i))))
-      (f argc argv)))
+   (let (argc 4)
+   (let (argv (build argc (lam (i : Integer) i)))
+      (f argc argv))))

--- a/mlir/test/Ksc/tuple.ks
+++ b/mlir/test/Ksc/tuple.ks
@@ -42,11 +42,11 @@
 ; LLVM: define i64 @"amain$ai"(i64 %0) {
 
 ; Direct get from temp tuple
-  (let ((a (get$2$2 (tuple 10.0 42)))
+  (let (a (get$2$2 (tuple 10.0 42)))
 ; MLIR: %[[ret:[ci_0-9]+]] = constant 42 : i64
 
 ; Creating tuple of two elements, extracting each one, and returning the sum
-        (t (tuple (add argc argc) 10.0 23)))
+  (let (t (tuple (add argc argc) 10.0 23))
 ; MLIR: %[[add:[0-9]+]] = addi %arg0, %arg0 : i64
 ; MLIR: %cst = constant 1.000000e+01 : f64
 ; MLIR: %c23{{.*}} = constant 23 : i64
@@ -58,5 +58,5 @@
 ; LLVM: %[[mul:[0-9]+]] = mul i64 %[[add]], 23
 ; LLVM: ret i64 %[[mul:[0-9]+]]
 
-  )
+  ))
 ))

--- a/mlir/test/Ksc/types.ks
+++ b/mlir/test/Ksc/types.ks
@@ -43,7 +43,7 @@
 ; MLIR:      func @main() -> i64 {
 ; LLVM:      define i64 @main() {
 
-  (let ((a (fun@ff 10.0 20.0 30.0))
+  (let (a (fun@ff 10.0 20.0 30.0))
 ; MLIR-NEXT:  %cst = constant 1.000000e+01 : f64
 ; MLIR-NEXT:  %cst_0 = constant 2.000000e+01 : f64
 ; MLIR-NEXT:  %cst_1 = constant 3.000000e+01 : f64
@@ -51,7 +51,7 @@
 
 ; LLVM-NEXT:  %[[func:[0-9]+]] = call double @"fun$aff$afff"(double 1.000000e+01, double 2.000000e+01, double 3.000000e+01)
 
-        (b (fun@ii 10 20 30)))
+  (let (b (fun@ii 10 20 30))
 ; MLIR-NEXT:  %c10{{.*}} = constant 10 : i64
 ; MLIR-NEXT:  %c20{{.*}} = constant 20 : i64
 ; MLIR-NEXT:  %c30{{.*}} = constant 30 : i64
@@ -59,7 +59,7 @@
 
 ; LLVM-NEXT:  %[[func:[0-9]+]] = call i64 @"fun$aii$aiii"(i64 10, i64 20, i64 30)
   b
-))
+)))
 ; AST does not return anything
 ; MLIR: return %[[func]] : i64
 ; LLVM: ret i64 %[[func]]


### PR DESCRIPTION
As of PR #684, ksc no longer outputs such lists.

This simplifies `AST::Let` in preparation for supporting tuple-unpacking lets.