### PR TITLE
Use one-arg representation of function signatures in ksc-mlir

### DIFF
--- a/doc/AST.cpp
+++ b/doc/AST.cpp
@@ -62,7 +62,7 @@ struct Let : public Expr {
 // Declaration, ex: (edef max Float (Float Float))
 struct Declaration : public Expr {
   Name name;
-  std::vector<Type> argTypes;
+  Type argType;
 };
 
 /// Call

--- a/mlir/include/Parser/AST.h
+++ b/mlir/include/Parser/AST.h
@@ -187,14 +187,14 @@ std::ostream& operator<<(std::ostream& s, StructuredName const& t);
 
 struct Signature {
   StructuredName name;
-  std::vector<Type> argTypes;   
+  Type argType;   
 
   bool operator<(Signature const& that) const {
     return name < that.name ||
-          (name == that.name && argTypes < that.argTypes);
+          (name == that.name && argType < that.argType);
   }
   bool operator==(Signature const& that) const {
-    return name == that.name && argTypes == that.argTypes;
+    return name == that.name && argType == that.argType;
   }
   bool operator!=(Signature const& that) const { return !(*this == that); }
 
@@ -392,16 +392,10 @@ struct Declaration : public Expr {
   Declaration(Signature signature, Type returnType)
       : Expr(returnType, Kind::Declaration), signature(std::move(signature)) {}
 
-  llvm::ArrayRef<Type> getArgTypes() const { return signature.argTypes; }
-  Type getArgType(size_t idx) const {
-    assert(idx < signature.argTypes.size() && "Offset error");
-    return signature.argTypes[idx];
-  }
+  Type getArgType() const { return signature.argType; }
   StructuredName const& getName() const { return signature.name; }
 
   std::string getMangledName() const { return signature.getMangledName(); }
-
-  size_t size() const { return signature.argTypes.size(); }
 
   std::ostream& dump(std::ostream& s, size_t tab = 0) const override;
 

--- a/mlir/include/Parser/Parser.h
+++ b/mlir/include/Parser/Parser.h
@@ -130,7 +130,7 @@ public:
   const Block* getExtraDecls() {
     return extraDecls.get();
   }
-  Declaration* addExtraDecl(StructuredName const& name, std::vector<Type> types, Type returnType);
+  Declaration* addExtraDecl(StructuredName const& name, Type argType, Type returnType);
 };
 
 } // namespace AST

--- a/mlir/ksc-mlir/test.cpp
+++ b/mlir/ksc-mlir/test.cpp
@@ -183,9 +183,10 @@ void test_parser_decl() {
   // Declaration has 3 parts: name, return type, arg types decl
   assert(decl->getName() == "fun");
   assert(decl->getType() == Type::Float);
-  assert(decl->getArgTypes()[0] == Type::Integer);
-  assert(decl->getArgTypes()[1] == Type::String);
-  assert(decl->getArgTypes()[2] == Type::Bool);
+  assert(decl->getArgType().isTuple());
+  assert(decl->getArgType().getSubType(0) == Type::Integer);
+  assert(decl->getArgType().getSubType(1) == Type::String);
+  assert(decl->getArgType().getSubType(2) == Type::Bool);
   cout << "    OK\n";
 }
 
@@ -345,16 +346,17 @@ void test_parser_vector_type() {
   // Check vectors were detected properly
   auto fooTy = foo->getType();
   assert(fooTy == Type::Vector && fooTy.getSubType() == Type::Float);
-  auto fooArgTy = foo->getArgType(0);
+  auto fooArgTy = foo->getArgType();
   assert(fooArgTy == Type::Vector && fooArgTy.getSubType() == Type::Float);
   auto barTy = bar->getType();
   assert(barTy == Type::Vector && barTy.getSubType() == Type::Vector);
   auto barSubTy = barTy.getSubType();
   assert(barSubTy == Type::Vector && barSubTy.getSubType() == Type::Float);
-  assert(bar->getArgType(0) == Type::Integer);
-  auto barArgTy = bar->getArgType(1);
+  assert(bar->getArgType().isTuple());
+  assert(bar->getArgType().getSubType(0) == Type::Integer);
+  auto barArgTy = bar->getArgType().getSubType(1);
   assert(barArgTy == Type::Vector && barArgTy.getSubType() == Type::Float);
-  assert(bar->getArgType(2) == Type::Float);
+  assert(bar->getArgType().getSubType(2) == Type::Float);
   cout << "    OK\n";
 }
 
@@ -407,16 +409,17 @@ void test_parser_vector() {
   // Check vectors were detected properly
   auto fooTy = foo->getType();
   assert(fooTy == Type::Vector && fooTy.getSubType() == Type::Float);
-  auto fooArgTy = foo->getArgType(0);
+  auto fooArgTy = foo->getArgType();
   assert(fooArgTy == Type::Vector && fooArgTy.getSubType() == Type::Float);
   auto barTy = bar->getType();
   assert(barTy == Type::Vector && barTy.getSubType() == Type::Vector);
   auto barSubTy = barTy.getSubType();
   assert(barSubTy == Type::Vector && barSubTy.getSubType() == Type::Float);
-  assert(bar->getArgType(0) == Type::Integer);
-  auto barArgTy = bar->getArgType(1);
+  assert(bar->getArgType().isTuple());
+  assert(bar->getArgType().getSubType(0) == Type::Integer);
+  auto barArgTy = bar->getArgType().getSubType(1);
   assert(barArgTy == Type::Vector && barArgTy.getSubType() == Type::Float);
-  assert(bar->getArgType(2) == Type::Float);
+  assert(bar->getArgType().getSubType(2) == Type::Float);
   cout << "    OK\n";
 }
 
@@ -436,27 +439,28 @@ void test_parser_tuple_type() {
   assert(foo && bar && baz);
   // Check vectors were detected properly
   auto fooTy = foo->getType();
-  assert(fooTy == Type::Tuple && fooTy.getSubType(0) == Type::Float);
-  auto fooArgTy = foo->getArgType(0);
-  assert(fooArgTy == Type::Tuple &&
+  assert(fooTy.isTuple() && fooTy.getSubType(0) == Type::Float);
+  auto fooArgTy = foo->getArgType();
+  assert(fooArgTy.isTuple() &&
          fooArgTy.getSubType(0) == Type::Float &&
          fooArgTy.getSubType(1) == Type::Float);
   auto barTy = bar->getType();
   assert(barTy == Type::Float);
-  assert(bar->getArgType(0) == Type::Integer);
-  auto barArgTy = bar->getArgType(1);
-  assert(barArgTy == Type::Tuple &&
+  assert(bar->getArgType().isTuple());
+  assert(bar->getArgType().getSubType(0) == Type::Integer);
+  auto barArgTy = bar->getArgType().getSubType(1);
+  assert(barArgTy.isTuple() &&
          barArgTy.getSubType(0) == Type::Float &&
          barArgTy.getSubType(1) == Type::Float);
-  assert(bar->getArgType(2) == Type::Float);
+  assert(bar->getArgType().getSubType(2) == Type::Float);
   auto bazTy = baz->getType();
   assert(bazTy == Type::Bool);
-  auto bazArgTy = baz->getArgType(0);
-  assert(bazArgTy == Type::Tuple &&
+  auto bazArgTy = baz->getArgType();
+  assert(bazArgTy.isTuple() &&
          bazArgTy.getSubType(0) == Type::Float &&
-         bazArgTy.getSubType(1) == Type::Tuple);
+         bazArgTy.getSubType(1).isTuple());
   auto bazSubArgTy = bazArgTy.getSubType(1);
-  assert(bazSubArgTy == Type::Tuple &&
+  assert(bazSubArgTy.isTuple() &&
          bazSubArgTy.getSubType(0) == Type::Integer &&
          bazSubArgTy.getSubType(1) == Type::Float);
   cout << "    OK\n";
@@ -473,7 +477,7 @@ void test_parser_tuple() {
   Tuple* tuple = llvm::dyn_cast<Tuple>(root->getOperand(0));
   assert(tuple);
   auto type = tuple->getType();
-  assert(type == Type::Tuple &&
+  assert(type.isTuple() &&
          type.getSubType(0) == Type::Float &&
          type.getSubType(1) == Type::Bool &&
          type.getSubType(2) == Type::Integer);
@@ -532,7 +536,7 @@ void test_parser_fold() {
   // Lambda parameter
   Variable* acc_x = fold->getLambdaParameter();
   assert(acc_x);
-  assert(acc_x->getType() == Type::Tuple);
+  assert(acc_x->getType().isTuple());
   assert(acc_x->getType().getSubType(0) == Type::Float);
   assert(acc_x->getType().getSubType(1) == Type::Float);
   // Init

--- a/mlir/lib/Parser/MLIR.cpp
+++ b/mlir/lib/Parser/MLIR.cpp
@@ -178,11 +178,19 @@ void Generator::buildGlobal(const AST::Block* block) {
     module->push_back(def);
 }
 
+// Recover multiple argument types from a one-argified argument type.
+std::vector<Knossos::AST::Type> multiArgify(Knossos::AST::Type t) {
+  if (t.isTuple())
+    return t.getSubTypes();
+  else
+    return std::vector<Knossos::AST::Type>(1, t);
+}
+
 // Declaration only, no need for basic blocks
 mlir::FuncOp Generator::buildDecl(const AST::Declaration* decl) {
   assert(!functions.count(decl->getMangledName()) && "Duplicated function declaration");
   Types argTypes;
-  for (auto &t: decl->getArgTypes()) {
+  for (auto &t: multiArgify(decl->getArgType())) {
     auto tys = ConvertType(t);
     argTypes.append(tys.begin(), tys.end());
   }

--- a/mlir/test/Ksc/tuple.ks
+++ b/mlir/test/Ksc/tuple.ks
@@ -3,21 +3,21 @@
 
 ; Tuple argument
 (edef tfun1 Float (Tuple Integer Float))
-; MLIR: func private @tfun1$a$dif$b(i64, f64) -> f64
-; LLVM: declare double @"tfun1$a$dif$b"(i64 %0, double %1)
+; MLIR: func private @tfun1$aif(i64, f64) -> f64
+; LLVM: declare double @"tfun1$aif"(i64 %0, double %1)
 
 ; Tuple return
 (edef tfun2 (Tuple Integer Float) (Tuple Bool Float))
-; MLIR: func private @tfun2$a$dbf$b(i1, f64) -> (i64, f64)
-; LLVM: declare { i64, double } @"tfun2$a$dbf$b"(i1 %0, double %1)
+; MLIR: func private @tfun2$abf(i1, f64) -> (i64, f64)
+; LLVM: declare { i64, double } @"tfun2$abf"(i1 %0, double %1)
 
 ; Both, with definition
 (def tswap (Tuple Float Float) (tup : (Tuple Float Float))
     (tuple (get$2$2 tup) (get$1$2 tup))
 )
-; MLIR: func private @tswap$a$dff$b(%arg0: f64, %arg1: f64) -> (f64, f64) {
+; MLIR: func private @tswap$aff(%arg0: f64, %arg1: f64) -> (f64, f64) {
 ; MLIR:   return %arg1, %arg0 : f64, f64
-; LLVM: define { double, double } @"tswap$a$dff$b"(double %0, double %1) {
+; LLVM: define { double, double } @"tswap$aff"(double %0, double %1) {
 ; LLVM:   %[[ins0:[0-9]+]] = insertvalue { double, double } undef, double %1, 0
 ; LLVM:   %[[ins1:[0-9]+]] = insertvalue { double, double } %[[ins0]], double %0, 1
 ; LLVM:   ret { double, double } %[[ins1]]
@@ -27,11 +27,11 @@
     (add i (get$2$2 (tswap (tuple j k))))
 )
 ; MLIR: func private @tfun3$afff(%arg0: f64, %arg1: f64, %arg2: f64) -> f64 {
-; MLIR:   %[[call:[0-9]+]]:2 = call @tswap$a$dff$b(%arg1, %arg2) : (f64, f64) -> (f64, f64)
+; MLIR:   %[[call:[0-9]+]]:2 = call @tswap$aff(%arg1, %arg2) : (f64, f64) -> (f64, f64)
 ; MLIR:   %[[add:[0-9]+]] = addf %arg0, %[[call]]#1 : f64
 ; MLIR:   return %[[add]] : f64
 ; LLVM: define double @"tfun3$afff"(double %0, double %1, double %2) {
-; LLVM:   %[[call:[0-9]+]] = call { double, double } @"tswap$a$dff$b"(double %1, double %2)
+; LLVM:   %[[call:[0-9]+]] = call { double, double } @"tswap$aff"(double %1, double %2)
 ; LLVM:   %[[ext0:[0-9]+]] = extractvalue { double, double } %[[call]], 0
 ; LLVM:   %[[ext1:[0-9]+]] = extractvalue { double, double } %[[call]], 1
 ; LLVM:   %[[add:[0-9]+]] = fadd double %0, %[[ext1]]


### PR DESCRIPTION
This PR changes `Signature` to store a single `Type` for its argument, rather than a `vector<Type>`. This means that ksc-mlir now correctly recognises `(edef f Float (Tuple Float Float))` as being callable by `(f 1.0 2.0)`.

There are no changes to `Definition` here, which means that defs which have an n-tuple parameter are are still expected to have `n` parameter names. This will need a separate fix to come later.
