### PR TITLE
Doctests of path.py, run from test_pytest.sh

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,7 +2,7 @@
 addopts =
     --strict-markers
     --doctest-modules
-    --doctest-glob src/python/ksc/*.py
+    --doctest-glob src/python/ksc/path.py
 
 testpaths =
     test

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,9 @@
 [pytest]
-addopts = --strict-markers
+addopts =
+    --strict-markers
+    --doctest-modules
+    --doctest-glob src/python/ksc/*.py
+
 testpaths =
     test
 #    src/bench remove until fast enough at discovery time

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,8 +1,7 @@
 [pytest]
 addopts =
     --strict-markers
-    --doctest-modules
-    --doctest-glob src/python/ksc/path.py
+    --doctest-modules src/python/ksc/path.py
 
 testpaths =
     test

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,8 +1,5 @@
 [pytest]
-addopts =
-    --strict-markers
-    --doctest-modules src/python/ksc/path.py
-
+addopts = --strict-markers
 testpaths =
     test
 #    src/bench remove until fast enough at discovery time

--- a/src/python/ksc/path.py
+++ b/src/python/ksc/path.py
@@ -4,12 +4,10 @@ each of which identifies a field of an Expr subclass or one argument of a Call.
 >>> e = Let(Var("a"), Const(5), Call("add", [Const(3), Var("b")]))
 >>> str(let_rhs.get(e))
 '5'
->>> lam_body.get(e)
+>>> lam_body.get(e)  # doctest: +ELLIPSIS
 Traceback (most recent call last):
 ...
 AssertionError...
->>> # Note the final ... allows to pass with pytest, but *not* python -m doctest;
->>> # without the ... it passes with python -m doctest, but not pytest :(
 
 ExprWithPath allows traversing an expr, and listing the addressable subexprs.
 >>> ewp = ExprWithPath.from_expr(e)
@@ -31,6 +29,17 @@ Traceback (most recent call last):
 IndexError: list index out of range
 >>> ExprWithPath.from_expr(e).all_subexprs_with_paths()  # doctest: +ELLIPSIS
 [ExprWithPath(..., path=(Let.rhs,), expr=<ksc.expr.Const...), ExprWithPath(..., path=(Let.body,), expr=<ksc.expr.Call...)]
+
+ExprWithPath also allows directly accessing other members of the Expr
+ (that are not addressable by a Path):
+>>> ewp.vars   # doctest: +ELLIPSIS
+<ksc.expr.Var...>
+>>> str(ewp.vars)
+'a'
+>>> ewp.body  # doctest: +ELLIPSIS
+ExprWithPath(...)
+>>> ewp.body.name
+StructuredName(add)
 """
 
 from collections.abc import Sequence as AbstractSeq

--- a/src/python/ksc/path.py
+++ b/src/python/ksc/path.py
@@ -4,6 +4,11 @@ each of which identifies a field of an Expr subclass or one argument of a Call.
 >>> e = Let(Var("a"), Const(5), Call("add", [Const(3), Var("b")]))
 >>> str(let_rhs.get(e))
 '5'
+>>> lam_body.get(e)
+Traceback (most recent call last):
+...
+AssertionError
+
 
 ExprWithPath allows traversing and navigating an expr, and listing the
 subexprs which also have paths
@@ -13,6 +18,10 @@ subexprs which also have paths
 (Let.body, call_args[0])
 >>> str(ExprWithPath.from_expr(e, [let_body, call_args[0]]).expr)
 '3'
+>>> ExprWithPath.from_expr(e, [let_body, call_args[2]])
+Traceback (most recent call last):
+...
+IndexError: list index out of range
 >>> ExprWithPath.from_expr(e).all_subexprs_with_paths() == [
 ... ExprWithPath.from_expr(e, [let_rhs]), ExprWithPath.from_expr(e, [let_body])
 ... ]

--- a/src/python/ksc/path.py
+++ b/src/python/ksc/path.py
@@ -14,17 +14,17 @@ ExprWithPath allows traversing an expr, and listing the addressable subexprs.
 >>> ewp.path
 ()
 >>> ewp.rhs
-ExprWithPath(..., path=(Let.rhs,), expr=5)
+ExprWithPath(..., path=(let_rhs,), expr=5)
 >>> ewp.body.args[0]
-ExprWithPath(..., path=(Let.body, call_args[0]), expr=3)
+ExprWithPath(..., path=(let_body, call_args[0]), expr=3)
 >>> ExprWithPath.from_expr(e, [let_body, call_args[0]])
-ExprWithPath(..., path=(Let.body, call_args[0]), expr=3)
+ExprWithPath(..., path=(let_body, call_args[0]), expr=3)
 >>> ExprWithPath.from_expr(e, [let_body, call_args[2]])
 Traceback (most recent call last):
 ...
 IndexError: list index out of range
 >>> ExprWithPath.from_expr(e).all_subexprs_with_paths()
-[ExprWithPath(..., path=(Let.rhs,), expr=5), ExprWithPath(..., path=(Let.body,), expr=(Call...))]
+[ExprWithPath(..., path=(let_rhs,), expr=5), ExprWithPath(..., path=(let_body,), expr=(Call...))]
 
 ExprWithPath also allows directly accessing other members of the Expr
  (which do not have Paths):

--- a/src/python/ksc/path.py
+++ b/src/python/ksc/path.py
@@ -1,6 +1,7 @@
 """
 Paths identify nodes (sub-expressions) within Expr's as a sequence of PathElements
 each of which identifies a field of an Expr subclass or one argument of a Call.
+>>> # doctests - run specifically for this file in pytest.ini
 >>> e = Let(Var("a"), Const(5), Call("add", [Const(3), Var("b")]))
 >>> let_rhs.get(e)
 5
@@ -18,7 +19,7 @@ ExprWithPath(..., path=(let_rhs,), expr=5)
 >>> ewp.body.args[0]
 ExprWithPath(..., path=(let_body, call_args[0]), expr=3)
 >>> ExprWithPath.from_expr(e, [let_body, call_args[0]])
-THIS SHOULD FAIL ExprWithPath(..., path=(let_body, call_args[0]), expr=3)
+ExprWithPath(..., path=(let_body, call_args[0]), expr=3)
 >>> ExprWithPath.from_expr(e, [let_body, call_args[2]])
 Traceback (most recent call last):
 ...

--- a/src/python/ksc/path.py
+++ b/src/python/ksc/path.py
@@ -2,8 +2,8 @@
 Paths identify nodes (sub-expressions) within Expr's as a sequence of PathElements
 each of which identifies a field of an Expr subclass or one argument of a Call.
 >>> e = Let(Var("a"), Const(5), Call("add", [Const(3), Var("b")]))
->>> str(let_rhs.get(e))
-'5'
+>>> let_rhs.get(e)
+5
 >>> lam_body.get(e)
 Traceback (most recent call last):
 ...
@@ -14,28 +14,22 @@ ExprWithPath allows traversing an expr, and listing the addressable subexprs.
 >>> ewp.path
 ()
 >>> ewp.rhs
-ExprWithPath(..., path=(Let.rhs,), expr=<ksc.expr.Const...)
->>> str(ewp.rhs.expr)
-'5'
+ExprWithPath(..., path=(Let.rhs,), expr=5)
 >>> ewp.body.args[0]
-ExprWithPath(..., path=(Let.body, call_args[0]), expr=<ksc.expr.Const...)
->>> str(ewp.body.args[0].expr)
-'3'
->>> str(ExprWithPath.from_expr(e, [let_body, call_args[0]]).expr)
-'3'
+ExprWithPath(..., path=(Let.body, call_args[0]), expr=3)
+>>> ExprWithPath.from_expr(e, [let_body, call_args[0]])
+ExprWithPath(..., path=(Let.body, call_args[0]), expr=3)
 >>> ExprWithPath.from_expr(e, [let_body, call_args[2]])
 Traceback (most recent call last):
 ...
 IndexError: list index out of range
 >>> ExprWithPath.from_expr(e).all_subexprs_with_paths()
-[ExprWithPath(..., path=(Let.rhs,), expr=<ksc.expr.Const...), ExprWithPath(..., path=(Let.body,), expr=<ksc.expr.Call...)]
+[ExprWithPath(..., path=(Let.rhs,), expr=5), ExprWithPath(..., path=(Let.body,), expr=(Call...))]
 
 ExprWithPath also allows directly accessing other members of the Expr
- (that are not addressable by a Path):
+ (which do not have Paths):
 >>> ewp.vars
-<ksc.expr.Var...>
->>> str(ewp.vars)
-'a'
+a
 >>> ewp.body
 ExprWithPath(...)
 >>> ewp.body.name

--- a/src/python/ksc/path.py
+++ b/src/python/ksc/path.py
@@ -18,7 +18,7 @@ ExprWithPath(..., path=(let_rhs,), expr=5)
 >>> ewp.body.args[0]
 ExprWithPath(..., path=(let_body, call_args[0]), expr=3)
 >>> ExprWithPath.from_expr(e, [let_body, call_args[0]])
-ExprWithPath(..., path=(let_body, call_args[0]), expr=3)
+THIS SHOULD FAIL ExprWithPath(..., path=(let_body, call_args[0]), expr=3)
 >>> ExprWithPath.from_expr(e, [let_body, call_args[2]])
 Traceback (most recent call last):
 ...

--- a/src/python/ksc/path.py
+++ b/src/python/ksc/path.py
@@ -1,7 +1,7 @@
 """
 Paths identify nodes (sub-expressions) within Expr's as a sequence of PathElements
 each of which identifies a field of an Expr subclass or one argument of a Call.
->>> # doctests - run specifically for this file in pytest.ini
+>>> # doctests - run specifically for this file in test_pytest.sh
 >>> e = Let(Var("a"), Const(5), Call("add", [Const(3), Var("b")]))
 >>> let_rhs.get(e)
 5

--- a/src/python/ksc/path.py
+++ b/src/python/ksc/path.py
@@ -9,23 +9,26 @@ Traceback (most recent call last):
 ...
 AssertionError
 
-
-ExprWithPath allows traversing and navigating an expr, and listing the
-subexprs which also have paths
->>> str(ExprWithPath.from_expr(e).rhs.expr)
+ExprWithPath allows traversing an expr, and listing the addressable subexprs.
+>>> ewp = ExprWithPath.from_expr(e)
+>>> ewp.path
+()
+>>> ewp.rhs  # doctest: +ELLIPSIS
+ExprWithPath(..., path=(Let.rhs,), ...)
+>>> str(ewp.rhs.expr)
 '5'
->>> ExprWithPath.from_expr(e).body.args[0].path
-(Let.body, call_args[0])
+>>> ewp.body.args[0]  # doctest: +ELLIPSIS
+ExprWithPath(..., path=(Let.body, call_args[0]), ...)
+>>> str(ewp.body.args[0].expr)
+'3'
 >>> str(ExprWithPath.from_expr(e, [let_body, call_args[0]]).expr)
 '3'
 >>> ExprWithPath.from_expr(e, [let_body, call_args[2]])
 Traceback (most recent call last):
 ...
 IndexError: list index out of range
->>> ExprWithPath.from_expr(e).all_subexprs_with_paths() == [
-... ExprWithPath.from_expr(e, [let_rhs]), ExprWithPath.from_expr(e, [let_body])
-... ]
-True
+>>> ExprWithPath.from_expr(e).all_subexprs_with_paths()  # doctest: +ELLIPSIS
+[ExprWithPath(..., path=(Let.rhs,), ...), ExprWithPath(..., path=(Let.body,), ...)]
 """
 
 from collections.abc import Sequence as AbstractSeq

--- a/src/python/ksc/path.py
+++ b/src/python/ksc/path.py
@@ -14,11 +14,11 @@ ExprWithPath allows traversing an expr, and listing the addressable subexprs.
 >>> ewp.path
 ()
 >>> ewp.rhs  # doctest: +ELLIPSIS
-ExprWithPath(..., path=(Let.rhs,), ...)
+ExprWithPath(..., path=(Let.rhs,), expr=<ksc.expr.Const...)
 >>> str(ewp.rhs.expr)
 '5'
 >>> ewp.body.args[0]  # doctest: +ELLIPSIS
-ExprWithPath(..., path=(Let.body, call_args[0]), ...)
+ExprWithPath(..., path=(Let.body, call_args[0]), expr=<ksc.expr.Const...)
 >>> str(ewp.body.args[0].expr)
 '3'
 >>> str(ExprWithPath.from_expr(e, [let_body, call_args[0]]).expr)
@@ -28,7 +28,7 @@ Traceback (most recent call last):
 ...
 IndexError: list index out of range
 >>> ExprWithPath.from_expr(e).all_subexprs_with_paths()  # doctest: +ELLIPSIS
-[ExprWithPath(..., path=(Let.rhs,), ...), ExprWithPath(..., path=(Let.body,), ...)]
+[ExprWithPath(..., path=(Let.rhs,), expr=<ksc.expr.Const...), ExprWithPath(..., path=(Let.body,), expr=<ksc.expr.Call...)]
 """
 
 from collections.abc import Sequence as AbstractSeq

--- a/src/python/ksc/path.py
+++ b/src/python/ksc/path.py
@@ -7,7 +7,9 @@ each of which identifies a field of an Expr subclass or one argument of a Call.
 >>> lam_body.get(e)
 Traceback (most recent call last):
 ...
-AssertionError
+AssertionError...
+>>> # Note the final ... allows to pass with pytest, but *not* python -m doctest;
+>>> # without the ... it passes with python -m doctest, but not pytest :(
 
 ExprWithPath allows traversing an expr, and listing the addressable subexprs.
 >>> ewp = ExprWithPath.from_expr(e)

--- a/src/python/ksc/path.py
+++ b/src/python/ksc/path.py
@@ -134,6 +134,14 @@ SerializedPath = List[str]
 
 
 def serialize_path(path: Path) -> SerializedPath:
+    """ Turns a path into a form that can be passed to json.dumps.
+    >>> serialize_path([let_rhs, call_args[0]])
+    ['let_rhs', 'call_args[0]']
+    >>> import json
+    >>> json.dumps(serialize_path([let_body, if_t_body, call_args[1]]))
+    '["let_body", "if_t_body", "call_args[1]"]'
+    """
+
     # There is no particular need to use str() to turn elements to strings,
     # but str() contains all the information that's needed.
     return [str(elem) for elem in path]

--- a/src/python/ksc/path.py
+++ b/src/python/ksc/path.py
@@ -4,7 +4,7 @@ each of which identifies a field of an Expr subclass or one argument of a Call.
 >>> e = Let(Var("a"), Const(5), Call("add", [Const(3), Var("b")]))
 >>> str(let_rhs.get(e))
 '5'
->>> lam_body.get(e)  # doctest: +ELLIPSIS
+>>> lam_body.get(e)
 Traceback (most recent call last):
 ...
 AssertionError...
@@ -13,11 +13,11 @@ ExprWithPath allows traversing an expr, and listing the addressable subexprs.
 >>> ewp = ExprWithPath.from_expr(e)
 >>> ewp.path
 ()
->>> ewp.rhs  # doctest: +ELLIPSIS
+>>> ewp.rhs
 ExprWithPath(..., path=(Let.rhs,), expr=<ksc.expr.Const...)
 >>> str(ewp.rhs.expr)
 '5'
->>> ewp.body.args[0]  # doctest: +ELLIPSIS
+>>> ewp.body.args[0]
 ExprWithPath(..., path=(Let.body, call_args[0]), expr=<ksc.expr.Const...)
 >>> str(ewp.body.args[0].expr)
 '3'
@@ -27,16 +27,16 @@ ExprWithPath(..., path=(Let.body, call_args[0]), expr=<ksc.expr.Const...)
 Traceback (most recent call last):
 ...
 IndexError: list index out of range
->>> ExprWithPath.from_expr(e).all_subexprs_with_paths()  # doctest: +ELLIPSIS
+>>> ExprWithPath.from_expr(e).all_subexprs_with_paths()
 [ExprWithPath(..., path=(Let.rhs,), expr=<ksc.expr.Const...), ExprWithPath(..., path=(Let.body,), expr=<ksc.expr.Call...)]
 
 ExprWithPath also allows directly accessing other members of the Expr
  (that are not addressable by a Path):
->>> ewp.vars   # doctest: +ELLIPSIS
+>>> ewp.vars
 <ksc.expr.Var...>
 >>> str(ewp.vars)
 'a'
->>> ewp.body  # doctest: +ELLIPSIS
+>>> ewp.body
 ExprWithPath(...)
 >>> ewp.body.name
 StructuredName(add)

--- a/test/builds/test_pytest.sh
+++ b/test/builds/test_pytest.sh
@@ -4,8 +4,8 @@ echo Installing dependencies...
 python3 -m pip install -r src/python/requirements.txt -f https://download.pytorch.org/whl/torch_stable.html
 python3 -m pip install pytest numpy torch==1.9.0+cu111 jax==0.1.57 jaxlib==0.1.37 -f https://download.pytorch.org/whl/torch_stable.html
 
-echo Running pytest
-python3 -m pytest test/python
+echo Running pytest '(+ doctest)'
+python3 -m pytest test/python --doctest-modules src/python/ksc/path.py
 
 echo Running pytest on ts2k
 python3 -m pytest test/ts2k

--- a/test/builds/test_pytest.sh
+++ b/test/builds/test_pytest.sh
@@ -7,6 +7,9 @@ python3 -m pip install pytest numpy torch==1.9.0+cu111 jax==0.1.57 jaxlib==0.1.3
 echo Running pytest
 python3 -m pytest test/python
 
+echo Running doctest
+python3 -m doctest src/python/ksc/*.py
+
 echo Running pytest on ts2k
 python3 -m pytest test/ts2k
 

--- a/test/builds/test_pytest.sh
+++ b/test/builds/test_pytest.sh
@@ -7,8 +7,8 @@ python3 -m pip install pytest numpy torch==1.9.0+cu111 jax==0.1.57 jaxlib==0.1.3
 echo Running pytest
 python3 -m pytest test/python
 
-echo Running doctest
-python3 -m doctest src/python/ksc/*.py
+echo Running pytest '(+ doctest)'
+python3 -m pytest test/python --doctest-modules $(ls src/python/ksc/*.py | grep -v '__init__')
 
 echo Running pytest on ts2k
 python3 -m pytest test/ts2k

--- a/test/builds/test_pytest.sh
+++ b/test/builds/test_pytest.sh
@@ -7,9 +7,6 @@ python3 -m pip install pytest numpy torch==1.9.0+cu111 jax==0.1.57 jaxlib==0.1.3
 echo Running pytest
 python3 -m pytest test/python
 
-echo Running pytest '(+ doctest)'
-python3 -m pytest test/python --doctest-modules $(ls src/python/ksc/*.py | grep -v '__init__')
-
 echo Running pytest on ts2k
 python3 -m pytest test/ts2k
 


### PR DESCRIPTION
This adds some usage examples of Path / ExprWithPath, whose correctness are tested by [doctest](https://docs.python.org/3/library/doctest.html), run within pytest using the [--doctest-modules flag](https://docs.pytest.org/en/6.2.x/doctest.html).

doctest is quite limited; majorly in that everything is about the text printed out by an interactive python interpreter session. So the examples have to fit that.

Besides pytest --doctest-modules, these can also be run directly from the command-line via `python -m doctest [-v] -o ELLIPSIS src/python/ksc/path.py`. The `-v` is useful for debugging; the ELLIPSIS because this seems to be turned on by default when running under pytest. Do we want to add `python3 -mdoctest -o ELLIPSIS src/python/ksc/*.py` to `test_pytest.sh` as an additional step to document this possibility?

(I think we want to keep the `pytest --doctest-modules` as `python3 -mdoctest` produces zero output upon success, so you can't even see anything's been run; with `-v` there are *reams* of output including every line of test, every expected+actual output, and every file scanned.)