### PR TITLE
Explicit imports

### DIFF
--- a/src/ksc/Prim.hs
+++ b/src/ksc/Prim.hs
@@ -8,8 +8,8 @@ module Prim where
 
 import Lang
 import LangUtils (isTrivial)
-import GHC.Stack
-import Data.Maybe
+import GHC.Stack (HasCallStack)
+import Data.Maybe (isJust)
 import Control.Monad (zipWithM)
 
 --------------------------------------------


### PR DESCRIPTION
Is it OK to make these imports explicit? I prefer people not to wonder where identifiers come from.