### PR TITLE
replace_subtree => replace_subtree_avoid_capture / apply_func_to_subtree

### DIFF
--- a/src/python/ksc/rewrites_prelude.py
+++ b/src/python/ksc/rewrites_prelude.py
@@ -1,6 +1,6 @@
 from typing import Callable, FrozenSet, Iterator
 
-from ksc.cav_subst import Location, replace_subtree
+from ksc.cav_subst import Location, apply_func_to_subtree
 from ksc.expr import StructuredName, Expr, Const, Call
 from ksc.filter_term import FilterTerm
 from ksc.interpreter import native_impls
@@ -22,12 +22,11 @@ class ConstantFolder(RuleMatcher):
         return frozenset([self._name])
 
     def apply_at(self, expr: Expr, path: Location, **kwargs) -> Expr:
-        def apply_here(const_zero: Expr, subtree: Expr):
-            assert const_zero == Const(0.0)  # Payload passed to replace_subtree below
+        def apply_here(subtree: Expr):
             assert isinstance(subtree, Call) and subtree.name == self._name
             return Const(self._native_impl(*[arg.value for arg in subtree.args]))
 
-        return replace_subtree(expr, path, Const(0.0), apply_here)
+        return apply_func_to_subtree(expr, path, apply_here)
 
     def matches_for_possible_expr(
         self,


### PR DESCRIPTION
This attempts to address #784. I split calls to replace_subtree into three categories:
* the "tricky case" of inlining calls to lams, done only in tests (as this construct is not in the current ks language as I understand it). This now uses the "full-blown" `replace_subtrees` interface which is as before - we can define a wrapper/helper anytime we need this outside of tests.
* those where we pass the new subtree into the call to replace_subtree, which must do renaming to avoid capturing any variables in the new subtree. There's really only one case in this category, the inline_var rule. Here I've renamed to `replace_subtree_avoid_capture` to be explicit.
* all the other cases where we do not need to do renaming-to-avoid-capture. In all of these, the *new* (replacement) subtree is obtained by passing the *existing* subtree to a function, so I've called this `apply_func_to_subtree`. (Could be perhaps `replace_subtree_using_func` ? I didn't like replace_subtree_with_func as that suggests the replacement is the function itself rather than its result.)