### PR TITLE
Run benchmark on PR but don't upload to Azure

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -49,7 +49,7 @@ jobs:
       # It grants the following roles (read,list,create) which is enough for the action to add a new result,
       # and other actions to aggregate the results.
       - name: 'Upload result via AzCopy (if on master)'
-        if: contains(github.ref, "master")
+        if: contains(github.ref, 'master')
         env:
           BENCHMARK_SAS: ${{ secrets.BENCHMARK_SAS }}
         run: |


### PR DESCRIPTION
Context here: https://github.com/microsoft/knossos-ksc/pull/855#issuecomment-856900161 where the nightly benchmark would have failed.

Still uploads to the artifacts.

We don't upload to Azure off master, we could and just filter but for now this added a correctness test without complicating the comparison.