### PR TITLE
Benchmark naming

### DIFF
--- a/src/bench/conftest.py
+++ b/src/bench/conftest.py
@@ -1,55 +1,87 @@
-# content of conftest.py
+# set up for global PyTest
 import pytest
 import importlib
 import inspect
+from collections import namedtuple
 
 from ts2ks import ts2mod
 
+
 def pytest_addoption(parser):
+    parser.addoption(
+        "--modulename", action="store", help="name of benchmark to dynamically load"
+    )
     parser.addoption(
         "--benchmarkname", action="store", help="name of benchmark to dynamically load"
     )
+
 
 @pytest.fixture
 def benchmarkname(request):
     return request.config.getoption("--benchmarkname")
 
 
+@pytest.fixture
+def modulename(request):
+    return request.config.getoption("--modulename")
+
+
+BenchmarkFunction = namedtuple("BenchmarkFunction", "name func")
+
+
+def functions_to_benchmark(mod, benchmark_name, example_input):
+    for fn in inspect.getmembers(
+        mod, lambda m: inspect.isfunction(m) and m.__name__.startswith(benchmark_name)
+    ):
+        fn_name, fn_obj = fn
+        if fn_name == benchmark_name + "_bench_configs":
+            continue
+        elif fn_name == benchmark_name + "_pytorch":
+            yield BenchmarkFunction("PyTorch", fn_obj)
+        elif fn_name == benchmark_name + "_pytorch_nice":
+            yield BenchmarkFunction("PyTorch Nice", fn_obj)
+        elif fn_name == benchmark_name:
+            yield BenchmarkFunction("Knossos", ts2mod(fn_obj, example_input).apply)
+        else:
+            # perhaps we should just allow anything that matches the pattern?
+            # would make it easier to add arbitrary comparisons e.g. TF
+            print(f"Ignoring {fn_name}")
+
+
+def func_namer(benchmark_func):
+    return benchmark_func.name
+
+
+def config_namer(config):
+    return str(config.shape)
+
+
 def pytest_generate_tests(metafunc):
     if "func" in metafunc.fixturenames:
 
-        benchmark_name = metafunc.config.getoption('benchmarkname')
+        module_name = metafunc.config.getoption("benchmarkname")
+        benchmark_name = metafunc.config.getoption("benchmarkname")
 
-        mod = importlib.import_module(benchmark_name)
+        mod = importlib.import_module(module_name)
 
-        functions_to_benchmark = []
+        configs = list(getattr(mod, benchmark_name + "_bench_configs")())
 
-        for fn in inspect.getmembers(mod, inspect.isfunction):
-            fn_name, fn_obj = fn
-            if fn_name == benchmark_name + '_bench_configs':
-                configs = list(fn_obj())
-            elif fn_name == benchmark_name + '_pytorch':
-                pt_fast = fn_obj
-                functions_to_benchmark.append(pt_fast)
-            elif fn_name == benchmark_name + '_pytorch_nice':
-                pt_nice = fn_obj
-                functions_to_benchmark.append(pt_nice)
-            elif fn_name == benchmark_name:
-                ks_fun = fn_obj
-                functions_to_benchmark.append(ks_fun)
-            else:
-                print(f"Ignoring {fn_name}")
+        example_inputs = (configs[0],)
 
-        ks_compiled = ts2mod(ks_fun, example_inputs=(configs[0],))
-        functions_to_benchmark.append(ks_compiled.apply)
-
-        metafunc.parametrize("func", functions_to_benchmark)
+        metafunc.parametrize(
+            "func",
+            functions_to_benchmark(mod, benchmark_name, example_inputs),
+            ids=func_namer,
+        )
 
         # We want to group by tensor size, it's not clear how to metaprogram the group mark cleanly.
         # pytest meta programming conflates arguments and decoration. I've not been able to find a way to directly
         # parameterize just marks so do the mark along with a oarameter
-        config_and_group_marker = [pytest.param(config, marks=[pytest.mark.benchmark(group=str(config.shape))]) for config in configs]
-        metafunc.parametrize("config", config_and_group_marker)
+        config_and_group_marker = [
+            pytest.param(config, marks=[pytest.mark.benchmark(group=str(config.shape))])
+            for config in configs
+        ]
+        metafunc.parametrize("config", config_and_group_marker, ids=config_namer)
 
         # Alternative use a dummy argument --benchmark-group-by=param:dummy_argument but messes with serialised versions and is just horrible
 

--- a/src/bench/run-all-pytest-bench.sh
+++ b/src/bench/run-all-pytest-bench.sh
@@ -2,4 +2,4 @@
 # BENCH=src/bench/run-bench.py
 
 #PYTHONPATH=examples/dl-activations python $BENCH relu3 vrelu3 
-PYTHONPATH=examples/dl-capsule pytest src/bench/ --benchmarkname=sqrl --benchmark-autosave
+PYTHONPATH=examples/dl-capsule pytest src/bench/ --modulename=sqrl --benchmarkname=sqrl --benchmark-autosave

--- a/src/bench/test_run_bench.py
+++ b/src/bench/test_run_bench.py
@@ -1,5 +1,6 @@
 import pytest
 
+
 def test_benchmark(benchmark, func, config):
     # any assertion we can make about result?
-    result = benchmark(func, config)
+    result = benchmark(func.func, config)


### PR DESCRIPTION
```
---------------------------------------------------------------------------------------- benchmark 'torch.Size([4, 4])': 3 tests -----------------------------------------------------------------------------------------
Name (time in us)                                       Min                 Max               Mean             StdDev             Median               IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_benchmark[PyTorch Nice-torch.Size([4, 4])]     20.2000 (1.0)      362.3000 (4.56)     22.3558 (1.0)       8.5155 (1.0)      21.0000 (1.0)      1.4000 (1.0)       315;477       44.7312 (1.0)       11919           1
test_benchmark[PyTorch-torch.Size([4, 4])]          22.1000 (1.09)      79.4000 (1.0)      26.3619 (1.18)     12.4406 (1.46)     23.3000 (1.11)     1.5250 (1.09)          1;3       37.9335 (0.85)         21           1
test_benchmark[Knossos-torch.Size([4, 4])]          27.0000 (1.34)     372.7000 (4.69)     38.6269 (1.73)     35.8527 (4.21)     31.2000 (1.49)     6.8750 (4.91)         6;19       25.8887 (0.58)        167           1
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

Also allow separate module naming