### PR TITLE
Ensure the preview CI Build has the preview Torch

### DIFF
--- a/test/builds/test_pytest_PyTorchPreview.cmd
+++ b/test/builds/test_pytest_PyTorchPreview.cmd
@@ -18,7 +18,7 @@ REM Too big, throw memory exception https://stackoverflow.com/a/31526029/35544
 REM currently have backend issues on PyTorch 1.8.0 https://github.com/microsoft/knossos-ksc/issues/659 so trying nightly
 echo Installing dependencies...
 python -m pip install --use-deprecated=legacy-resolver --no-cache-dir -r src/python/requirements.txt -f https://download.pytorch.org/whl/torch_stable.html || exit /b
-python -m pip uninstall torch
+python -m pip uninstall -y torch
 python -m pip install --pre --use-deprecated=legacy-resolver --no-cache-dir pytest numpy torch -f https://download.pytorch.org/whl/nightly/cu111/torch_nightly.html || exit /b
 
 echo Installing ksc...


### PR DESCRIPTION
This one is a bit messy. After moving Python TS2K into KSC in #860 we need to first get rid of the stable version of Torch before trying to install the preview version of Torch or pip won't install - we don't want to specify the preview version string as that changes.

Currently this breaks on the nightly preview test we have in place to detect Windows breakages.

I'm going to have a think if there's a nicer way to do this by splitting requirements files but this restores a working state for now.