### PR TITLE
Proposed refactoring of #754

### DIFF
--- a/src/python/ksc/rewrites_ast.py
+++ b/src/python/ksc/rewrites_ast.py
@@ -14,75 +14,7 @@ from ksc.rewrites import RuleMatcher, LetBindingEnvironment, Match
 from ksc.utils import singleton
 
 ###############################################################################
-
-# class xLiftingRule(RuleMatcher):
-#     possible_filter_terms = frozenset([Call, If, Let, Assert])
-
-#     def matches_for_possible_expr(
-#         self,
-#         subtree: Expr,
-#         path_from_root: Location,
-#         root: Expr,
-#         env: LetBindingEnvironment,
-#     ) -> Iterator[Match]:
-#         if isinstance(subtree, Lam):
-#             # Lam's inside build/sumbuild are handled as part of the (sum)build
-#             return
-#         children = subexps_no_binds(subtree)
-#         for i, ch in enumerate(children):
-#             nested_lam = isinstance(ch, Lam)
-#             e = ch.body if nested_lam else ch
-
-#             to_lift = None
-#             if isinstance(self, lift_if.__class__) and isinstance(e, If):
-#                 to_lift = e.cond
-#             if isinstance(self, lift_bind.__class__) and isinstance(e, Let):
-#                 to_lift = e.rhs
-
-#             if to_lift is None:
-#                 continue
-
-#             if (
-#                 isinstance(subtree, Let)
-#                 and i == 1
-#                 and subtree.vars.name in to_lift.free_vars_
-#             ):
-#                 pass  # Cannot lift computation using a variable outside of let that binds that variable
-#             elif nested_lam and ch.arg.name in to_lift.free_vars_:
-#                 pass  # Similarly - cannot lift loop-variant computation out of lam within (sum)build
-#             elif (
-#                 isinstance(subtree, If)
-#                 and i > 0
-#                 and not can_speculate_ahead_of_condition(to_lift, subtree.cond, i == 1)
-#             ):
-#                 pass  # Don't lift computation out of "if" that may be guarding against an exception
-#             else:
-#                 yield Match(
-#                     self,
-#                     root,
-#                     path_from_root + ((i, 0) if nested_lam else (i,)),
-#                     {"buildlam": nested_lam},
-#                 )
-
-#     def apply_at(self, e: Expr, path: Location, buildlam: bool) -> Expr:
-#         assert (not buildlam) or len(path) > 1
-#         rest_of_path = path[-(1 + int(buildlam)) :]
-#         path_to_parent = path[: -len(rest_of_path)]
-#         return replace_subtree(
-#             e,
-#             path_to_parent,
-#             Const(0.0),
-#             lambda _, parent: self.apply_to_parent(parent, rest_of_path),
-#         )
-
-#     @abstractmethod
-#     def apply_to_parent(self, parent: Expr, path_to_child: Location) -> Expr:
-#         """ Args -
-#             <parent>: the node to lift over
-#             <path_to_child> path within parent identifying the liftable child (maybe a grandchild to lift over (sum)build+lam).
-#         Return an Expr equivalent to <parent>. """
-
-
+#
 # lift_if: EXPR{If} -> If{EXPR}
 # For several varieties of Expr, e.g:
 #  Call:
@@ -212,8 +144,10 @@ class lift_if(RuleMatcher):
         )
 
 
-# Lifting rules:
-#   lift_bind:
+###############################################################################
+#
+# lift_bind: Expr{Let} -> Let{Expr}
+#
 #  Call:
 #      (foo a1 a2 (LET (x e1) y) a4) -> (LET (x e1) (foo a1 a2 y a4))
 #                                    -? x not in freevars{a1,a2,a4}


### PR DESCRIPTION
The commoning in #754 makes it extremely hard to grok.  This moves towards understanding what should and can be shared.  On the way, some observations:

- Inconsistent handling of `Lam` adds complexity.   Let's keep it consistent, and if it's really important that build{if} lifts to if{build} in one rule, make a hyper-specific rule (or a compound rule) that does it.

- The current "return True" in the "speculation" checker appears to fail unsafe?

- Mixing child indices and subexprs_no_binds suggests to me that a case-by-case analysis as performed in the comments might well be more maintainable.