### PR TITLE
Adding polymorphism to ksc

### DIFF
--- a/src/ksc/Ksc/Pipeline.hs
+++ b/src/ksc/Ksc/Pipeline.hs
@@ -18,7 +18,7 @@ import Lang (Decl, DeclX(DefDecl), DerivedFun(Fun), Derivations(JustFun),
              def_fun, displayN, partitionDecls,
              ppr, renderSexp, (<+>))
 import qualified Lang as L
-import LangUtils (GblSymTab, emptyGblST, extendGblST, stInsertFun)
+import LangUtils (GblSymTab, emptyGblST, extendGblST, stInsertFun, lookupDef)
 import qualified Ksc.Futhark
 import Parse (parseF)
 import Rules (mkRuleBase)
@@ -29,7 +29,6 @@ import Ksc.SUF.AD (sufFwdRevPassDef, sufRevDef)
 
 import Data.Maybe (maybeToList)
 import Data.List (intercalate)
-import qualified Data.Map as Map
 import GHC.Stack (HasCallStack)
 
 -------------------------------------
@@ -172,7 +171,8 @@ more complicated typechecking story.
 
 deriveDecl :: GblSymTab -> L.TDecl -> KM (GblSymTab, [L.TDecl])
 deriveDecl = deriveDeclUsing $ \env (L.GDef derivation fun) -> do
-    { let tdef = case Map.lookup fun env of
+    { -- fun :: UserFun Typed
+      let tdef = case lookupDef fun env of
               Nothing -> error $ unwords
                 [ "Internal bug. Error when attempting to gdef."
                 ,  "TODO: This ought to have been caught by type checking." ]

--- a/test/ksc/poly1.ks
+++ b/test/ksc/poly1.ks
@@ -1,0 +1,7 @@
+; Copyright (c) Microsoft Corporation.
+; Licensed under the MIT license.
+
+(def id [a] a ( x : a ) x)
+
+
+(def f Float () (id 0.0))


### PR DESCRIPTION
The big changes are these:

* A Type can now contain a type variable

* A top-level Def binds type variables, def_qvars :: [TyVar]

* The concrete syntax and parser supports polymorphic
  definitions. E.g. here is the identity function:
     (def id [a] a ( x : a ) x)

* In a Call, the TFun has a field tf_targs :: [Type], which
  are the types at which the function is instantiated. Of course
  tf_targs is usually empty.

* A BaseUserFun is contains an ArgTypeDescriptor, rather than
  a mere Type (as previosly):
      data ArgTypeDescriptor = Mono Type | Poly

  So we can can have BaseUserFuns like [f Int], [f Bool],
  but also [f poly].

* The GblSymTab can contain
    - either a polymorphic definition
    - or multiple monomorphic ones

   Its structure reflects this:
     type GblSymTab   = M.Map (DerivedFun BaseUserFunName)
                              FunBindings
     data FunBindings = PolyBind  TDef
                      | MonoBinds (M.Map Type TDef)

Everything else is driven by these changes in the data types.