### PR TITLE
Refactor how rewrite.py passes delayed match application (for typing & clarity) 

### DIFF
--- a/src/python/ksc/rewrites.py
+++ b/src/python/ksc/rewrites.py
@@ -63,11 +63,8 @@ from ksc.visitors import ExprTransformer
 @dataclass(frozen=True)
 class Match:
     rule: "RuleMatcher"
-    apply: Callable[[], Expr]
+    apply_rewrite: Callable[[], Expr]
     ewp: ExprWithPath
-
-    def apply_rewrite(self):
-        return self.apply()
 
     @property
     def path(self):
@@ -211,7 +208,7 @@ class inline_var(RuleMatcher):
                 ),  # No applicator; renaming will prevent capturing let.rhs, so just insert that
             )
 
-        yield Match(ewp=ewp, rule=self, apply=apply)
+        yield Match(ewp=ewp, rule=self, apply_rewrite=apply)
 
 
 @singleton
@@ -252,7 +249,7 @@ class inline_call(RuleMatcher):
             # In the meantime, the 0.0 here (as elsewhere) indicates there are no variables to avoid capturing.
             return replace_subtree(ewp.root, ewp.path, Const(0.0), apply_here)
 
-        yield Match(ewp=ewp, rule=self, apply=apply)
+        yield Match(ewp=ewp, rule=self, apply_rewrite=apply)
 
 
 @singleton
@@ -276,7 +273,7 @@ class delete_let(RuleMatcher):
                 # The constant just has no free variables that we want to avoid being captured
                 return replace_subtree(ewp.root, ewp.path, Const(0.0), apply_here)
 
-            yield Match(ewp=ewp, rule=self, apply=apply)
+            yield Match(ewp=ewp, rule=self, apply_rewrite=apply)
 
 
 ###############################################################################
@@ -346,7 +343,7 @@ class ParsedRuleMatcher(RuleMatcher):
                 # The constant just has no free variables that we want to avoid being captured
                 return replace_subtree(ewp.root, ewp.path, Const(0.0), apply_here)
 
-            yield Match(ewp=ewp, rule=self, apply=apply)
+            yield Match(ewp=ewp, rule=self, apply_rewrite=apply)
 
 
 def _combine_substs(

--- a/src/python/ksc/rewrites_prelude.py
+++ b/src/python/ksc/rewrites_prelude.py
@@ -40,7 +40,7 @@ class ConstantFolder(RuleMatcher):
 
                 return replace_subtree(ewp.root, ewp.path, Const(0.0), apply_here)
 
-            yield Match(ewp=ewp, rule=self, apply=apply)
+            yield Match(ewp=ewp, rule=self, apply_rewrite=apply)
 
 
 constant_folding_rules = [ConstantFolder(sn, func) for sn, func in native_impls.items()]


### PR DESCRIPTION
Follow on from #920 

Instead of creating a Match with a variable number of custom parameters then dispatched by an ABC, then filling in kwargs. Can we instead just create a callable and let it be run on demand?

The benefit is that it keeps the parameter handling local, so could do away with lots of the comments. It's going to type check, which the "specialisation" of kwargs isn't accepted by mypy, even if we add kwargs to the overriding functions.