### PR TITLE
Add a function to convert Defs to one-arg

### DIFF
--- a/src/python/ksc/oneargify_defs.py
+++ b/src/python/ksc/oneargify_defs.py
@@ -1,0 +1,25 @@
+from typing import List, Iterable
+from ksc.cav_subst import make_nonfree_var
+from ksc.expr import ASTNode, Def, Let, Var
+from ksc.untuple_lets import untuple_one_let
+from ksc.type import Type
+
+
+def oneargify_def(d: Def) -> Def:
+    if len(d.args) == 1:
+        return d
+    tuple_arg = make_nonfree_var(
+        "func_arg", [d.body] + d.args, type=Type.Tuple(*[a.type_ for a in d.args]),
+    )
+    return Def(
+        d.name,
+        d.return_type,
+        args=[Var(tuple_arg.name, decl=True, type=tuple_arg.type_)],
+        body=untuple_one_let(
+            Let([Var(a.name, a.type_) for a in d.args], tuple_arg, d.body)
+        ),
+    )
+
+
+def oneargify_defs(decls: Iterable[ASTNode]) -> List[ASTNode]:
+    return [oneargify_def(decl) if isinstance(decl, Def) else decl for decl in decls]

--- a/test/python/test_oneargify_defs.py
+++ b/test/python/test_oneargify_defs.py
@@ -1,0 +1,52 @@
+from ksc.oneargify_defs import oneargify_def, oneargify_defs
+from ksc.parse_ks import parse_ks_file
+from ksc.utils import single_elem
+from ksc.type_propagate import type_propagate, type_propagate_decls
+
+
+def test_oneargify_def(prelude_symtab):
+    d, expected = list(
+        parse_ks_file(
+            """
+(def foo Float ((a : Float) (b : Float)) (mul (add a 2.0) (add b 3.0)))
+(def foo Float (func_arg_0 : Tuple Float Float)
+    (let (a (get$1$2 func_arg_0))
+       (let (b (get$2$2 func_arg_0))
+           (mul (add a 2.0) (add b 3.0)))))
+    """
+        )
+    )
+    type_propagate(d, prelude_symtab)
+    actual = oneargify_def(d)
+    type_propagate(expected, prelude_symtab)
+    assert actual == expected
+
+
+def test_oneargify_defs(prelude_symtab):
+    decls = list(
+        parse_ks_file(
+            """
+(edef foo Float (Tuple Float Float))
+(def inc Integer (x : Integer) (add x 1))
+(def rev (Tuple Float Float) (x : Tuple Float Float) (tuple (get$2$2 x) (get$1$2 x)))
+(rule "rev_of_rev" (in : Tuple Float Float) (rev (rev in)) in)
+(def twoarg Float ((a : Float) (b : Float)) (foo a b))
+"""
+        )
+    )
+    expected_twoarg = single_elem(
+        list(
+            parse_ks_file(
+                """
+(def twoarg Float (func_arg_0 : Tuple Float Float)
+    (let (a (get$1$2 func_arg_0))
+        (let (b (get$2$2 func_arg_0))
+            (foo a b))))
+    """
+            )
+        )
+    )
+    type_propagate_decls(decls, prelude_symtab)
+    type_propagate(expected_twoarg, prelude_symtab)
+    # Check edef + rule are preserved
+    assert oneargify_defs(decls) == decls[:-1] + [expected_twoarg]


### PR DESCRIPTION
E.g. `(def foo Float ((a : Float) (b : Float)) (mul (add a 2.0) (add b 3.0)))` becomes:
```
(def foo Float (func_arg_0 : Tuple Float Float)
    (let (a (get$1$2 func_arg_0))
       (let (b (get$2$2 func_arg_0))
           (mul (add a 2.0) (add b 3.0)))))
```

tests may be a bit over the top, this is fairly simple. (And the version taking a list of ASTNodes may never be needed, but it is...one line)