### PR TITLE
Untuple_one_let, with special-case for Var

### DIFF
--- a/src/python/ksc/untuple_lets.py
+++ b/src/python/ksc/untuple_lets.py
@@ -16,26 +16,33 @@ def make_tuple_get(idx: int, size: int, tuple_val: Expr) -> Expr:
 @singleton
 class _UntupleLets(ExprTransformer):
     def visit_let(self, l: Let) -> Expr:
-        rhs = self.visit(l.rhs)
-        body = self.visit(l.body)
-        if isinstance(l.vars, Var):
-            return Let(l.vars, rhs, body)
-        # Tupled let, binding multiple variables. Convert to nested single lets.
+        return untuple_one_let(Let(l.vars, self.visit(l.rhs), self.visit(l.body)))
 
-        # Optional special case, otherwise we could inline the tuple (uphill) and then use
-        # the select-of-tuple rules, once for each element, then delete the outermost let.
-        if is_literal_tuple(l.rhs):
-            assert len(l.rhs.args) == len(l.vars)
-            for arg, val in reversed(list(zip(l.vars, l.rhs.args))):
-                body = Let(arg, val, body)
-            return body
+
+def untuple_one_let(l: Let) -> Expr:
+    if isinstance(l.vars, Var):
+        return l
+    # So, tupled let, binding multiple variables. Convert to nested single lets.
+    body = l.body
+
+    # Optional special case, otherwise we could inline the tuple (uphill) and then use
+    # the select-of-tuple rules, once for each element, then delete the outermost let.
+    if is_literal_tuple(l.rhs):
+        assert len(l.rhs.args) == len(l.vars)
+        for arg, val in reversed(list(zip(l.vars, l.rhs.args))):
+            body = Let(arg, val, body)
+        return body
+    else:
+        # A tuple of variables, assigned to a single value - e.g. (let ((x y z) val) ...).
+        # If the val is not a variable, we should compute it once only into a fresh name.
+        # Then each variable to a get$n$m of that.
+        if isinstance(l.rhs, Var):
+            temp_var = l.rhs
         else:
-            # A tuple of variables, assigned to a single value - e.g. (let ((x y z) val) ...).
-            # In this case we must assign the value to a fresh name, then each variable to a get$n$m of that.
-            temp_var = make_nonfree_var("temp", [rhs, body])
-            for posn, var in reversed(list(enumerate(l.vars, 1))):
-                body = Let(var, make_tuple_get(posn, len(l.vars), temp_var), body)
-            return Let(temp_var, l.rhs, body)
+            temp_var = make_nonfree_var("temp", [l.rhs, body])
+        for posn, var in reversed(list(enumerate(l.vars, 1))):
+            body = Let(var, make_tuple_get(posn, len(l.vars), temp_var), body)
+        return body if isinstance(l.rhs, Var) else Let(temp_var, l.rhs, body)
 
 
 def untuple_lets(e: Expr):

--- a/test/python/test_untuple_lets.py
+++ b/test/python/test_untuple_lets.py
@@ -27,6 +27,16 @@ def test_untupling2():
     assert untuple_lets(expected) == expected
 
 
+def test_untupling_var():
+    actual = untuple_lets(parse_expr_string("(let ((a b) foo) (add a b))"))
+    # No need to generate a temp_N to hold value of Var foo
+    expected = parse_expr_string(
+        "(let (a (get$1$2 foo)) (let (b (get$2$2 foo)) (add a b)))"
+    )
+    assert actual == expected
+    assert untuple_lets(expected) == expected
+
+
 def test_untupling_avoids_capture():
     def test_with_var_name(v: str):
         actual = untuple_lets(parse_expr_string(f"(let ((a b) (foo {v})) (add a b))"))


### PR DESCRIPTION
* Break out untuple_one_let, which avoids recursive traversal, thus being more efficient when the rhs and body are known not to contain tupled lets.
* Add a special case that avoids generating a `(let (x v)` (with fresh name x) when `v` is a Var. That is, previously
```
(let ((a b) someVar) (....a....b....))
```
was transformed to
```
(let (freshVar someVar) (let (a (get$1$2 freshVar)) (let (b (get$2$2 freshVar)) (....a....b....))))
```
however the new temporary `freshVar` is only necessary if `someVar` were instead an expensive computation; if `someVar` is indeed a variable, then this PR transforms to:
```
(let (a (get$1$2 someVar)) (let (b (get$2$2 someVar)) (....a....b....)))
```

Note: the diff appears much larger here than it really is, due to reindenting.