### PR TITLE
Assert that Let vars are not decl

### DIFF
--- a/src/python/ksc/expr.py
+++ b/src/python/ksc/expr.py
@@ -436,6 +436,8 @@ class Let(Expr):
 
     def __init__(self, vars, rhs, body, type=None):
         super().__init__(vars=vars, rhs=rhs, body=body, type_=type)
+        var_list = [self.vars] if isinstance(self.vars, Var) else self.vars
+        assert all(not v.decl for v in var_list)
 
 
 class If(Expr):


### PR DESCRIPTION
This continues in the theme of #827. `Let` vars *never* have `decl` set - the current codebase is 100% consistent on that front. So, this PR adds an assertion to enforce this (i.e. make sure we stay consistent in the future!). The assert also provides some documentation.

There is a counterargument that we do not generally check vars elsewhere aren't `decl`, so why should we do so here? But I think we should so that we make clear that `decl` does not mean "binding occurrence".

A further extension might be to assert that `decl` *is* set for Def args, not done in this PR.