### PR TITLE
Improve type prop error message

### DIFF
--- a/src/python/ksc/type_propagate.py
+++ b/src/python/ksc/type_propagate.py
@@ -377,13 +377,13 @@ def _(ex, symtab):
     exname = ex.name.mangled()
     near_miss = False
     closest_match = None
-    closest_match_distance = float('inf')
+    closest_match_distance = float("inf")
     DISTANCE_THRESHOLD = 3
-    for key,val in symtab.items():
+    for key, val in symtab.items():
         if isinstance(key, StructuredName):
             key_str = key.mangle_without_type()
         else:
-            key_str=str(key)
+            key_str = str(key)
         distance = editdistance.eval(key_str, exname)
         if distance < closest_match_distance:
             closest_match = key

--- a/test/python/test_type_propagation.py
+++ b/test/python/test_type_propagation.py
@@ -94,3 +94,16 @@ def test_type_propagate_warnings():
     with pytest.raises(KSTypeError) as excinfo:
         type_propagate_decls(decls, {})
     assert "Redefinition of [foo Float]" in str(excinfo.value)
+
+    decls = list(
+        parse_ks_string(
+            """
+    (def foo Float (a : Float) 1.0)
+    (def goo Integer (a : Float) (floo 2.0))
+    """,
+            __file__,
+        )
+    )
+    with pytest.raises(KSTypeError) as excinfo:
+        type_propagate_decls(decls, {})
+    assert "Couldn't find" in str(excinfo.value)


### PR DESCRIPTION
Print a more helpful message on not-found functions
```

test/python/test_type_propagation.py ...type_propagate: at  floo@f(2.0)
type_propagate: Couldn't find [floo Float] called with types (Float) 
type_propagate: Looked up [floo Float]
type_propagate: Near misses floo@f:
type_propagate: No near misses (closest was [foo Float], dist = 3)
type_propagate: Boilerplate for prelude.ks:
(edef [floo Float] RET (Float))
(edef D$[floo Float] (LM Float dRET) (Float))
(def rev$[floo Float] Float ((t : Float) (dret : dRET))
```