### PR TITLE
Add ExprHashedWithAlpha wrapper class for python dict/set

### DIFF
--- a/src/python/ksc/alpha_equiv.py
+++ b/src/python/ksc/alpha_equiv.py
@@ -86,7 +86,7 @@ def _alpha_equiv_lam(left: Lam, right: Expr, var_map: BoundVarBijection) -> bool
 
 ###############################################################################
 # Hash modulo alpha, i.e. respecting the above:
-#    are_alpha_equivalent(a,b) ==> alpha_hash(a) == alpha_hash(b)
+#    are_alpha_equivalent(a,b) ==> hash_with_alpha(a) == hash_with_alpha(b)
 
 
 def _hash_str(s: str) -> int:
@@ -134,19 +134,19 @@ def _alpha_hash_helper(e: Expr, reverse_debruijn_vars: PMap[str, int]) -> int:
 
 
 @_alpha_hash_helper.register
-def _alpha_hash_const(c: Const, reverse_debruijn_vars: PMap[str, int]) -> int:
+def _hash_with_alpha_const(c: Const, reverse_debruijn_vars: PMap[str, int]) -> int:
     # System hash() is repeatable for int/float but not str.
     return _hash_str(c.value) if isinstance(c.value, str) else hash(c.value)
 
 
 @_alpha_hash_helper.register
-def _alpha_hash_call(c: Call, reverse_debruijn_vars: PMap[str, int]) -> int:
+def _hash_with_alpha_call(c: Call, reverse_debruijn_vars: PMap[str, int]) -> int:
     # StructuredName can be hash()'d directly but again this depends on PYTHONHASHSEED.
     return _hash_children(_hash_str(str(c.name)), c, reverse_debruijn_vars)
 
 
 @_alpha_hash_helper.register
-def _alpha_hash_var(v: Var, reverse_debruijn_vars: PMap[str, int]) -> int:
+def _hash_with_alpha_var(v: Var, reverse_debruijn_vars: PMap[str, int]) -> int:
     reverse_debruijn_idx = reverse_debruijn_vars.get(v.name)
     if reverse_debruijn_idx is not None:
         return len(reverse_debruijn_vars) - reverse_debruijn_idx
@@ -155,7 +155,7 @@ def _alpha_hash_var(v: Var, reverse_debruijn_vars: PMap[str, int]) -> int:
 
 
 @_alpha_hash_helper.register
-def _alpha_hash_let(l: Let, reverse_debruijn_vars: PMap[str, int]) -> int:
+def _hash_with_alpha_let(l: Let, reverse_debruijn_vars: PMap[str, int]) -> int:
     return hash(
         (
             _class_hashes[Let],
@@ -166,7 +166,7 @@ def _alpha_hash_let(l: Let, reverse_debruijn_vars: PMap[str, int]) -> int:
 
 
 @_alpha_hash_helper.register
-def _alpha_hash_lam(l: Lam, reverse_debruijn_vars: PMap[str, int]) -> int:
+def _hash_with_alpha_lam(l: Lam, reverse_debruijn_vars: PMap[str, int]) -> int:
     return hash(
         (
             _class_hashes[Lam],
@@ -175,19 +175,19 @@ def _alpha_hash_lam(l: Lam, reverse_debruijn_vars: PMap[str, int]) -> int:
     )
 
 
-def alpha_hash(e: Expr):
+def hash_with_alpha(e: Expr):
     return _alpha_hash_helper(e, pmap())
 
 
-class AlphaHashWrapper(NamedTuple):
-    """ Allows alpha_hash and are_alpha_equivalent to be used with a python set/dict """
+class ExprHashedWithAlpha(NamedTuple):
+    """ Allows hash_with_alpha and are_alpha_equivalent to be used with a python set/dict """
 
     expr: Expr
 
     def __hash__(self):
-        return alpha_hash(self.expr)
+        return hash_with_alpha(self.expr)
 
     def __eq__(self, other):
-        return isinstance(other, AlphaHashWrapper) and are_alpha_equivalent(
+        return isinstance(other, ExprHashedWithAlpha) and are_alpha_equivalent(
             self.expr, other.expr
         )

--- a/test/python/test_alpha_equiv.py
+++ b/test/python/test_alpha_equiv.py
@@ -1,4 +1,8 @@
-from ksc.alpha_equiv import are_alpha_equivalent, alpha_hash, AlphaHashWrapper
+from ksc.alpha_equiv import (
+    are_alpha_equivalent,
+    hash_with_alpha,
+    ExprHashedWithAlpha,
+)
 from ksc.expr import Const, Let, Var
 from ksc.parse_ks import parse_expr_string
 from ksc.type_propagate import type_propagate_decls, type_propagate
@@ -9,13 +13,13 @@ def test_alpha_equivalence():
     exp1 = parse_expr_string("(let (x (add z 1.0)) (mul x 2.0))")
     exp2 = parse_expr_string("(let (x (add z 1.0)) (mul x 2.1))")
     assert not are_alpha_equivalent(exp1, exp2)
-    assert alpha_hash(exp1) != alpha_hash(exp2)
+    assert hash_with_alpha(exp1) != hash_with_alpha(exp2)
     exp3 = parse_expr_string("(let (y (add z 1.0)) (mul y 2.0))")
     assert are_alpha_equivalent(exp1, exp3)
-    assert alpha_hash(exp1) == alpha_hash(exp3)
+    assert hash_with_alpha(exp1) == hash_with_alpha(exp3)
     exp4 = parse_expr_string("(let (x (add z 1.0)) (mul y 2.0))")
     assert not are_alpha_equivalent(exp1, exp4)
-    assert alpha_hash(exp1) != alpha_hash(exp4)
+    assert hash_with_alpha(exp1) != hash_with_alpha(exp4)
 
 
 def test_alpha_equivalence_aliasing():
@@ -24,13 +28,13 @@ def test_alpha_equivalence_aliasing():
     exp1 = Let(Var("x"), Const(1), Let(Var("y"), Const(2), body))
     exp2 = Let(Var("y"), Const(1), Let(Var("x"), Const(2), body))
     assert not are_alpha_equivalent(exp1, exp2)
-    assert alpha_hash(exp1) != alpha_hash(exp2)
+    assert hash_with_alpha(exp1) != hash_with_alpha(exp2)
 
     # But other variables can be alpha-renamed and Expr's still be equal.
     exp3 = Let(Var("a"), Const(1), Let(Var("b"), Const(2), body))
     exp4 = Let(Var("b"), Const(1), Let(Var("a"), Const(2), body))
     assert are_alpha_equivalent(exp3, exp4)
-    assert alpha_hash(exp3) == alpha_hash(exp4)
+    assert hash_with_alpha(exp3) == hash_with_alpha(exp4)
 
 
 def test_alpha_equivalence_diff_types():
@@ -38,11 +42,11 @@ def test_alpha_equivalence_diff_types():
     x_again = Var("x")
     assert x == x_again
     assert are_alpha_equivalent(x, x_again)
-    assert alpha_hash(x) == alpha_hash(x_again)
+    assert hash_with_alpha(x) == hash_with_alpha(x_again)
     x_again.type_ = Type.Integer
     assert x == x_again  # Allows different type
     assert are_alpha_equivalent(x, x_again)
-    assert alpha_hash(x) == alpha_hash(x_again)
+    assert hash_with_alpha(x) == hash_with_alpha(x_again)
 
 
 def test_alpha_equivalence_type_propagation(prelude_symtab):
@@ -53,11 +57,11 @@ def test_alpha_equivalence_type_propagation(prelude_symtab):
     type_propagate(exp1, symtab)
     assert exp1 != exp2  # One has resolved calls to StructuredNames
     assert not are_alpha_equivalent(exp1, exp2)
-    assert alpha_hash(exp1) != alpha_hash(exp2)
+    assert hash_with_alpha(exp1) != hash_with_alpha(exp2)
     type_propagate(exp2, symtab)
     assert exp1 == exp2
     assert are_alpha_equivalent(exp1, exp2)
-    assert alpha_hash(exp1) == alpha_hash(exp2)
+    assert hash_with_alpha(exp1) == hash_with_alpha(exp2)
 
 
 def test_alpha_equivalence_shadows_free():
@@ -66,10 +70,10 @@ def test_alpha_equivalence_shadows_free():
     e_diff = parse_expr_string("(lam (q : Bool) (assert p q))")
     type_propagate_decls([e, e_renamed, e_diff], {"p": Type.Bool})
     assert are_alpha_equivalent(e, e_renamed)
-    assert alpha_hash(e) == alpha_hash(e_renamed)
+    assert hash_with_alpha(e) == hash_with_alpha(e_renamed)
     # These two are different because in one case q binds p but in the other case p2 does not bind p
     assert not are_alpha_equivalent(e, e_diff)
-    assert alpha_hash(e) != alpha_hash(e_diff)
+    assert hash_with_alpha(e) != hash_with_alpha(e_diff)
     # This demonstrates the need to check the right bound var is not used other than in correspondence to the left bound var
     assert not are_alpha_equivalent(e_diff, e)
 
@@ -82,7 +86,7 @@ def test_alpha_equiv_two_lets():
     type_propagate_decls([e, e2], {})
     assert are_alpha_equivalent(e, e2)
     assert are_alpha_equivalent(e2, e)
-    assert alpha_hash(e) == alpha_hash(e2)
+    assert hash_with_alpha(e) == hash_with_alpha(e2)
 
 
 def test_alpha_equiv_all_node_types():
@@ -93,18 +97,18 @@ def test_alpha_equiv_all_node_types():
         "(lam (c : Float) (let (d (if (gt c 0.0) c 0.0)) (assert (gte d 0.0) d)))"
     )
     assert are_alpha_equivalent(e1, e2)
-    assert alpha_hash(e1) == alpha_hash(e2)
+    assert hash_with_alpha(e1) == hash_with_alpha(e2)
 
     e_diff = parse_expr_string(
         "(lam (a : Float) (let (b (if (gte a 0.0) a 0.0)) (assert (gte b 0.0) b)))"
     )
     assert not are_alpha_equivalent(e1, e_diff)
-    assert alpha_hash(e1) != alpha_hash(e_diff)
+    assert hash_with_alpha(e1) != hash_with_alpha(e_diff)
 
 
-def test_alpha_hash_wrapper():
+def test_hash_with_alpha_wrapper():
     exprs = [
-        AlphaHashWrapper(parse_expr_string(s))
+        ExprHashedWithAlpha(parse_expr_string(s))
         for s in [
             ("(let (x 3) (add x x))"),
             ("(let (y 3) (add y y))"),
@@ -114,7 +118,7 @@ def test_alpha_hash_wrapper():
     s = set(exprs)
     assert len(s) == 2
     assert s == frozenset(exprs[1:])
-    z = AlphaHashWrapper(parse_expr_string("(let (z 3) (add z z))"))
+    z = ExprHashedWithAlpha(parse_expr_string("(let (z 3) (add z z))"))
     s.remove(z)
     assert s == frozenset([exprs[2]])
 


### PR DESCRIPTION
This allows using are_alpha_equivalent and alpha_hash with a normal dict/set, which depend upon the definition of == and `hash()`