### PR TITLE
Respect generate_lm argument when generating autograd function

### DIFF
--- a/src/ts2k/ts2ks/ts2ks.py
+++ b/src/ts2k/ts2ks/ts2ks.py
@@ -386,11 +386,8 @@ def forward_template(py_mod, ctx, *args):
 def backward_template(py_mod, generate_lm, ctx, *args):
     ks_args = make_tuple_if_many_args(torch_to_ks(py_mod, x) for x in ctx.saved_tensors)
     ks_grad_args = make_tuple_if_many_args(torch_to_ks(py_mod, x) for x in args)
-    if generate_lm:
-        outputs = py_mod.rev_entry(ks_args, ks_grad_args)
-    else:
-        outputs = py_mod.sufrev_entry(ks_args, ks_grad_args)
-
+    rev_entry = py_mod.rev_entry if generate_lm else py_mod.sufrev_entry
+    outputs = rev_entry(ks_args, ks_grad_args)
     return torch_from_ks(outputs)
 
 


### PR DESCRIPTION
When wrapping ks code as a `torch.autograd.Function`, PR #762 unconditionally uses `sufrev_entry` to implement `backward` (see commit https://github.com/microsoft/knossos-ksc/pull/762/commits/25db62cdb7d9edef53f596c9d2ed973de5b12abd ). This breaks `ts2mod` when `generate_lm=True` is requested.

Similarly, PR #820 is broken in that, although you can request SUF in ts2mod, the resulting module cannot actually be used as an autograd.Function because this would call the non-existent function `rev_entry`.

To fix this, this PR passes the `generate_lm` argument down to the place where `backward` is implemented, so that we can use either `rev_entry` or `sufrev_entry` as appropriate.
