### PR TITLE
Move shape transforms to Opt

### DIFF
--- a/knossos.cabal
+++ b/knossos.cabal
@@ -14,6 +14,7 @@ executable ksc
                  KMonad
                  Ksc.CatLang
                  Ksc.Futhark
+                 Ksc.Opt.Shape
                  Ksc.Pipeline
                  Ksc.SUF
                  Ksc.SUF.AD

--- a/src/ksc/Ksc/Opt/Shape.hs
+++ b/src/ksc/Ksc/Opt/Shape.hs
@@ -1,0 +1,46 @@
+module Ksc.Opt.Shape where
+
+import Lang
+import Prim
+import Shapes
+
+optShape :: TExpr -> Maybe TExpr
+
+optShape e
+  | Just unit <- shapeIsUnit_maybe (typeof e)
+  = Just unit
+
+optShape (Dummy ty)     = Just $ Dummy (Lang.shapeType ty)
+optShape (Assert e1 e2) = Just $ Assert e1 (pShape e2)
+optShape (Tuple es)     = Just $ Tuple (map pShape es)
+optShape (If b t e)     = Just $ If b (pShape t) (pShape e)
+
+optShape (Let (VarPat v) e1 e2) = Just $ Let (VarPat v) e1 (pShape e2)
+optShape (Let (TupPat p) e1 e2) = Just $ Let (TupPat p) e1 (pShape e2)
+
+optShape (Call (TFun _ (Fun JustFun (PrimFun p))) arg) = optShapePrim p arg
+optShape (Call (TFun ty (Fun ds f)) e) = Just $ Call (TFun (shapeType ty) (Fun (ShapeFun ds) f)) e
+optShape (Konst _)      = Nothing
+-- Shape of constant: should not occur as this is handled by the unit-shape case
+optShape Var{}          = Nothing
+-- Shape of Lam not supported
+optShape (Lam{})        = Nothing
+-- Shape of App not supported
+optShape (App{})        = Nothing
+
+optShapePrim :: PrimFun -> TExpr -> Maybe TExpr
+optShapePrim (P_SelFun i n) e = Just $ pSel i n (pShape e)
+optShapePrim P_index (Tuple [i, n]) = Just $ pIndex i (pShape n)
+optShapePrim P_build (Tuple [sz, Lam i e2]) = Just $ pBuild sz (Lam i (pShape e2))
+optShapePrim P_sumbuild (Tuple [sz, Lam i e2]) = Just $ mkLet i (mkZero sz) (pShape e2)
+optShapePrim P_sum v = Just $ pIndex (mkZero (pSize v)) (pShape v)
+optShapePrim P_constVec (Tuple [sz, v]) = Just $ pConstVec sz (pShape v)
+optShapePrim P_deltaVec (Tuple [sz, _i, v]) = Just $ pConstVec sz (pShape v)
+optShapePrim P_ts_add (Tuple [lhs, _]) = Just $ pShape lhs
+optShapePrim P_ts_scale (Tuple [_, v]) = Just $ pShape v
+optShapePrim P_ts_neg v = Just $ pShape v
+optShapePrim P_delta (Tuple [_, _, v]) = Just $ pShape v
+optShapePrim P_unzip v = Just $ pUnzip (pShape v)
+optShapePrim P_trace v = Just $ pShape v
+optShapePrim P_copydown v = Just $ pShape v
+optShapePrim _ _ = Nothing

--- a/src/ksc/Opt.hs
+++ b/src/ksc/Opt.hs
@@ -15,6 +15,7 @@ import Prim
 import Rules
 import OptLet
 import KMonad
+import Ksc.Opt.Shape ( optShape )
 import qualified Ksc.SUF.Rewrite as SUF
 import Ksc.Traversal( traverseState, mapAccumLM )
 
@@ -372,6 +373,7 @@ optPrimFun _ P_deltaVec (Tuple [n, _i, val])
   = Just $ pConstVec n val
 
 optPrimFun _ P_sum         arg           = optSum arg
+optPrimFun _ P_shape       arg           = optShape arg
 optPrimFun _ P_build       (Tuple [sz, Lam i e2]) = optBuild sz i e2
 optPrimFun _ P_sumbuild    (Tuple [sz, Lam i e2]) = optSumBuild sz i e2
 optPrimFun env P_lmApply   (Tuple [e1,e2])        = optLMApply env (AD BasicAD Fwd) e1 e2

--- a/src/ksc/Shapes.hs
+++ b/src/ksc/Shapes.hs
@@ -6,104 +6,26 @@
 module Shapes where
 
 import Lang
-import LangUtils
 import Prim
 import GHC.Stack
 import Data.Maybe(mapMaybe)
 
 shapeDefs :: HasCallStack => [TDef] -> [TDef]
-shapeDefs = mapMaybe (shapeDef . noTupPatifyDef)
+shapeDefs = mapMaybe shapeDef
 
 shapeDef :: HasCallStack => TDef -> Maybe TDef
 
-shapeDef (Def { def_fun = Fun ShapeFun{} _ })
-  = Nothing
-
 shapeDef (Def { def_fun = Fun ds f
-              , def_pat = VarPat params
+              , def_pat = params
               , def_rhs = UserRhs def_rhs
               , def_res_ty = res_ty })
   = Just $
     Def { def_fun    = Fun (ShapeFun ds) f
-        , def_pat    = VarPat params
+        , def_pat    = params
         , def_res_ty = shapeType res_ty
-        , def_rhs    = UserRhs (mkLetForShapeOfParameter params (shapeE def_rhs)) }
-
-shapeDef (Def { def_pat = TupPat {} })
-  -- TupPat should not appear.  See Note [Replacing TupPat with nested Let] in LangUtils
-  = error "shapeDef: TupPat encountered.\nThis should not occur."
+        , def_rhs    = UserRhs (pShape def_rhs) }
 
 shapeDef _ = Nothing
-
-
-{- Note [Variables in the shape transform]
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-For each variable v in the original function (including the function parameter),
-the shape transform generates two variables, v and varshape$v, such that
-varshape$v is the shape of v. Normally one of these variables will turn out to
-be unused, and will eventually be optimized away.
--}
-
-shapeVar :: TVar -> TVar
-shapeVar tv = mkTVar (shapeType (tVarType tv)) ("varshape$" ++ nameOfVar (tVarVar tv))
-
--- Generate a variable for the shape of the function parameter:
--- see note [Variables in the shape transform]
-mkLetForShapeOfParameter :: TVar -> TExpr -> TExpr
-mkLetForShapeOfParameter param = mkLet (shapeVar param) (pShape (Var param))
-
-shapeE :: HasCallStack => TExpr -> TExpr
-
-shapeE e
-  | Just unit <- shapeIsUnit_maybe (typeof e)
-  = unit
-
-shapeE (Konst _)      = error "Shape of constant: should not occur as this is handled by the unit-shape case"
-shapeE (Var tv)       = Var (shapeVar tv)
-shapeE (Dummy ty)     = Dummy (shapeType ty)
-shapeE (Assert e1 e2) = Assert e1 (shapeE e2)
-shapeE (Tuple es)     = Tuple (map shapeE es)
-shapeE (If b t e)     = If b (shapeE t) (shapeE e)
-
--- Shape of Let: see Note [Variables in the shape transform]
-shapeE (Let (VarPat v) e1 e2) = mkLets [(v, e1), (shapeVar v, shapeE e1)] (shapeE e2)
-shapeE (Let (TupPat _) _ _) = error "shapeE: TupPat should not occur"
-
-shapeE (Call tf e)    = shapeCall tf e
-shapeE (Lam{})        = error "Shape of lambda not supported"
-shapeE (App{})        = error "Shape of App not supported"
-
-
-shapeCall :: HasCallStack => TFun Typed -> TExpr -> TExpr
-
-shapeCall (TFun _ (Fun JustFun (PrimFun (P_SelFun i n)))) e
-  = pSel i n (shapeE e)
-
-shapeCall (TFun _ (Fun JustFun (PrimFun f))) e
-  | Just e' <- shapeCallPrim f e
-  = e'
-
-shapeCall (TFun ty (Fun ds f)) e
-  | isBaseUserFun f
-  = Call (TFun (shapeType ty) (Fun (ShapeFun ds) f)) e
-
-shapeCall tf e = pShape (Call tf e)  -- Fall back to calling the original function and evaluating the shape of the returned object
-
-shapeCallPrim :: HasCallStack => PrimFun -> TExpr -> Maybe TExpr
-shapeCallPrim P_index (Tuple [i, n]) = Just $ pIndex i (shapeE n)
-shapeCallPrim P_build (Tuple [sz, Lam i e2]) = Just $ pBuild sz (Lam i (shapeE e2))
-shapeCallPrim P_sumbuild (Tuple [sz, Lam i e2]) = Just $ mkLet i (mkZero sz) (shapeE e2)
-shapeCallPrim P_sum v = Just $ pIndex (mkZero (pSize v)) (shapeE v)
-shapeCallPrim P_constVec (Tuple [sz, v]) = Just $ pConstVec sz (shapeE v)
-shapeCallPrim P_deltaVec (Tuple [sz, _i, v]) = Just $ pConstVec sz (shapeE v)
-shapeCallPrim P_ts_add (Tuple [lhs, _]) = Just $ shapeE lhs
-shapeCallPrim P_ts_scale (Tuple [_, v]) = Just $ shapeE v
-shapeCallPrim P_ts_neg v = Just $ shapeE v
-shapeCallPrim P_delta (Tuple [_, _, v]) = Just $ shapeE v
-shapeCallPrim P_unzip v = Just $ pUnzip (shapeE v)
-shapeCallPrim P_trace v = Just $ shapeE v
-shapeCallPrim P_copydown v = Just $ shapeE v
-shapeCallPrim _ _ = Nothing
 
 -- Given a Type t, determines whether (shapeType t) is a unit type;
 -- if so then the unit value is returned.


### PR DESCRIPTION
This is what it looks like for the shape transforms to be implemented as optimisation rules (~needs https://github.com/microsoft/knossos-ksc/pull/738 to avoid a bug~ EDIT: already merged).

~Only draft at the moment because~

1. ~@awf I think you want these rules in a separate module, is that right?~
2. ~The rules depend on there being `shape$...` variables in scope. This will be the case if we are in the body of a generated `[shape ...]` function but not otherwise. I'm not sure how to deal with that.~

### Example output

```
(def
 [shape [rev [gmm_knossos_gmm_objective (Tuple (Vec (Vec Float))
                                               (Vec Float)
                                               (Vec (Vec Float))
                                               (Vec (Vec Float))
                                               (Vec (Vec Float))
                                               (Tuple Float Integer))]]] (Tuple (Vec (Vec (Tuple)))
                                                                                (Vec (Tuple))
                                                                                (Vec (Vec (Tuple)))
                                                                                (Vec (Vec (Tuple)))
                                                                                (Vec (Vec (Tuple)))
                                                                                (Tuple (Tuple)
                                                                                       (Tuple)))
 (_t1 : (Tuple (Tuple (Vec (Vec Float))
                      (Vec Float)
                      (Vec (Vec Float))
                      (Vec (Vec Float))
                      (Vec (Vec Float))
                      (Tuple Float Integer))
               Float))
 (let (_t (get$1$2 _t1))
  (let (x (get$1$6 _t))
   (let (t$8243 (get$5$6 _t))
    (let (t$8247 (size (index 0 x)))
     (let (t$8248 ([gmm_knossos_tri Integer] t$8247))
      (assert (eq (size (index 0 t$8243)) t$8248)
       (let (ksc$argVar (get$3$6 _t))
        (let (ksc$argVar_4 (get$4$6 _t))
         (tuple (constVec (size x) (constVec t$8247 (tuple)))
                (constVec (size (get$2$6 _t)) (tuple))
                (constVec (size ksc$argVar)
                          (constVec (size (index 0 ksc$argVar)) (tuple)))
                (constVec (size ksc$argVar_4)
                          (constVec (size (index 0 ksc$argVar_4)) (tuple)))
                (constVec (size t$8243) (constVec t$8248 (tuple)))
                (tuple (tuple) (tuple))))))))))))
```