### PR TITLE
Remove deprecated function __make_cpp_str

### DIFF
--- a/src/python/ksc/ks_function.py
+++ b/src/python/ksc/ks_function.py
@@ -1,6 +1,8 @@
 from ksc.utils import translate_and_import
 from ksc.compile import generate_and_compile_cpp_from_ks
+from ksc.expr import make_structured_name
 from ksc.shape import ShapeType, shape_type_from_object
+from ksc.type import make_tuple_if_many
 
 
 class KsFunction:
@@ -62,7 +64,15 @@ class KsFunction:
         if backend == "cpp":
             if self._py_mod is None:
                 self._py_mod = generate_and_compile_cpp_from_ks(
-                    ks_str, self.name, self._arg_types
+                    ks_str,
+                    [
+                        (
+                            "entry",
+                            make_structured_name(
+                                (self.name, make_tuple_if_many(self._arg_types))
+                            ),
+                        )
+                    ],
                 )
         else:
             if self._py_mod is None:


### PR DESCRIPTION
Follows on from #865.

When compiling ks to a python module, we now always specify the entry-points using structured names. This PR removes the one remaining place where we were not using structured names.
