### PR TITLE
Loosen benchmark time check

### DIFF
--- a/src/bench/benchmark_shim.py
+++ b/src/bench/benchmark_shim.py
@@ -36,7 +36,7 @@ def benchmark_semi_pedantic(
 
     if duration > benchmark._max_time:
         raise Exception(
-            f"""Duration({duration}) of even a single benchmark round is greater than max_time({benchmark._max_time}), aborting."""
+            f"""The duration({duration}) of a single run of the benchmark function was longer than max_time({benchmark._max_time}), aborting."""
         )
 
     # Choose how many time we must repeat the test


### PR DESCRIPTION
Only abort if even a single round is over the max_time. Previously it enforced rounds * duration < max_time but that was getting in the way, see #907 

This check prevents incredibly slow benchmarks blocking nightly runs but hopefully gets in the way less.

Note this may want revising further later, we really want per benchmark time limiting which isn't configurable on pytest-benchmark as-is.