### PR TITLE
Add optimisation rule for map of constVec

### DIFF
--- a/src/ksc/Opt.hs
+++ b/src/ksc/Opt.hs
@@ -372,6 +372,10 @@ optPrimFun _ P_deltaVec (Tuple [n, _i, val])
   | isKZero val
   = Just $ pConstVec n val
 
+optPrimFun _ P_map (Tuple [Lam v body, Call constVec (Tuple [n, k])])
+  | constVec `isThePrimFun` P_constVec
+  = Just $ pConstVec n (mkLet v k body)
+
 optPrimFun _ P_sum         arg           = optSum arg
 optPrimFun _ P_shape       arg           = optShape arg
 optPrimFun _ P_build       (Tuple [sz, Lam i e2]) = optBuild sz i e2


### PR DESCRIPTION
Needed for https://github.com/microsoft/knossos-ksc/pull/766 but probably worth getting in on its own.