### PR TITLE
Benchmark: use no_grad() in PyTorch for inference

### DIFF
--- a/src/bench/test_run_bench.py
+++ b/src/bench/test_run_bench.py
@@ -7,8 +7,9 @@ cpu_device = torch.device("cpu")
 
 def test_inference(benchmark, reference_func, func, config):
     config_on_func_device = func.to_device(config)
-    result = benchmark(func.func, config_on_func_device).to(cpu_device)
-    reference_result = reference_func(config)
+    with torch.no_grad():
+        result = benchmark(func.func, config_on_func_device).to(cpu_device)
+        reference_result = reference_func(config)
     # TODO: generalise correctness test as examples require more than single tensor
     assert torch.allclose(
         result, reference_result


### PR DESCRIPTION
Using longer runs (5 seconds) from #894 

Before:
![image](https://user-images.githubusercontent.com/1099725/123236561-30694b80-d4dd-11eb-8dae-4ab9ea4c197e.png)

After:
![image](https://user-images.githubusercontent.com/1099725/123236664-48d96600-d4dd-11eb-952e-025ac34c6063.png)

It's possible this helped inference but note there are some overall shifts on forward and backwards as well. Given this is the right thing to do I suggest adding this in any case.