### PR TITLE
Don't raise exception if we can't achieve min_rounds within duration

### DIFF
--- a/src/bench/benchmark_shim.py
+++ b/src/bench/benchmark_shim.py
@@ -36,10 +36,6 @@ def benchmark_semi_pedantic(
 
     # Choose how many time we must repeat the test
     rounds = int(ceil(benchmark._max_time / duration))
-    if rounds < benchmark._min_rounds:
-        raise Exception(
-            f"""Duration({duration}) and min_rounds({benchmark._min_rounds}) can't be completed within max_time({benchmark._max_time})"""
-        )
     rounds = max(rounds, benchmark._min_rounds)
     rounds = min(rounds, sys.maxsize)
 


### PR DESCRIPTION
(Just continue anyway however long it takes)

This PR is part question, part issue, part proposed solution.  I don't understand why there's an exception if we can't achieve `min_rounds` in the given duration. The very next line chooses the greater of `rounds` and `benchmark._min_rounds` and it's redundant if the exception is thrown, because if we hit it `rounds >= benchmark._min_rounds`.

I want to be able to override `min_rounds` from the command line and this exception is preventing me from doing that. I suggest just removing the exception. Does that make sense?

