### PR TITLE
Lowering of build using edsc features of MLIR

### DIFF
--- a/mlir/include/Parser/MLIR.h
+++ b/mlir/include/Parser/MLIR.h
@@ -5,9 +5,7 @@
 #include <map>
 
 #include "mlir/IR/Builders.h"
-#include "mlir/IR/Function.h"
 #include "mlir/IR/MLIRContext.h"
-#include "mlir/IR/Module.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Target/LLVMIR.h"
 #include "mlir/Transforms/Passes.h"
@@ -64,6 +62,10 @@ class Generator {
   Values buildGet(const AST::Get*);
   Values buildFold(const AST::Fold*);
 
+  // Function level builders for parallel lowering
+  Values buildBuildParallel(const AST::Build*);
+
+
   // Variables
   void declareVariable(std::string const& name, Values vals);
   void declareVariable(const AST::Variable* var, Values vals = {});
@@ -72,7 +74,7 @@ class Generator {
   void serialiseArgs(const AST::Definition *def, mlir::Block &entry);
 
 public:
-  Generator() : builder(&context), UNK(builder.getUnknownLoc()) { }
+  Generator(mlir::MLIRContext &context) : builder(&context), UNK(builder.getUnknownLoc()) { }
 
   // Build from MLIR source
   const mlir::ModuleOp build(const std::string& mlir);

--- a/mlir/include/Parser/MLIR.h
+++ b/mlir/include/Parser/MLIR.h
@@ -62,10 +62,6 @@ class Generator {
   Values buildGet(const AST::Get*);
   Values buildFold(const AST::Fold*);
 
-  // Function level builders for parallel lowering
-  Values buildBuildParallel(const AST::Build*);
-
-
   // Variables
   void declareVariable(std::string const& name, Values vals);
   void declareVariable(const AST::Variable* var, Values vals = {});

--- a/mlir/ksc-mlir/main.cpp
+++ b/mlir/ksc-mlir/main.cpp
@@ -75,11 +75,7 @@ int main(int argc, char **argv) {
     }
   }
 
-  // FIXME: registering dialects must happen before building the context
-  // Create a more logical API that doesn't require it to be done by the caller
-  mlir::registerAllDialects();
 
-  // mlir::registerDialect<mlir::knossos::KnossosDialect>();
 
   // Unit tests
   // FIXME: Use gtest or similar
@@ -128,8 +124,14 @@ int main(int argc, char **argv) {
     }
   }
 
+  // FIXME: registering dialects must happen before building the context
+  // Create a more logical API that doesn't require it to be done by the caller
+  mlir::MLIRContext context;
+  mlir::registerAllDialects(context);
+  context.loadDialect<mlir::StandardOpsDialect, mlir::scf::SCFDialect, mlir::math::MathDialect>();
+
   // Call generator and print output (MLIR/LLVM)
-  Generator g;
+  Generator g(context);
   mlir::ModuleOp module;
   if (source == Source::KSC)
     module = g.build(p.getExtraDecls(), p.getRootNode());


### PR DESCRIPTION
This PR showcases the usage of MLIR edsc features in the lowering of a build node. 
- The C++ code to emit the IR looks much closer to the IR itself using this approach. 
- I choose a lowering target with a higher abstraction level: Lowering to a loop (nest) instead of a chain of basic blocks, i.e `scf` dialect instead of `std` dialect.

### edsc - Embedded Domain Specific Concepts
We move away from using a series of `create` calls on the builder itself, i.e. [old build lowering](https://github.com/microsoft/knossos-ksc/blob/bb38adf3406619948c3ac5ee570a9fa40c797da2/mlir/lib/Parser/MLIR.cpp#L470)
Instead, we set up a `ScopedContext` once with the correct insertion point. Then we can use a much simpler declarative interface to emit new operations. [new build lowering](https://github.com/microsoft/knossos-ksc/blob/764f5cc5a6292a57b378f0f1c7ced07c6e255447/mlir/lib/Parser/MLIR.cpp#L475)

This PR is tested to work partially with LLVM commit f4013359b3da2c78e94a64245de8638460f96c1a. 
e.g. lowering of maths.ks works as expected `ksc-mlir MLIR mlir/test/Programs/maths.ks`. However, due to slight changes in the MLIR format all FileCheck tests are expected to fail. 
Creating new FileCheck tests is eased dramatically by using [generate-test-checks.py](https://github.com/llvm/llvm-project/blob/a99b8ae3909106d831d880c1647dabe92f470290/mlir/utils/generate-test-checks.py)