### PR TITLE
Use AzCopy to store benchmark results to blob storage

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -4,9 +4,6 @@ on:
   schedule:
     - cron:  '5 3 * * *'
 
-  push:
-    branches: [cogravil/benchmarkresults]
-
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The action stores the benchmark result to the artifact. However, that's not convenient (or performant) to aggregate.

Also copy the result to blob storage which can then be used.