### PR TITLE
Remove tuple AD?

### DIFF
--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -286,7 +286,7 @@ separate into four categories:
  * **Maths**: `log, exp, sin, cos, max, min, abs` for `Float`
  * **Type Conversion**: `to_float` for `Integer`
 
-Compilers will also generate their auto derivative, appending `D$` or `Dt$` to
+Compilers will also generate their auto derivative, appending `D$` to
 their names, but those should be used by the compiler only during
 auto-derivation.
 

--- a/doc/sphinx/SYNTAX.md
+++ b/doc/sphinx/SYNTAX.md
@@ -286,7 +286,7 @@ separate into four categories:
  * **Maths**: `log, exp, sin, cos, max, min, abs` for `Float`
  * **Type Conversion**: `to_float` for `Integer`
 
-Compilers will also generate their auto derivative, appending `D$` or `Dt$` to
+Compilers will also generate their auto derivative, appending `D$` to
 their names, but those should be used by the compiler only during
 auto-derivation.
 

--- a/examples/ml-gmm/gmm-buildfromsparse.ks
+++ b/examples/ml-gmm/gmm-buildfromsparse.ks
@@ -11,16 +11,11 @@
  [rev [to_float Integer]] (Tuple)
  ((x : Integer) (d_dto_float : Float))
  (tuple))
-(edef
- [Dt [to_float Integer]]
- (Tuple Float (LM Integer Float))
- (Integer))
 (def [not Bool] Bool (p : Bool) (if p false true))
 (def [fwd [not Bool]] (Tuple) (_t1 : (Tuple Bool (Tuple))) (tuple))
 (def [rev [not Bool]] (Tuple) (_t1 : (Tuple Bool (Tuple))) (tuple))
 (edef [neg Float] Float (Float))
 (edef [D [neg Float]] (LM Float Float) (Float))
-(edef [Dt [neg Float]] (Tuple Float (LM Float Float)) (Float))
 (def
  [fwd [neg Float]] Float
  ((x : Float) (dx : Float))
@@ -31,10 +26,6 @@
  ([neg Float] d_dneg))
 (edef [neg Integer] Integer (Integer))
 (edef [D [neg Integer]] (LM Integer Integer) (Integer))
-(edef
- [Dt [neg Integer]]
- (Tuple Integer (LM Integer Integer))
- (Integer))
 (def
  [fwd [neg Integer]] (Tuple)
  ((x : Integer) (dx : (Tuple)))
@@ -47,10 +38,6 @@
 (edef
  [D [add (Tuple Float Float)]]
  (LM (Tuple Float Float) Float)
- ((Tuple Float Float)))
-(edef
- [Dt [add (Tuple Float Float)]]
- (Tuple Float (LM (Tuple Float Float) Float))
  ((Tuple Float Float)))
 (def
  [fwd [add (Tuple Float Float)]] Float
@@ -68,10 +55,6 @@
  [D [add (Tuple Integer Integer)]]
  (LM (Tuple Integer Integer) Integer)
  ((Tuple Integer Integer)))
-(edef
- [Dt [add (Tuple Integer Integer)]]
- (Tuple Integer (LM (Tuple Integer Integer) Integer))
- ((Tuple Integer Integer)))
 (def
  [fwd [add (Tuple Integer Integer)]] (Tuple)
  ((xt : (Tuple Integer Integer)) (dxt : (Tuple (Tuple) (Tuple))))
@@ -84,10 +67,6 @@
 (edef
  [D [sub (Tuple Float Float)]]
  (LM (Tuple Float Float) Float)
- ((Tuple Float Float)))
-(edef
- [Dt [sub (Tuple Float Float)]]
- (Tuple Float (LM (Tuple Float Float) Float))
  ((Tuple Float Float)))
 (def
  [fwd [sub (Tuple Float Float)]] Float
@@ -104,10 +83,6 @@
 (edef
  [D [sub (Tuple Integer Integer)]]
  (LM (Tuple Integer Integer) Integer)
- ((Tuple Integer Integer)))
-(edef
- [Dt [sub (Tuple Integer Integer)]]
- (Tuple Integer (LM (Tuple Integer Integer) Integer))
  ((Tuple Integer Integer)))
 (def
  [fwd [sub (Tuple Integer Integer)]] (Tuple)
@@ -201,10 +176,6 @@
  [D [mul (Tuple Float Float)]]
  (LM (Tuple Float Float) Float)
  ((Tuple Float Float)))
-(edef
- [Dt [mul (Tuple Float Float)]]
- (Tuple Float (LM (Tuple Float Float) Float))
- ((Tuple Float Float)))
 (def
  [fwd [mul (Tuple Float Float)]] Float
  ((xt : (Tuple Float Float)) (dxt : (Tuple Float Float)))
@@ -227,10 +198,6 @@
 (edef
  [D [mul (Tuple Integer Integer)]]
  (LM (Tuple Integer Integer) Integer)
- ((Tuple Integer Integer)))
-(edef
- [Dt [mul (Tuple Integer Integer)]]
- (Tuple Integer (LM (Tuple Integer Integer) Integer))
  ((Tuple Integer Integer)))
 (def
  [fwd [mul (Tuple Integer Integer)]] (Tuple)
@@ -261,11 +228,6 @@
  [D [mul (Tuple (Tensor 2 Float) (Vec Float))]]
  (LM (Tuple (Tensor 2 Float) (Vec Float)) (Vec Float))
  ((Tuple (Tensor 2 Float) (Vec Float))))
-(edef
- [Dt [mul (Tuple (Tensor 2 Float) (Vec Float))]]
- (Tuple (Vec Float)
-        (LM (Tuple (Tensor 2 Float) (Vec Float)) (Vec Float)))
- ((Tuple (Tensor 2 Float) (Vec Float))))
 (def
  [fwd [mul (Tuple (Tensor 2 Float) (Vec Float))]] (Vec Float)
  ((M_v : (Tuple (Tensor 2 Float) (Vec Float)))
@@ -283,10 +245,6 @@
 (edef
  [D [div (Tuple Float Float)]]
  (LM (Tuple Float Float) Float)
- ((Tuple Float Float)))
-(edef
- [Dt [div (Tuple Float Float)]]
- (Tuple Float (LM (Tuple Float Float) Float))
  ((Tuple Float Float)))
 (def
  [fwd [div (Tuple Float Float)]] Float
@@ -315,10 +273,6 @@
  [D [div (Tuple Integer Integer)]]
  (LM (Tuple Integer Integer) Integer)
  ((Tuple Integer Integer)))
-(edef
- [Dt [div (Tuple Integer Integer)]]
- (Tuple Integer (LM (Tuple Integer Integer) Integer))
- ((Tuple Integer Integer)))
 (def
  [fwd [div (Tuple Integer Integer)]] (Tuple)
  ((xt : (Tuple Integer Integer)) (dxt : (Tuple (Tuple) (Tuple))))
@@ -331,10 +285,6 @@
 (edef
  [D [pow (Tuple Float Integer)]]
  (LM (Tuple Float Integer) Float)
- ((Tuple Float Integer)))
-(edef
- [Dt [pow (Tuple Float Integer)]]
- (Tuple Float (LM (Tuple Float Integer) Float))
  ((Tuple Float Integer)))
 (def
  [fwd [pow (Tuple Float Integer)]] Float
@@ -360,10 +310,6 @@
  [D [gt (Tuple Float Float)]]
  (LM (Tuple Float Float) Bool)
  ((Tuple Float Float)))
-(edef
- [Dt [gt (Tuple Float Float)]]
- (Tuple Bool (LM (Tuple Float Float) Bool))
- ((Tuple Float Float)))
 (def
  [fwd [gt (Tuple Float Float)]] (Tuple)
  ((xt : (Tuple Float Float)) (dxt : (Tuple Float Float)))
@@ -376,10 +322,6 @@
 (edef
  [D [gt (Tuple Integer Integer)]]
  (LM (Tuple Integer Integer) Bool)
- ((Tuple Integer Integer)))
-(edef
- [Dt [gt (Tuple Integer Integer)]]
- (Tuple Bool (LM (Tuple Integer Integer) Bool))
  ((Tuple Integer Integer)))
 (def
  [fwd [gt (Tuple Integer Integer)]] (Tuple)
@@ -394,10 +336,6 @@
  [D [lt (Tuple Float Float)]]
  (LM (Tuple Float Float) Bool)
  ((Tuple Float Float)))
-(edef
- [Dt [lt (Tuple Float Float)]]
- (Tuple Bool (LM (Tuple Float Float) Bool))
- ((Tuple Float Float)))
 (def
  [fwd [lt (Tuple Float Float)]] (Tuple)
  ((xt : (Tuple Float Float)) (dxt : (Tuple Float Float)))
@@ -410,10 +348,6 @@
 (edef
  [D [lt (Tuple Integer Integer)]]
  (LM (Tuple Integer Integer) Bool)
- ((Tuple Integer Integer)))
-(edef
- [Dt [lt (Tuple Integer Integer)]]
- (Tuple Bool (LM (Tuple Integer Integer) Bool))
  ((Tuple Integer Integer)))
 (def
  [fwd [lt (Tuple Integer Integer)]] (Tuple)
@@ -428,10 +362,6 @@
  [D [lte (Tuple Float Float)]]
  (LM (Tuple Float Float) Bool)
  ((Tuple Float Float)))
-(edef
- [Dt [lte (Tuple Float Float)]]
- (Tuple Bool (LM (Tuple Float Float) Bool))
- ((Tuple Float Float)))
 (def
  [fwd [lte (Tuple Float Float)]] (Tuple)
  ((xt : (Tuple Float Float)) (dxt : (Tuple Float Float)))
@@ -444,10 +374,6 @@
 (edef
  [D [lte (Tuple Integer Integer)]]
  (LM (Tuple Integer Integer) Bool)
- ((Tuple Integer Integer)))
-(edef
- [Dt [lte (Tuple Integer Integer)]]
- (Tuple Bool (LM (Tuple Integer Integer) Bool))
  ((Tuple Integer Integer)))
 (def
  [fwd [lte (Tuple Integer Integer)]] (Tuple)
@@ -462,10 +388,6 @@
  [D [gte (Tuple Float Float)]]
  (LM (Tuple Float Float) Bool)
  ((Tuple Float Float)))
-(edef
- [Dt [gte (Tuple Float Float)]]
- (Tuple Bool (LM (Tuple Float Float) Bool))
- ((Tuple Float Float)))
 (def
  [fwd [gte (Tuple Float Float)]] (Tuple)
  ((xt : (Tuple Float Float)) (dxt : (Tuple Float Float)))
@@ -478,10 +400,6 @@
 (edef
  [D [gte (Tuple Integer Integer)]]
  (LM (Tuple Integer Integer) Bool)
- ((Tuple Integer Integer)))
-(edef
- [Dt [gte (Tuple Integer Integer)]]
- (Tuple Bool (LM (Tuple Integer Integer) Bool))
  ((Tuple Integer Integer)))
 (def
  [fwd [gte (Tuple Integer Integer)]] (Tuple)
@@ -501,7 +419,6 @@
  [rev [log Float]] Float
  ((x : Float) (d_dlog : Float))
  ([div (Tuple Float Float)] d_dlog x))
-(edef [Dt [log Float]] (Tuple Float (LM Float Float)) (Float))
 (edef [exp Float] Float (Float))
 (edef [D [exp Float]] (LM Float Float) (Float))
 (def
@@ -512,7 +429,6 @@
  [rev [exp Float]] Float
  ((x : Float) (d_dexp : Float))
  ([mul (Tuple Float Float)] ([exp Float] x) d_dexp))
-(edef [Dt [exp Float]] (Tuple Float (LM Float Float)) (Float))
 (def
  [exp (Vec Float)] (Vec Float)
  (v : Vec Float)
@@ -546,7 +462,6 @@
  [rev [sin Float]] Float
  ((x : Float) (d_dsin : Float))
  ([mul (Tuple Float Float)] ([cos Float] x) d_dsin))
-(edef [Dt [sin Float]] (Tuple Float (LM Float Float)) (Float))
 (edef [D [cos Float]] (LM Float Float) (Float))
 (def
  [fwd [cos Float]] Float
@@ -556,7 +471,6 @@
  [rev [cos Float]] Float
  ((x : Float) (d_dcos : Float))
  ([neg Float] ([mul (Tuple Float Float)] ([sin Float] x) d_dcos)))
-(edef [Dt [cos Float]] (Tuple Float (LM Float Float)) (Float))
 (edef [cosh Float] Float (Float))
 (edef [tanh Float] Float (Float))
 (def
@@ -574,23 +488,14 @@
   ([div (Tuple Float Float)] d_dr
                              ([mul (Tuple Float Float)] cosh_x cosh_x))))
 (edef [D [tanh Float]] (LM Float Float) (Float))
-(edef [Dt [tanh Float]] (Tuple Float (LM Float Float)) (Float))
 (edef [max (Tuple Float Float)] Float ((Tuple Float Float)))
 (edef
  [D [max (Tuple Float Float)]]
  (LM (Tuple Float Float) Float)
  ((Tuple Float Float)))
-(edef
- [Dt [max (Tuple Float Float)]]
- (Tuple Float (LM (Tuple Float Float) Float))
- ((Tuple Float Float)))
 (edef [imax (Vec Float)] Integer ((Vec Float)))
 (edef [max (Vec Float)] Float ((Vec Float)))
 (edef [D [max (Vec Float)]] (LM (Vec Float) Float) ((Vec Float)))
-(edef
- [Dt [max (Vec Float)]]
- (Tuple Float (LM (Vec Float) Float))
- ((Vec Float)))
 (def
  [fwd [max (Vec Float)]] Float
  ((x : Vec Float) (dx : Vec Float))
@@ -609,10 +514,6 @@
  [rev [$ranhashdoub Integer]] (Tuple)
  ((x : Integer) (d_dranhashdoub : Float))
  (tuple))
-(edef
- [Dt [$ranhashdoub Integer]]
- (Tuple Float (LM Integer Float))
- (Integer))
 (edef [abs Float] Float (Float))
 (edef [D [abs Float]] (LM Float Float) (Float))
 (def
@@ -623,20 +524,14 @@
  [rev [abs Float]] Float
  ((x : Float) (d_dabs : Float))
  (if ([gt (Tuple Float Float)] x 0.0) d_dabs ([neg Float] d_dabs)))
-(edef [Dt [abs Float]] (Tuple Float (LM Float Float)) (Float))
 (edef [lgamma Float] Float (Float))
 (edef [D [lgamma Float]] (LM Float Float) (Float))
 (edef [fwd [lgamma Float]] Float ((Tuple Float Float)))
 (edef [rev [lgamma Float]] Float ((Tuple Float Float)))
-(edef [Dt [lgamma Float]] (Tuple Float (LM Float Float)) (Float))
 (edef [or (Tuple Bool Bool)] Bool ((Tuple Bool Bool)))
 (edef
  [D [or (Tuple Bool Bool)]]
  (LM (Tuple Bool Bool) Bool)
- ((Tuple Bool Bool)))
-(edef
- [Dt [or (Tuple Bool Bool)]]
- (Tuple Bool (LM (Tuple Bool Bool) Bool))
  ((Tuple Bool Bool)))
 (def
  [fwd [or (Tuple Bool Bool)]] (Tuple)
@@ -650,10 +545,6 @@
 (edef
  [D [and (Tuple Bool Bool)]]
  (LM (Tuple Bool Bool) Bool)
- ((Tuple Bool Bool)))
-(edef
- [Dt [and (Tuple Bool Bool)]]
- (Tuple Bool (LM (Tuple Bool Bool) Bool))
  ((Tuple Bool Bool)))
 (def
  [fwd [and (Tuple Bool Bool)]] (Tuple)
@@ -698,10 +589,6 @@
 (edef
  [D [dot (Tuple (Vec Float) (Vec Float))]]
  (LM (Tuple (Vec Float) (Vec Float)) Float)
- ((Tuple (Vec Float) (Vec Float))))
-(edef
- [Dt [dot (Tuple (Vec Float) (Vec Float))]]
- (Tuple Float (LM (Tuple (Vec Float) (Vec Float)) Float))
  ((Tuple (Vec Float) (Vec Float))))
 (edef
  [R$dot (Tuple (Vec Float) (Vec Float))]

--- a/rlo/src/rlo/ksc/gmm/gmm_template.kso
+++ b/rlo/src/rlo/ksc/gmm/gmm_template.kso
@@ -28,10 +28,6 @@
  (LM (Tuple (Vec Float) (Vec Float)) Float)
  ((Vec Float) (Vec Float)))
 (edef
- Dt$dotv
- (Tuple Float (LM (Tuple (Vec Float) (Vec Float)) Float))
- ((Vec Float) (Vec Float)))
-(edef
  R$dotv
  (LM Float (Tuple (Vec Float) (Vec Float)))
  ((Vec Float) (Vec Float)))
@@ -47,7 +43,6 @@
 (edef D$lgamma (LM Float Float) (Float))
 (edef fwd$lgamma Float (Float Float))
 (edef rev$lgamma Float (Float Float))
-(edef Dt$lgamma (Tuple Float (LM Float Float)) (Float))
 (def
  dotvv Float
  ((a : Vec (Vec Float)) (b : Vec (Vec Float)))
@@ -58,11 +53,6 @@
 (edef
  D$mul$Mat$Vec
  (LM (Tuple (Vec (Vec Float)) (Vec Float)) (Vec Float))
- ((Vec (Vec Float)) (Vec Float)))
-(edef
- Dt$mul$Mat$Vec
- (Tuple (Vec Float)
-        (LM (Tuple (Vec (Vec Float)) (Vec Float)) (Vec Float)))
  ((Vec (Vec Float)) (Vec Float)))
 (edef
  R$mul$Mat$Vec

--- a/src/f2k/Knossos.ks
+++ b/src/f2k/Knossos.ks
@@ -10,7 +10,6 @@
 
 (edef maximum Float ((Vec Float)))
 (edef D$maximum (LM (Vec Float) Float) ((Vec Float)))
-(edef Dt$maximum (Tuple Float (LM (Vec Float) Float)) ((Vec Float)))
 (edef fwd$maximum Float (Tuple (Vec Float) (Vec Float)))
 (edef rev$maximum (Vec Float) (Tuple (Vec Float) Float))
 
@@ -18,14 +17,12 @@
 (edef D$lgamma (LM Float Float) (Float))
 (edef fwd$lgamma Float (Tuple Float Float))
 (edef rev$lgamma Float (Tuple Float Float))
-(edef Dt$lgamma (Tuple Float (LM Float Float)) (Float))
 
 (def gammaLn Float (x : Float)
    (lgamma x))
 
 (edef pow@Float Float (Tuple (Float) (Float)))
 (edef D$pow@Float (LM (Tuple Float Float) Float) (Tuple Float Float))
-(edef Dt$pow@Float (Tuple Float (LM (Tuple Float Float) Float)) (Tuple Float Float))
 (edef fwd$pow@Float Float (Tuple (Tuple Float Float) (Tuple Float Float)))
 (edef rev$pow@Float (Tuple Float Float) (Tuple (Tuple Float Float) Float))
 

--- a/src/ksc/Ksc/AD.hs
+++ b/src/ksc/Ksc/AD.hs
@@ -241,7 +241,7 @@ applyD dir def@(Def { def_pat = TupPat {} })
 -- fwd$f  :: (S1, S2) (dS1, dS2) -> dT
 applyD Fwd (Def { def_fun = Fun GradFun f, def_res_ty = res_ty
                 , def_pat = VarPat x, def_rhs = UserRhs rhs })
-  = Def { def_fun    = Fun (DrvFun (AD Fwd)) f
+  = Def { def_fun    = Fun (DrvFun Fwd) f
         , def_pat   = VarPat x_dx
         , def_rhs    = UserRhs $ extract2args $ perhapsFstToo $ lmApply lm $ Var dx
         , def_res_ty = t }
@@ -267,7 +267,7 @@ applyD Fwd (Def { def_fun = Fun GradFun f, def_res_ty = res_ty
 -- rev$f :: (S1, S2) dT -> (dS1,dS2)
 applyD Rev (Def { def_fun = Fun GradFun f, def_res_ty = res_ty
                 , def_pat = VarPat x, def_rhs = UserRhs rhs })
-  = Def { def_fun    = Fun (DrvFun (AD Rev)) f
+  = Def { def_fun    = Fun (DrvFun Rev) f
         , def_pat    = VarPat x_dr
         , def_rhs    = UserRhs $ extract2args $ lmApplyR (Var dr) lm
         , def_res_ty = tangentType (typeof x) }

--- a/src/ksc/Ksc/Cgen.hs
+++ b/src/ksc/Ksc/Cgen.hs
@@ -627,8 +627,6 @@ cgenFun cgenBaseFun f = case f of
   Fun GradFun{}  s  -> "D$" ++ cgenBaseFun s
   Fun (DrvFun (AD BasicAD Fwd)) s -> "fwd$" ++ cgenBaseFun s
   Fun (DrvFun (AD BasicAD Rev)) s -> "rev$" ++ cgenBaseFun s
-  Fun (DrvFun (AD TupleAD Fwd)) s -> "fwdt$" ++ cgenBaseFun s
-  Fun (DrvFun (AD TupleAD Rev)) s -> "revt$" ++ cgenBaseFun s
   Fun (ShapeFun ds) ff   -> "shape$" ++ cgenFun cgenBaseFun (Fun ds ff)
   Fun CLFun s       -> "CL$" ++ cgenBaseFun s
   Fun SUFFwdPass s  -> "suffwdpass$" ++ cgenBaseFun s

--- a/src/ksc/Ksc/Cgen.hs
+++ b/src/ksc/Ksc/Cgen.hs
@@ -625,8 +625,8 @@ cgenFun :: HasCallStack
 cgenFun cgenBaseFun f = case f of
   Fun JustFun baseFun   -> cgenBaseFun baseFun
   Fun GradFun{}  s  -> "D$" ++ cgenBaseFun s
-  Fun (DrvFun (AD Fwd)) s -> "fwd$" ++ cgenBaseFun s
-  Fun (DrvFun (AD Rev)) s -> "rev$" ++ cgenBaseFun s
+  Fun (DrvFun Fwd) s -> "fwd$" ++ cgenBaseFun s
+  Fun (DrvFun Rev) s -> "rev$" ++ cgenBaseFun s
   Fun (ShapeFun ds) ff   -> "shape$" ++ cgenFun cgenBaseFun (Fun ds ff)
   Fun CLFun s       -> "CL$" ++ cgenBaseFun s
   Fun SUFFwdPass s  -> "suffwdpass$" ++ cgenBaseFun s

--- a/src/ksc/Ksc/Cgen.hs
+++ b/src/ksc/Ksc/Cgen.hs
@@ -625,8 +625,8 @@ cgenFun :: HasCallStack
 cgenFun cgenBaseFun f = case f of
   Fun JustFun baseFun   -> cgenBaseFun baseFun
   Fun GradFun{}  s  -> "D$" ++ cgenBaseFun s
-  Fun (DrvFun (AD BasicAD Fwd)) s -> "fwd$" ++ cgenBaseFun s
-  Fun (DrvFun (AD BasicAD Rev)) s -> "rev$" ++ cgenBaseFun s
+  Fun (DrvFun (AD Fwd)) s -> "fwd$" ++ cgenBaseFun s
+  Fun (DrvFun (AD Rev)) s -> "rev$" ++ cgenBaseFun s
   Fun (ShapeFun ds) ff   -> "shape$" ++ cgenFun cgenBaseFun (Fun ds ff)
   Fun CLFun s       -> "CL$" ++ cgenBaseFun s
   Fun SUFFwdPass s  -> "suffwdpass$" ++ cgenBaseFun s

--- a/src/ksc/Ksc/Lang.hs
+++ b/src/ksc/Ksc/Lang.hs
@@ -83,7 +83,7 @@ isUserDef :: DefX p -> Bool
 isUserDef (Def { def_rhs = UserRhs {} }) = True
 isUserDef _ = False
 
-data Derivation = DerivationDrvFun ADMode
+data Derivation = DerivationDrvFun ADDir
                 | DerivationCLFun
                 | DerivationShapeFun
                 | DerivationSUFFwdPass
@@ -418,7 +418,7 @@ pattern PrimFunT p <- BaseFunId (BasePrimFunName p) _
 data Derivations
   = JustFun        -- The function              f(x)
   | GradFun        -- Full Jacobian Df(x)
-  | DrvFun ADMode  -- Derivative derivative f'(x,dx)
+  | DrvFun ADDir   -- Derivative derivative f'(x,dx)
                    --   Rev <=> reverse mode f`(x,dr)
   | CLFun          -- f(x), roundtripped through CatLang
   | ShapeFun Derivations
@@ -504,8 +504,6 @@ isSelFun = \case
 
 baseFunOfFun :: Fun p -> BaseFun p
 baseFunOfFun (Fun _ baseFun) = baseFun
-
-type ADMode = ADDir
 
 data ADDir = Fwd | Rev
   deriving( Eq, Ord, Show )

--- a/src/ksc/Ksc/Lang.hs
+++ b/src/ksc/Ksc/Lang.hs
@@ -505,8 +505,7 @@ isSelFun = \case
 baseFunOfFun :: Fun p -> BaseFun p
 baseFunOfFun (Fun _ baseFun) = baseFun
 
-data ADMode = AD { adDir :: ADDir }
-  deriving( Eq, Ord, Show )
+type ADMode = ADDir
 
 data ADDir = Fwd | Rev
   deriving( Eq, Ord, Show )
@@ -931,9 +930,6 @@ instance Pretty a => Pretty (Maybe a) where
 instance (Pretty a, Pretty b) => Pretty (a,b) where
   ppr (x,y) = parens (sep [ ppr x <> comma, ppr y])
 
-instance Pretty ADMode where
-  ppr (AD p) = ppr p
-
 instance Pretty ADDir where
   ppr Fwd = char 'f'
   ppr Rev = char 'r'
@@ -1031,8 +1027,8 @@ pprUserFun = pprDerivedFun (pprBaseUserFun @p)
 pprDerivedFun :: (BaseFunId funid p -> SDoc) -> DerivedFun funid p -> SDoc
 pprDerivedFun f (Fun JustFun s)               = f s
 pprDerivedFun f (Fun GradFun   s)             = brackets (char 'D'   <+> f s)
-pprDerivedFun f (Fun (DrvFun   (AD Fwd)) s)   = brackets (text "fwd" <+> f s)
-pprDerivedFun f (Fun (DrvFun   (AD Rev)) s)   = brackets (text "rev" <+> f s)
+pprDerivedFun f (Fun (DrvFun   Fwd) s)        = brackets (text "fwd" <+> f s)
+pprDerivedFun f (Fun (DrvFun   Rev) s)        = brackets (text "rev" <+> f s)
 pprDerivedFun f (Fun (ShapeFun ds) sf)             = brackets (text "shape" <+> pprDerivedFun f (Fun ds sf))
 pprDerivedFun f (Fun CLFun    s)              = brackets (text "CL" <+> f s)
 pprDerivedFun f (Fun SUFFwdPass s)            = brackets (text "suffwdpass" <+> f s)
@@ -1170,8 +1166,8 @@ instance Pretty GDefX where
 
 instance Pretty Derivation where
   ppr = \case
-    DerivationDrvFun (AD Fwd) -> text "fwd"
-    DerivationDrvFun (AD Rev) -> text "rev"
+    DerivationDrvFun Fwd -> text "fwd"
+    DerivationDrvFun Rev -> text "rev"
     DerivationCLFun    -> text "CL"
     DerivationShapeFun -> text "shape"
     DerivationSUFFwdPass -> text "suffwdpass"

--- a/src/ksc/Ksc/Lang.hs
+++ b/src/ksc/Ksc/Lang.hs
@@ -34,12 +34,10 @@ import           Test.Hspec
 
 mkGradType :: ADPlan -> Type -> Type -> Type
 mkGradType BasicAD s ty = TypeLM s ty
-mkGradType TupleAD s ty = TypeTuple [ty, TypeLM s ty]
   -- For TupleAD, mkGradType s t = (t, s -o t)
 
 mkGradTuple :: ADPlan -> TExpr -> TExpr -> TExpr
 mkGradTuple BasicAD _ lm = lm
-mkGradTuple TupleAD p lm = Tuple [p, lm]
 
 data Phase = Parsed | Typed | OccAnald
 
@@ -510,7 +508,7 @@ baseFunOfFun (Fun _ baseFun) = baseFun
 data ADMode = AD { adPlan :: ADPlan, adDir :: ADDir }
   deriving( Eq, Ord, Show )
 
-data ADPlan = BasicAD | TupleAD
+data ADPlan = BasicAD
   deriving( Eq, Ord, Show )
 
 data ADDir = Fwd | Rev
@@ -945,7 +943,6 @@ instance Pretty ADDir where
 
 instance Pretty ADPlan where
   ppr BasicAD = empty
-  ppr TupleAD = char 't'
 
 instance Pretty Var where
   ppr (Simple s) = text s
@@ -1181,8 +1178,6 @@ instance Pretty Derivation where
   ppr = \case
     DerivationDrvFun (AD BasicAD Fwd) -> text "fwd"
     DerivationDrvFun (AD BasicAD Rev) -> text "rev"
-    DerivationDrvFun (AD TupleAD Fwd) -> text "fwdt"
-    DerivationDrvFun (AD TupleAD Rev) -> text "revt"
     DerivationCLFun    -> text "CL"
     DerivationShapeFun -> text "shape"
     DerivationSUFFwdPass -> text "suffwdpass"

--- a/src/ksc/Ksc/LangUtils.hs
+++ b/src/ksc/Ksc/LangUtils.hs
@@ -267,7 +267,7 @@ notInScope v in_scope
     (str, rebuild) = case v of
             Simple s -> (s, Simple)
             Delta  s -> (s, Delta)
-            Grad s m -> (s, \s' -> Grad s' m)
+            Grad s   -> (s, Grad)
 
     try :: Int -> Var
     try n | var' `S.member` in_scope = try (n+1)

--- a/src/ksc/Ksc/Opt.hs
+++ b/src/ksc/Ksc/Opt.hs
@@ -756,7 +756,7 @@ optGradPrim _ f     a = optTrace("No opt for grad of prim " ++ render (ppr f) ++
 
 -----------------------
 -- See Note [Automatic differentiation documentation]
-optDrvFun :: HasCallStack => ADMode -> BaseFun p -> TExpr -> Maybe TExpr
+optDrvFun :: HasCallStack => ADDir -> BaseFun p -> TExpr -> Maybe TExpr
 optDrvFun dir (PrimFunT f) args = optDrvPrim dir f args
 optDrvFun _ _ _ = Nothing
 
@@ -786,7 +786,7 @@ optDrvPrim _ _ _ = Nothing
 -- See Note [Automatic differentiation documentation]
 --
 -- Called for (lmApply lm dx)
-optLMApply :: InScopeSet -> ADMode -> TExpr -> TExpr -> Maybe TExpr
+optLMApply :: InScopeSet -> ADDir -> TExpr -> TExpr -> Maybe TExpr
 
 optLMApply _ adm (Assert e1 e2) dx
   = Just (Assert e1 (lmApply_AD adm e2 dx))

--- a/src/ksc/Ksc/Opt.hs
+++ b/src/ksc/Ksc/Opt.hs
@@ -789,13 +789,13 @@ optDrvPrim _ _ _ = Nothing
 optLMApply :: InScopeSet -> ADDir -> TExpr -> TExpr -> Maybe TExpr
 
 optLMApply _ adm (Assert e1 e2) dx
-  = Just (Assert e1 (lmApply_AD adm e2 dx))
+  = Just (Assert e1 (lmApply_Dir adm e2 dx))
 
 optLMApply _ adm (Let v rhs body) dx
-  = Just $ Let v rhs $ lmApply_AD adm body dx
+  = Just $ Let v rhs $ lmApply_Dir adm body dx
 
 optLMApply _ adm (If b et ef) dx
-  = Just $ If b (lmApply_AD adm et dx) (lmApply_AD adm ef dx)
+  = Just $ If b (lmApply_Dir adm et dx) (lmApply_Dir adm ef dx)
 
 -- Called for (lmApply (lm* es) dx)
 -- In BasicAD only

--- a/src/ksc/Ksc/Opt.hs
+++ b/src/ksc/Ksc/Opt.hs
@@ -216,8 +216,8 @@ rewriteCall _ fun (If e1 e2 e3)
 rewriteCall env (TFun _ (Fun JustFun fun)) arg
   = optFun env fun arg
 
-rewriteCall env (TFun ty (Fun (GradFun adm) f)) arg
-  = optGradFun (optEnvInScope env) adm ty f arg
+rewriteCall env (TFun ty (Fun GradFun f)) arg
+  = optGradFun (optEnvInScope env) ty f arg
 
 rewriteCall _ (TFun _ (Fun (DrvFun adm) f)) arg
   = optDrvFun adm f arg
@@ -401,8 +401,8 @@ optPrimFun _ P_sum         arg           = optSum arg
 optPrimFun _ P_shape       arg           = Just $ optShape arg
 optPrimFun _ P_build       (Tuple [sz, Lam i e2]) = optBuild sz i e2
 optPrimFun _ P_sumbuild    (Tuple [sz, Lam i e2]) = optSumBuild sz i e2
-optPrimFun env P_lmApply   (Tuple [e1,e2])        = optLMApply env (AD BasicAD Fwd) e1 e2
-optPrimFun env P_lmApplyR  (Tuple [e1,e2])        = optLMApply env (AD BasicAD Rev) e2 e1
+optPrimFun env P_lmApply   (Tuple [e1,e2])        = optLMApply env (AD Fwd) e1 e2
+optPrimFun env P_lmApplyR  (Tuple [e1,e2])        = optLMApply env (AD Rev) e2 e1
 optPrimFun _ P_lmCompose   (Tuple [f,g])  = optLMCompose f g
 
 optPrimFun _ P_lmVCat (Tuple es)
@@ -656,15 +656,15 @@ optSumBuild _ _ _ = Nothing
 
 -----------------------
 -- See Note [Automatic differentiation documentation]
-optGradFun :: HasCallStack => InScopeSet -> ADPlan
+optGradFun :: HasCallStack => InScopeSet
                            -> Type -> BaseFun Typed -> TExpr -> Maybe TExpr
 -- Inline the definitions for grad(+), grad(*) etc
-optGradFun _ _ _ (BaseFunId (BaseUserFunName {}) _) _
+optGradFun _ _ (BaseFunId (BaseUserFunName {}) _) _
   = Nothing
 
 -- From here on we have primitives or selection
 
-optGradFun _ BasicAD ty (PrimFunT f)  args = optGradPrim ty f args
+optGradFun _ ty (PrimFunT f)  args = optGradPrim ty f args
 
 type TBinds = [(TVar, TExpr)]
 
@@ -757,7 +757,7 @@ optGradPrim _ f     a = optTrace("No opt for grad of prim " ++ render (ppr f) ++
 -----------------------
 -- See Note [Automatic differentiation documentation]
 optDrvFun :: HasCallStack => ADMode -> BaseFun p -> TExpr -> Maybe TExpr
-optDrvFun (AD BasicAD dir) (PrimFunT f) args = optDrvPrim dir f args
+optDrvFun (AD dir) (PrimFunT f) args = optDrvPrim dir f args
 optDrvFun _ _ _ = Nothing
 
 -- See Note [Automatic differentiation documentation]
@@ -799,29 +799,27 @@ optLMApply _ adm (If b et ef) dx
 
 -- Called for (lmApply (lm* es) dx)
 -- In BasicAD only
-optLMApply env (AD BasicAD dir) (Call (TFun _ (Fun JustFun (PrimFunT f))) es) dx
+optLMApply env (AD dir) (Call (TFun _ (Fun JustFun (PrimFunT f))) es) dx
   = optLMApplyCall env dir f es dx
 
 -- Looking at:   D$f(e1, e2) `lmApply` dx
 --   f :: S1 S2 -> T
 --   D$f :: S1 S2 -> ((S1,S2) -o T)
 --   fwd$f :: S1 S2 S1_t S2_t -> T_t
-optLMApply _ (AD adp1 Fwd) (Call (TFun (TypeLM _ t) (Fun (GradFun adp2) f)) es) dx
-  | adp1 == adp2
+optLMApply _ (AD Fwd) (Call (TFun (TypeLM _ t) (Fun GradFun f)) es) dx
   = Just (Call grad_fun es_dx)
   where
-    grad_fun = TFun (tangentType t) (Fun (DrvFun (AD adp1 Fwd)) f)
+    grad_fun = TFun (tangentType t) (Fun (DrvFun (AD Fwd)) f)
     es_dx = Tuple [es, dx]
 
 -- Looking at:   dr `lmApplyR` D$f(e1, e2)
 --   f :: S1 S2 -> T
 --   D$f :: S1 S2 -> ((S1,S2) -o T)
 --   rev$f :: S1 S2 T_ -> (S1_t,S2_t)
-optLMApply _ (AD adp1 Rev) (Call (TFun (TypeLM s _) (Fun (GradFun adp2) f)) es) dx
-  | adp1 == adp2
+optLMApply _ (AD Rev) (Call (TFun (TypeLM s _) (Fun GradFun f)) es) dx
   = Just (Call grad_fun es_dx)
   where
-    grad_fun = TFun (tangentType s) (Fun (DrvFun (AD adp1 Rev)) f)
+    grad_fun = TFun (tangentType s) (Fun (DrvFun (AD Rev)) f)
     es_dx = Tuple [es, dx]
 
 {-

--- a/src/ksc/Ksc/Parse.hs
+++ b/src/ksc/Ksc/Parse.hs
@@ -393,9 +393,9 @@ pBaseFun = pPrimFun
 
 pFunG :: forall p. Parser (BaseFun p) -> Parser (Fun p)
 pFunG pBase = try (brackets $
-            ((pDerivation "D" (GradFun BasicAD))
-         <|> (pDerivation "fwd" (DrvFun (AD BasicAD Fwd)))
-         <|> (pDerivation "rev"  (DrvFun (AD BasicAD Rev)))
+            ((pDerivation "D" GradFun)
+         <|> (pDerivation "fwd" (DrvFun (AD Fwd)))
+         <|> (pDerivation "rev"  (DrvFun (AD Rev)))
          <|> (pDerivation "CL" CLFun)
          <|> (pDerivation "suffwdpass" SUFFwdPass)
          <|> (pDerivation "sufrevpass" SUFRevPass)
@@ -450,8 +450,8 @@ pEdef = do { pReserved "edef"
 
 pDerivation :: Parser Derivation
 pDerivation =
-      (pReserved "fwd" $> DerivationDrvFun (AD BasicAD Fwd))
-  <|> (pReserved "rev" $> DerivationDrvFun (AD BasicAD Rev))
+      (pReserved "fwd" $> DerivationDrvFun (AD Fwd))
+  <|> (pReserved "rev" $> DerivationDrvFun (AD Rev))
   <|> (pReserved "CL"  $> DerivationCLFun)
   <|> (pReserved "shape" $> DerivationShapeFun)
   <|> (pReserved "suffwdpass" $> DerivationSUFFwdPass)

--- a/src/ksc/Ksc/Parse.hs
+++ b/src/ksc/Ksc/Parse.hs
@@ -394,8 +394,8 @@ pBaseFun = pPrimFun
 pFunG :: forall p. Parser (BaseFun p) -> Parser (Fun p)
 pFunG pBase = try (brackets $
             ((pDerivation "D" GradFun)
-         <|> (pDerivation "fwd" (DrvFun (AD Fwd)))
-         <|> (pDerivation "rev"  (DrvFun (AD Rev)))
+         <|> (pDerivation "fwd" (DrvFun Fwd))
+         <|> (pDerivation "rev"  (DrvFun Rev))
          <|> (pDerivation "CL" CLFun)
          <|> (pDerivation "suffwdpass" SUFFwdPass)
          <|> (pDerivation "sufrevpass" SUFRevPass)
@@ -450,8 +450,8 @@ pEdef = do { pReserved "edef"
 
 pDerivation :: Parser Derivation
 pDerivation =
-      (pReserved "fwd" $> DerivationDrvFun (AD Fwd))
-  <|> (pReserved "rev" $> DerivationDrvFun (AD Rev))
+      (pReserved "fwd" $> DerivationDrvFun Fwd)
+  <|> (pReserved "rev" $> DerivationDrvFun Rev)
   <|> (pReserved "CL"  $> DerivationCLFun)
   <|> (pReserved "shape" $> DerivationShapeFun)
   <|> (pReserved "suffwdpass" $> DerivationSUFFwdPass)

--- a/src/ksc/Ksc/Parse.hs
+++ b/src/ksc/Ksc/Parse.hs
@@ -58,7 +58,7 @@ x : Tensor 1 (Tensor 2 Float)
         | "[" <derivation> <sname> "]"
         | "[" <var> <type> "]"
 
-<derivation> ::= "rev" | "fwd" | "shape" | "cost" | "D" | "Dt" | "suffwdpass" | "sufrevpass"
+<derivation> ::= "rev" | "fwd" | "shape" | "cost" | "D" | "suffwdpass" | "sufrevpass"
 
 An example
   (def f7 ((x : Vec Float) (y : Vec Float))
@@ -394,11 +394,8 @@ pBaseFun = pPrimFun
 pFunG :: forall p. Parser (BaseFun p) -> Parser (Fun p)
 pFunG pBase = try (brackets $
             ((pDerivation "D" (GradFun BasicAD))
-         <|> (pDerivation "Dt" (GradFun TupleAD))
          <|> (pDerivation "fwd" (DrvFun (AD BasicAD Fwd)))
-         <|> (pDerivation "fwdt" (DrvFun (AD TupleAD Fwd)))
          <|> (pDerivation "rev"  (DrvFun (AD BasicAD Rev)))
-         <|> (pDerivation "revt" (DrvFun (AD TupleAD Rev)))
          <|> (pDerivation "CL" CLFun)
          <|> (pDerivation "suffwdpass" SUFFwdPass)
          <|> (pDerivation "sufrevpass" SUFRevPass)

--- a/src/ksc/Ksc/Pipeline.hs
+++ b/src/ksc/Ksc/Pipeline.hs
@@ -181,8 +181,8 @@ deriveDecl = deriveDeclUsing $ \env (L.GDef derivation fun) -> do
               Just tdef' -> tdef'
 
     ; case derivation of
-        L.DerivationDrvFun (L.AD plan dir) -> do
-          { let mgradDef = gradDef plan tdef
+        L.DerivationDrvFun (L.AD dir) -> do
+          { let mgradDef = gradDef tdef
           ; let env' = maybe env (flip stInsertFun env) mgradDef
           ; graddedDef <- case mgradDef of
               Nothing -> do

--- a/src/ksc/Ksc/Pipeline.hs
+++ b/src/ksc/Ksc/Pipeline.hs
@@ -181,7 +181,7 @@ deriveDecl = deriveDeclUsing $ \env (L.GDef derivation fun) -> do
               Just tdef' -> tdef'
 
     ; case derivation of
-        L.DerivationDrvFun (L.AD dir) -> do
+        L.DerivationDrvFun dir -> do
           { let mgradDef = gradDef tdef
           ; let env' = maybe env (flip stInsertFun env) mgradDef
           ; graddedDef <- case mgradDef of

--- a/src/ksc/Ksc/Prim.hs
+++ b/src/ksc/Ksc/Prim.hs
@@ -425,7 +425,7 @@ lmApplyR :: HasCallStack => TExpr -> TExpr -> TExpr
 lmApplyR = mkPrimCall2 P_lmApplyR
 
 lmApply_AD :: HasCallStack => ADMode -> TExpr -> TExpr -> TExpr
-lmApply_AD (AD BasicAD dir) = lmApply_Dir  dir
+lmApply_AD (AD dir) = lmApply_Dir  dir
 
 lmApply_Dir :: HasCallStack => ADDir -> TExpr -> TExpr -> TExpr
 lmApply_Dir Fwd e ds = lmApply  e ds
@@ -605,18 +605,18 @@ primCallResultTy_maybe fun arg_ty
          | otherwise
          -> Left (text "Ill-typed call to primitive:" <+> ppr fun)
 
-      Fun (GradFun adp) f
+      Fun GradFun f
         -> case primCallResultTy_maybe (Fun JustFun f) arg_ty of
             Left err -> Left err
-            Right res_ty -> Right (mkGradType adp arg_ty res_ty)
+            Right res_ty -> Right (mkGradType arg_ty res_ty)
 
       Fun (DrvFun adm) f
-        | AD BasicAD Fwd <- adm    -- f :: S1 -> T, then fwd$f :: (S1, S2_t) -> T_t
+        | AD Fwd <- adm    -- f :: S1 -> T, then fwd$f :: (S1, S2_t) -> T_t
         , TypeTuple [x, _dx] <- arg_ty
         , Right t_ty <- primCallResultTy_maybe (Fun JustFun f) x
         -> Right (tangentType t_ty)
 
-        | AD BasicAD Rev <- adm    -- f :: S1 -> T, then rev$f :: (S1, T_t) -> S1_t
+        | AD Rev <- adm    -- f :: S1 -> T, then rev$f :: (S1, T_t) -> S1_t
         , TypeTuple [s, _dt] <- arg_ty
         -> Right (tangentType s)
         | otherwise
@@ -648,7 +648,7 @@ primCallResultTy_maybe fun arg_ty
         -> Left (text "Type error in SUF rev fun:" <+> ppr fun
              <+> text "Arg ty was:" <+> ppr arg_ty)
 
-      Fun SUFRev f -> primCallResultTy_maybe (Fun (DrvFun (AD BasicAD Rev)) f) arg_ty
+      Fun SUFRev f -> primCallResultTy_maybe (Fun (DrvFun (AD Rev)) f) arg_ty
 
 primFunCallResultTy :: HasCallStack => PrimFun -> TExpr -> Type
 primFunCallResultTy fun args

--- a/src/ksc/Ksc/Prim.hs
+++ b/src/ksc/Ksc/Prim.hs
@@ -426,7 +426,6 @@ lmApplyR = mkPrimCall2 P_lmApplyR
 
 lmApply_AD :: HasCallStack => ADMode -> TExpr -> TExpr -> TExpr
 lmApply_AD (AD BasicAD dir) = lmApply_Dir  dir
-lmApply_AD (AD TupleAD dir) = lmApplyT_Dir dir
 
 lmApply_Dir :: HasCallStack => ADDir -> TExpr -> TExpr -> TExpr
 lmApply_Dir Fwd e ds = lmApply  e ds
@@ -616,11 +615,6 @@ primCallResultTy_maybe fun arg_ty
         , TypeTuple [x, _dx] <- arg_ty
         , Right t_ty <- primCallResultTy_maybe (Fun JustFun f) x
         -> Right (tangentType t_ty)
-
-        | AD TupleAD Fwd <- adm    -- f :: S1 -> T, then fwdt$f :: (S1, S2_t) -> (T,T_t)
-        , TypeTuple [x, _dx] <- arg_ty
-        , Right t_ty <- primCallResultTy_maybe (Fun JustFun f) x
-        -> Right (TypeTuple [t_ty, tangentType t_ty])
 
         | AD BasicAD Rev <- adm    -- f :: S1 -> T, then rev$f :: (S1, T_t) -> S1_t
         , TypeTuple [s, _dt] <- arg_ty

--- a/src/ksc/Ksc/Prim.hs
+++ b/src/ksc/Ksc/Prim.hs
@@ -424,9 +424,6 @@ lmApply = mkPrimCall2 P_lmApply
 lmApplyR :: HasCallStack => TExpr -> TExpr -> TExpr
 lmApplyR = mkPrimCall2 P_lmApplyR
 
-lmApply_AD :: HasCallStack => ADDir -> TExpr -> TExpr -> TExpr
-lmApply_AD dir = lmApply_Dir  dir
-
 lmApply_Dir :: HasCallStack => ADDir -> TExpr -> TExpr -> TExpr
 lmApply_Dir Fwd e ds = lmApply  e ds
 lmApply_Dir Rev e dt = lmApplyR dt e

--- a/src/ksc/Ksc/Prim.hs
+++ b/src/ksc/Ksc/Prim.hs
@@ -425,7 +425,7 @@ lmApplyR :: HasCallStack => TExpr -> TExpr -> TExpr
 lmApplyR = mkPrimCall2 P_lmApplyR
 
 lmApply_AD :: HasCallStack => ADMode -> TExpr -> TExpr -> TExpr
-lmApply_AD (AD dir) = lmApply_Dir  dir
+lmApply_AD dir = lmApply_Dir  dir
 
 lmApply_Dir :: HasCallStack => ADDir -> TExpr -> TExpr -> TExpr
 lmApply_Dir Fwd e ds = lmApply  e ds
@@ -611,12 +611,12 @@ primCallResultTy_maybe fun arg_ty
             Right res_ty -> Right (mkGradType arg_ty res_ty)
 
       Fun (DrvFun adm) f
-        | AD Fwd <- adm    -- f :: S1 -> T, then fwd$f :: (S1, S2_t) -> T_t
+        | Fwd <- adm    -- f :: S1 -> T, then fwd$f :: (S1, S2_t) -> T_t
         , TypeTuple [x, _dx] <- arg_ty
         , Right t_ty <- primCallResultTy_maybe (Fun JustFun f) x
         -> Right (tangentType t_ty)
 
-        | AD Rev <- adm    -- f :: S1 -> T, then rev$f :: (S1, T_t) -> S1_t
+        | Rev <- adm    -- f :: S1 -> T, then rev$f :: (S1, T_t) -> S1_t
         , TypeTuple [s, _dt] <- arg_ty
         -> Right (tangentType s)
         | otherwise
@@ -648,7 +648,7 @@ primCallResultTy_maybe fun arg_ty
         -> Left (text "Type error in SUF rev fun:" <+> ppr fun
              <+> text "Arg ty was:" <+> ppr arg_ty)
 
-      Fun SUFRev f -> primCallResultTy_maybe (Fun (DrvFun (AD Rev)) f) arg_ty
+      Fun SUFRev f -> primCallResultTy_maybe (Fun (DrvFun Rev) f) arg_ty
 
 primFunCallResultTy :: HasCallStack => PrimFun -> TExpr -> Type
 primFunCallResultTy fun args

--- a/src/ksc/Ksc/Prim.hs
+++ b/src/ksc/Ksc/Prim.hs
@@ -424,7 +424,7 @@ lmApply = mkPrimCall2 P_lmApply
 lmApplyR :: HasCallStack => TExpr -> TExpr -> TExpr
 lmApplyR = mkPrimCall2 P_lmApplyR
 
-lmApply_AD :: HasCallStack => ADMode -> TExpr -> TExpr -> TExpr
+lmApply_AD :: HasCallStack => ADDir -> TExpr -> TExpr -> TExpr
 lmApply_AD dir = lmApply_Dir  dir
 
 lmApply_Dir :: HasCallStack => ADDir -> TExpr -> TExpr -> TExpr

--- a/src/python/ksc/type_propagate.py
+++ b/src/python/ksc/type_propagate.py
@@ -103,11 +103,6 @@ def infer_fn_type_from_derived_fn_args(sname: StructuredName, argtype: Type) -> 
             S = argtype
             return infer_fn_type_from_derived_fn_args(sname.se[1], S)
 
-        # [Dt f] : S -> LM dT dS
-        if derivation == "Dt":
-            S = argtype
-            return infer_fn_type_from_derived_fn_args(sname.se[1], S)
-
         # [shape f] : S -> shapeType(S)
         if derivation == "shape":
             S = argtype

--- a/src/runtime/prelude-aten.ks
+++ b/src/runtime/prelude-aten.ks
@@ -289,7 +289,6 @@
 (def [shape aten::pow] (Tuple Integer Integer) ((a : Tensor 2 Float) (n : Integer))
     (shape a))
 (edef [D aten::pow] (LM (Tuple (Tensor 2 Float) Integer) (Tensor 2 Float)) (Tuple (Tensor 2 Float) Integer))
-(edef [Dt aten::pow] (Tuple (Tensor 2 Float) (LM (Tuple (Tensor 2 Float) Integer) (Tensor 2 Float))) (Tuple (Tensor 2 Float) Integer))
 
 (def [rev aten::pow] (Tuple (Tensor 2 Float) (Tuple)) ((a_n : Tuple (Tensor 2 Float) Integer) (dr : Tensor 2 Float))
     (let ((a n) a_n)
@@ -438,8 +437,6 @@
 
 (edef [D aten::matmul] (LM (Tuple (Tensor 2 Float) (Tensor  1 Float)) (Tensor  1 Float))
           (Tuple (Tensor 2 Float) (Tensor  1 Float)))
-(edef [Dt aten::matmul] (Tuple (Tensor  1 Float) (LM (Tuple (Tensor 2 Float) (Tensor  1 Float)) (Tensor  1 Float)))
-          (Tuple (Tensor 2 Float) (Tensor  1 Float)))
 
 (def [fwd aten::matmul] (Tensor 1 Float)
           ((M_v : (Tuple (Tensor 2 Float) (Tensor  1 Float))) (dM_dv : (Tuple (Tensor 2 Float) (Tensor  1 Float))))
@@ -466,7 +463,6 @@
         (tuple M P))))))
 
 (edef [D aten::matmul] (LM (Tuple (Tensor 2 Float) (Tensor 2 Float)) (Tensor 2 Float)) (Tuple (Tensor 2 Float) (Tensor 2 Float)))
-(edef [Dt aten::matmul] (Tuple (Tensor 2 Float) (LM (Tuple (Tensor 2 Float) (Tensor 2 Float)) (Tensor 2 Float))) (Tuple (Tensor 2 Float) (Tensor 2 Float)))
 (def [fwd aten::matmul] (Tensor 2 Float) ((A_B : (Tuple (Tensor 2 Float) (Tensor 2 Float))) (dA_dB : (Tuple (Tensor 2 Float) (Tensor 2 Float))))
      (let ((A B) A_B)
      (let ((dA dB) dA_dB)
@@ -509,7 +505,6 @@
 (def [shape addA1bt] (Tuple Integer Integer) ((a : Tensor 2 Float) (b : Tensor 1 Float))
     (shape a))
 (edef [D addA1bt] (LM (Tuple (Tensor 2 Float) (Tensor 1 Float)) (Tensor 2 Float)) (Tuple (Tensor 2 Float) (Tensor 1 Float)))
-(edef [Dt addA1bt] (Tuple (Tensor 2 Float) (LM (Tuple (Tensor 2 Float) (Tensor 1 Float)) (Tensor 2 Float))) (Tuple (Tensor 2 Float) (Tensor 1 Float)))
 (def [fwd addA1bt] (Tensor 2 Float) ((arg : (Tuple (Tensor 2 Float) (Tensor 1 Float))) (darg : (Tuple (Tensor 2 Float) (Tensor 1 Float))))
      (addA1bt darg))
 (edef [rev addA1bt] (Tuple (Tensor 2 Float) (Tensor 1 Float)) (Tuple (Tuple (Tensor 2 Float) (Tensor 1 Float)) (Tensor 2 Float)))
@@ -612,7 +607,6 @@
 (edef aten::cat (Tensor 2 Float) (Tuple (Tensor 1 (Tensor 2 Float)) Integer))
 (edef [shape aten::cat] (Tuple Integer Integer) (Tuple (Tensor 1 (Tensor 2 Float)) Integer))
 (edef [D aten::cat] (LM (Tuple (Tensor 1 (Tensor 2 Float)) Integer) (Tensor 2 Float)) (Tuple (Tensor 1 (Tensor 2 Float)) Integer))
-(edef [Dt aten::cat] (Tuple (Tensor 2 Float) (LM (Tuple (Tensor 1 (Tensor 2 Float)) Integer) (Tensor 2 Float))) (Tuple (Tensor 1 (Tensor 2 Float)) Integer))
 (def [fwd aten::cat] (Tensor 2 Float) ((as_i : Tuple (Tensor 1 (Tensor 2 Float)) Integer) (da : Tuple (Tensor 1 (Tensor 2 Float)) (Tuple)))
     (let ((as i) as_i)
     (let ((das _) da)

--- a/src/runtime/prelude.ks
+++ b/src/runtime/prelude.ks
@@ -6,7 +6,6 @@
 (edef [D to_float] (LM Integer Float) (Integer))
 (def [fwd to_float] Float ((x : Integer) (dx : (Tuple))) 0.0)
 (def [rev to_float] (Tuple) ((x : Integer) (d_dto_float : Float)) (tuple))
-(edef [Dt to_float] (Tuple Float (LM Integer Float)) (Integer))
 (def [suffwdpass to_float] (Tuple Float (Tuple)) (x : Integer)
      (tuple (to_float x) (tuple)))
 (def [sufrevpass [to_float Integer]] (Tuple) ((d_dto_float : Float) (bog : Tuple)) (tuple))
@@ -23,7 +22,6 @@
 ;; neg x = -x
 (edef neg Float (Float))
 (edef [D neg] (LM Float Float) (Float))
-(edef [Dt neg] (Tuple Float (LM Float Float)) (Float))
 (def [fwd neg] Float ((x : Float) (dx : Float))
      (neg dx))
 (def [rev neg] Float ((x : Float) (d_dneg : Float))
@@ -36,7 +34,6 @@
 
 (edef neg Integer (Integer))
 (edef [D neg] (LM Integer Integer) (Integer))
-(edef [Dt neg] (Tuple Integer (LM Integer Integer)) (Integer))
 (def [fwd neg] (Tuple) ((x : Integer) (dx : (Tuple)))
      (tuple))
 (def [rev neg] (Tuple) ((x : Integer) (d_dneg : (Tuple)))
@@ -51,7 +48,6 @@
 ;; add (x, y) = x + y
 (edef add Float (Tuple Float Float))
 (edef [D add] (LM (Tuple Float Float) Float) (Tuple Float Float))
-(edef [Dt add] (Tuple Float (LM (Tuple Float Float) Float)) (Tuple Float Float))
 (def
  [fwd add] Float
  ((xt : (Tuple Float Float)) (dxt : (Tuple Float Float)))
@@ -71,7 +67,6 @@
 
 (edef add Integer (Tuple Integer Integer))
 (edef [D add] (LM (Tuple Integer Integer) Integer) (Tuple Integer Integer))
-(edef [Dt add] (Tuple Integer (LM (Tuple Integer Integer) Integer)) (Tuple Integer Integer))
 (def
  [fwd add] (Tuple)
  ((xt : (Tuple Integer Integer)) (dxt : (Tuple (Tuple) (Tuple))))
@@ -90,7 +85,6 @@
 ;; sub (x, y) = x - y
 (edef sub Float (Tuple Float Float))
 (edef [D sub] (LM (Tuple Float Float) Float) (Tuple Float Float))
-(edef [Dt sub] (Tuple Float (LM (Tuple Float Float) Float)) (Tuple Float Float))
 (def
  [fwd sub] Float
  ((xt : (Tuple Float Float)) (dxt : (Tuple Float Float)))
@@ -111,7 +105,6 @@
 
 (edef sub Integer (Tuple Integer Integer))
 (edef [D sub] (LM (Tuple Integer Integer) Integer) (Tuple Integer Integer))
-(edef [Dt sub] (Tuple Integer (LM (Tuple Integer Integer) Integer)) (Tuple Integer Integer))
 (def
  [fwd sub] (Tuple)
  ((xt : (Tuple Integer Integer)) (dxt : (Tuple (Tuple) (Tuple))))
@@ -146,7 +139,6 @@
 ;; mul (x, y) = x * y
 (edef mul Float (Tuple Float Float))
 (edef [D mul] (LM (Tuple Float Float) Float) (Tuple Float Float))
-(edef [Dt mul] (Tuple Float (LM (Tuple Float Float) Float)) (Tuple Float Float))
 (def [fwd mul] Float ((xt : (Tuple Float Float)) (dxt : (Tuple Float Float)))
       (let ((x1 x2) xt)
       (let ((dx1 dx2) dxt)
@@ -167,7 +159,6 @@
 
 (edef mul Integer (Tuple Integer Integer))
 (edef [D mul] (LM (Tuple Integer Integer) Integer) (Tuple Integer Integer))
-(edef [Dt mul] (Tuple Integer (LM (Tuple Integer Integer) Integer)) (Tuple Integer Integer))
 (def
  [fwd mul] (Tuple)
  ((xt : (Tuple Integer Integer)) (dxt : (Tuple (Tuple) (Tuple))))
@@ -201,8 +192,6 @@
 
 (edef [D mul] (LM (Tuple (Tensor 2 Float) (Vec Float)) (Vec Float))
           (Tuple (Tensor 2 Float) (Vec Float)))
-(edef [Dt mul] (Tuple (Vec Float) (LM (Tuple (Tensor 2 Float) (Vec Float)) (Vec Float)))
-          (Tuple (Tensor 2 Float) (Vec Float)))
 
 (def [fwd mul] (Vec Float)
           ((M_v : (Tuple (Tensor 2 Float) (Vec Float))) (dM_dv : (Tuple (Tensor 2 Float) (Vec Float))))
@@ -225,7 +214,6 @@
 ;; div (x, y) = x / y
 (edef div Float (Tuple Float Float))
 (edef [D div] (LM (Tuple Float Float) Float) (Tuple Float Float))
-(edef [Dt div] (Tuple Float (LM (Tuple Float Float) Float)) (Tuple Float Float))
 (def
  [fwd div] Float
  ((xt : (Tuple Float Float)) (dxt : (Tuple Float Float)))
@@ -253,7 +241,6 @@
 
 (edef div Integer (Tuple Integer Integer))
 (edef [D div] (LM (Tuple Integer Integer) Integer) (Tuple Integer Integer))
-(edef [Dt div] (Tuple Integer (LM (Tuple Integer Integer) Integer)) (Tuple Integer Integer))
 (def
  [fwd div] (Tuple)
  ((xt : (Tuple Integer Integer)) (dxt : (Tuple (Tuple) (Tuple))))
@@ -272,7 +259,6 @@
 ;; pow (x, y) = x ^ y
 (edef pow Float (Tuple Float Integer))
 (edef [D pow] (LM (Tuple Float Integer) Float) (Tuple Float Integer))
-(edef [Dt pow] (Tuple Float (LM (Tuple Float Integer) Float)) (Tuple Float Integer))
 (def revpow Float ((x : Float) (n : Integer) (d : Float))
      (mul d (mul (to_float n) (pow x (sub n 1)))))
 
@@ -306,7 +292,6 @@
 ; ;; eq (x, y) = x == y
 ; (edef eq Bool (Tuple Float Float))
 ; (edef [D eq] (LM (Tuple Float Float) Bool) (Tuple Float Float))
-; (edef [Dt eq] (Tuple Bool (LM (Tuple Float Float) Bool)) (Tuple Float Float))
 ; (def
 ;  [fwd eq] (Tuple)
 ;  ((xt : (Tuple Float Float)) (dxt : (Tuple Float Float)))
@@ -318,7 +303,6 @@
 
 ; (edef eq Bool (Tuple Integer Integer))
 ; (edef [D eq] (LM (Tuple Integer Integer) Bool) (Tuple Integer Integer))
-; (edef [Dt eq] (Tuple Bool (LM (Tuple Integer Integer) Bool)) (Tuple Integer Integer))
 ; (def
 ;  [fwd eq] (Tuple)
 ;  ((xt : (Tuple Integer Integer)) (dxt : (Tuple (Tuple) (Tuple))))
@@ -332,7 +316,6 @@
 ;; gt (x, y) = x > y
 (edef gt Bool (Tuple Float Float))
 (edef [D gt] (LM (Tuple Float Float) Bool) (Tuple Float Float))
-(edef [Dt gt] (Tuple Bool (LM (Tuple Float Float) Bool)) (Tuple Float Float))
 (def
  [fwd gt] (Tuple)
  ((xt : (Tuple Float Float)) (dxt : (Tuple Float Float)))
@@ -349,7 +332,6 @@
 
 (edef gt Bool (Tuple Integer Integer))
 (edef [D gt] (LM (Tuple Integer Integer) Bool) (Tuple Integer Integer))
-(edef [Dt gt] (Tuple Bool (LM (Tuple Integer Integer) Bool)) (Tuple Integer Integer))
 (def
  [fwd gt] (Tuple)
  ((xt : (Tuple Integer Integer)) (dxt : (Tuple (Tuple) (Tuple))))
@@ -368,7 +350,6 @@
 ;; lt (x, y) = x < y
 (edef lt Bool (Tuple Float Float))
 (edef [D lt] (LM (Tuple Float Float) Bool) (Tuple Float Float))
-(edef [Dt lt] (Tuple Bool (LM (Tuple Float Float) Bool)) (Tuple Float Float))
 (def
  [fwd lt] (Tuple)
  ((xt : (Tuple Float Float)) (dxt : (Tuple Float Float)))
@@ -385,7 +366,6 @@
 
 (edef lt Bool (Tuple Integer Integer))
 (edef [D lt] (LM (Tuple Integer Integer) Bool) (Tuple Integer Integer))
-(edef [Dt lt] (Tuple Bool (LM (Tuple Integer Integer) Bool)) (Tuple Integer Integer))
 (def
  [fwd lt] (Tuple)
  ((xt : (Tuple Integer Integer)) (dxt : (Tuple (Tuple) (Tuple))))
@@ -404,7 +384,6 @@
 ;; lte (x, y) = x <= y
 (edef lte Bool (Tuple Float Float))
 (edef [D lte] (LM (Tuple Float Float) Bool) (Tuple Float Float))
-(edef [Dt lte] (Tuple Bool (LM (Tuple Float Float) Bool)) (Tuple Float Float))
 (def
  [fwd lte] (Tuple)
  ((xt : (Tuple Float Float)) (dxt : (Tuple Float Float)))
@@ -416,7 +395,6 @@
 
 (edef lte Bool (Tuple Integer Integer))
 (edef [D lte] (LM (Tuple Integer Integer) Bool) (Tuple Integer Integer))
-(edef [Dt lte] (Tuple Bool (LM (Tuple Integer Integer) Bool)) (Tuple Integer Integer))
 (def
  [fwd lte] (Tuple)
  ((xt : (Tuple Integer Integer)) (dxt : (Tuple (Tuple) (Tuple))))
@@ -430,7 +408,6 @@
 ;; gte (x, y) = x >= y
 (edef gte Bool (Tuple Float Float))
 (edef [D gte] (LM (Tuple Float Float) Bool) (Tuple Float Float))
-(edef [Dt gte] (Tuple Bool (LM (Tuple Float Float) Bool)) (Tuple Float Float))
 (def
  [fwd gte] (Tuple)
  ((xt : (Tuple Float Float)) (dxt : (Tuple Float Float)))
@@ -447,7 +424,6 @@
 
 (edef gte Bool (Tuple Integer Integer))
 (edef [D gte] (LM (Tuple Integer Integer) Bool) (Tuple Integer Integer))
-(edef [Dt gte] (Tuple Bool (LM (Tuple Integer Integer) Bool)) (Tuple Integer Integer))
 (def
  [fwd gte] (Tuple)
  ((xt : (Tuple Integer Integer)) (dxt : (Tuple (Tuple) (Tuple))))
@@ -466,7 +442,6 @@
 (edef [D log] (LM Float Float) (Float))
 (def [fwd log] Float ((x : Float) (dx : Float)) (div dx x))
 (def [rev log] Float ((x : Float) (d_dlog : Float)) (div d_dlog x))
-(edef [Dt log] (Tuple Float (LM Float Float)) (Float))
 
 (def [suffwdpass log] (Tuple Float Float) (x : Float)
      (tuple (log x) x))
@@ -477,7 +452,6 @@
 (edef [D exp] (LM Float Float) (Float))
 (def [fwd exp] Float ((x : Float) (dx : Float)) (mul (exp x) dx))
 (def [rev exp] Float ((x : Float) (d_dexp : Float)) (mul (exp x) d_dexp))
-(edef [Dt exp] (Tuple Float (LM Float Float)) (Float))
 
 (def [suffwdpass exp] (Tuple Float Float) (x : Float)
      (let (exp_x (exp x))
@@ -501,12 +475,10 @@
 (def [suffwdpass sin] (Tuple Float Float) (x : Float) (tuple (sin x) x))
 (def [sufrevpass [sin Float]] Float ((d_dsin : Float) (bog : Float))
      (mul (cos bog) d_dsin))
-(edef [Dt sin] (Tuple Float (LM Float Float)) (Float))
 
 (edef [D cos] (LM Float Float) (Float))
 (def [fwd cos] Float ((x : Float) (dx : Float)) (neg (mul (sin x) dx)))
 (def [rev cos] Float ((x : Float) (d_dcos : Float)) (neg (mul (sin x) d_dcos)))
-(edef [Dt cos] (Tuple Float (LM Float Float)) (Float))
 (def [suffwdpass cos] (Tuple Float Float) (x : Float) (tuple (cos x) x))
 (def [sufrevpass [cos Float]] Float ((d_dcos : Float) (bog : Float))
      (neg (mul (sin bog) d_dcos)))
@@ -523,7 +495,6 @@
      (let (cosh_x_2 (mul cosh_x cosh_x))
        (div d_dr cosh_x_2))))
 (edef [D tanh] (LM Float Float) (Float))
-(edef [Dt tanh] (Tuple Float (LM Float Float)) (Float))
 (def [suffwdpass tanh] (Tuple Float Float) (x : Float)
      (tuple (tanh x) x))
 (def [sufrevpass [tanh Float]] Float ((d_dtanh : Float) (x : Float))
@@ -533,12 +504,10 @@
 
 (edef max Float (Tuple Float Float))
 (edef [D max] (LM (Tuple Float Float) Float) (Tuple Float Float))
-(edef [Dt max] (Tuple Float (LM (Tuple Float Float) Float)) (Tuple Float Float))
 
 (edef imax Integer ((Tensor 1 Float)))
 (edef max Float ((Tensor 1 Float)))
 (edef [D max] (LM (Tensor 1 Float) Float) ((Tensor 1 Float)))
-(edef [Dt max] (Tuple Float (LM (Tensor 1 Float) Float)) ((Tensor 1 Float)))
 (def [fwd max] Float ((x : (Tensor 1 Float)) (dx : (Tensor 1 Float)))
   (index (imax x) dx))
 (def [rev max] (Tensor 1 Float) ((x : (Tensor 1 Float)) (d_dr : Float))
@@ -553,7 +522,6 @@
 (edef [D $ranhashdoub] (LM Integer Float) (Integer))
 (def [fwd $ranhashdoub] Float ((x : Integer) (dx : (Tuple))) 0.0)
 (def [rev $ranhashdoub] (Tuple) ((x : Integer) (d_dranhashdoub : Float)) (tuple))
-(edef [Dt $ranhashdoub] (Tuple Float (LM Integer Float)) (Integer))
 
 (def [suffwdpass $ranhashdoub] (Tuple Float (Tuple)) (x : Integer)
      (tuple ($ranhashdoub x) (tuple)))
@@ -565,13 +533,11 @@
 (def [fwd abs] Float ((x : Float) (dx : Float)) (if (gt x 0.0) dx (neg dx)))
 (def [rev abs] Float ((x : Float) (d_dabs : Float))
      (if (gt x 0.0) d_dabs (neg d_dabs)))
-(edef [Dt abs] (Tuple Float (LM Float Float)) (Float))
 
 (edef lgamma Float (Float))
 (edef [D lgamma] (LM Float Float) (Float))
 (edef [fwd lgamma] Float (Tuple Float Float))
 (edef [rev lgamma] Float (Tuple Float Float))
-(edef [Dt lgamma] (Tuple Float (LM Float Float)) (Float))
 
 (def [suffwdpass lgamma] (Tuple Float Float) (x : Float)
      (tuple (lgamma x) x))
@@ -580,7 +546,6 @@
 
 (edef or Bool (Tuple Bool Bool))
 (edef [D or] (LM (Tuple Bool Bool) Bool) (Tuple Bool Bool))
-(edef [Dt or] (Tuple Bool (LM (Tuple Bool Bool) Bool)) (Tuple Bool Bool))
 (def [fwd or] (Tuple)
      ((xt : Tuple Bool Bool) (dxt : Tuple Bool Bool))
      (tuple))
@@ -595,7 +560,6 @@
 
 (edef and Bool (Tuple Bool Bool))
 (edef [D and] (LM (Tuple Bool Bool) Bool) (Tuple Bool Bool))
-(edef [Dt and] (Tuple Bool (LM (Tuple Bool Bool) Bool)) (Tuple Bool Bool))
 (def [fwd and] (Tuple)
      ((xt : Tuple Bool Bool) (dxt : Tuple (Tuple) (Tuple)))
      (tuple))

--- a/test/ksc/edef.ks
+++ b/test/ksc/edef.ks
@@ -2,10 +2,8 @@
 ; Licensed under the MIT license.
 (edef edef_example Float (Float))
 (edef [D edef_example] (LM Float Float) (Float))
-(edef [Dt edef_example] (Tuple Float (LM Float Float)) (Float))
 (edef R$edef_example (LM Float Float) (Float))
 (edef [fwd edef_example] Float (Tuple Float Float))
-(edef [fwdt edef_example] Float (Tuple Float Float))
 (edef [rev edef_example] Float (Tuple Float Float))
 (edef [suffwdpass edef_example] (Tuple Float (Tuple)) (Float))
 (edef [sufrevpass [edef_example Float]] (Float) (Tuple Float (Tuple)))

--- a/test/ksc/gmm.ks
+++ b/test/ksc/gmm.ks
@@ -13,8 +13,6 @@
 (edef dot Float (Tuple (Vec Float) (Vec Float)))
 (edef [D dot] (LM (Tuple (Vec Float) (Vec Float)) Float)
              (Tuple (Vec Float) (Vec Float)))
-(edef [Dt dot] (Tuple Float (LM (Tuple (Vec Float) (Vec Float)) Float))
-              (Tuple (Vec Float) (Vec Float)))
 (edef R$dot (LM Float (Tuple (Vec Float) (Vec Float))) (Tuple (Vec Float) (Vec Float)))
 (def [fwd dot] Float ((a_b : (Tuple (Vec Float) (Vec Float))) (da_db : (Tuple (Vec Float) (Vec Float))))
      (let ((a b) a_b)

--- a/test/ksc/run-gmm-obj-for-profiling.ks
+++ b/test/ksc/run-gmm-obj-for-profiling.ks
@@ -13,8 +13,6 @@
 (edef dot Float (Tuple (Vec Float) (Vec Float)))
 (edef [D dot] (LM (Tuple (Vec Float) (Vec Float)) Float)
              (Tuple (Vec Float) (Vec Float)))
-(edef [Dt dot] (Tuple Float (LM (Tuple (Vec Float) (Vec Float)) Float))
-              (Tuple (Vec Float) (Vec Float)))
 (edef R$dot (LM Float (Tuple (Vec Float) (Vec Float))) (Tuple (Vec Float) (Vec Float)))
 (def [fwd dot] Float ((a_b : (Tuple (Vec Float) (Vec Float))) (da_db : (Tuple (Vec Float) (Vec Float))))
      (let ((a b) a_b)

--- a/test/ksc/run-gmm-rev-for-profiling.ks
+++ b/test/ksc/run-gmm-rev-for-profiling.ks
@@ -13,8 +13,6 @@
 (edef dot Float (Tuple (Vec Float) (Vec Float)))
 (edef [D dot] (LM (Tuple (Vec Float) (Vec Float)) Float)
              (Tuple (Vec Float) (Vec Float)))
-(edef [Dt dot] (Tuple Float (LM (Tuple (Vec Float) (Vec Float)) Float))
-              (Tuple (Vec Float) (Vec Float)))
 (edef R$dot (LM Float (Tuple (Vec Float) (Vec Float))) (Tuple (Vec Float) (Vec Float)))
 (def [fwd dot] Float ((a_b : (Tuple (Vec Float) (Vec Float))) (da_db : (Tuple (Vec Float) (Vec Float))))
      (let ((a b) a_b)

--- a/test/ksc/syntax-primer.ks
+++ b/test/ksc/syntax-primer.ks
@@ -271,7 +271,6 @@ If you prefer block comments then use pairs of #| and |#
 ; manual derivatives (i.e. using "def") for your function.
 (edef my_log Float (Float))
 (edef [D [my_log Float]] (LM Float Float) (Float)) ; External definition of Jacobian
-(edef [Dt my_log] (Tuple Float (LM Float Float)) (Float)) ; and its transpose
 
 ;; KS-visible definition of forward derivative
 (def [fwd [my_log Float]] Float ((x : Float) (dx : Float)) 

--- a/test/python/test_structured_names.py
+++ b/test/python/test_structured_names.py
@@ -8,9 +8,9 @@ from ksc.type import Type
 
 
 def test_structured_names():
-    sname = parse_structured_name(s_exps_from_string("[Dt [my_log Float]]")[0])
+    sname = parse_structured_name(s_exps_from_string("[D [my_log Float]]")[0])
     assert sname.is_derivation()
-    assert sname.is_derived("Dt")
+    assert sname.is_derived("D")
     assert sname.has_type()
     _sn, ty = sname.add_type(Type.Float)
     assert ty == Type.Float

--- a/test/python/test_type_propagation.py
+++ b/test/python/test_type_propagation.py
@@ -20,7 +20,7 @@ def test_type_propagate_prelude_and_primer():
     decls_file = list(parse_ks_filename("test/ksc/syntax-primer.ks"))
     type_propagate_decls(decls_file, symtab)
     assert parse_structured_name(
-        s_exps_from_string("[Dt [my_log Float]]", __file__)[0]
+        s_exps_from_string("[D [my_log Float]]", __file__)[0]
     ) in [d.name for d in decls_file]
 
 


### PR DESCRIPTION
Since I'm getting back into the guts of LM AD again I wanted to see how things would look if we removed tuple AD.

We don't use tuple AD. Reverse mode tuple AD is not compositional so can never work. Forward mode tuple AD has problems removing linear map constructors when it comes to `lmApply` so we never used it in practice.

I was expecting that removing tuple AD would remove a lot of old code. In practice it's only a bit of old code. What do we think? Do we want to keep tuple AD around for some reason? Is this too little code saving to bother removing it?

