### PR TITLE
double -> ks::Float

### DIFF
--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -101,8 +101,8 @@ sign, for example: `42` and `-123`.
 
 #### Float
 
-`Float` types are 64-bit IEE 754 double-precision floating point numbers. Other
-precisions could be considered in the future.
+`Float` types are 32-bit IEE 754 single-precision floating point numbers. Other
+precisions are an open issue (https://github.com/microsoft/knossos-ksc/issues/358)
 
 `Float` literals are numeric values with a decimal point, with optional sign,
 for example: `10.0` and `-1.23`. Scientific notation is not supported.

--- a/doc/sphinx/SYNTAX.md
+++ b/doc/sphinx/SYNTAX.md
@@ -101,8 +101,8 @@ sign, for example: `42` and `-123`.
 
 #### Float
 
-`Float` types are 64-bit IEE 754 double-precision floating point numbers. Other
-precisions could be considered in the future.
+`Float` types are 32-bit IEE 754 single-precision floating point numbers. Other
+precisions are an open issue (https://github.com/microsoft/knossos-ksc/issues/358)
 
 `Float` literals are numeric values with a decimal point, with optional sign,
 for example: `10.0` and `-1.23`. Scientific notation is not supported.

--- a/etc/prettify-cpp.sh
+++ b/etc/prettify-cpp.sh
@@ -5,12 +5,12 @@
 #   $ ./ksc  test/ksc/gmm.ks 
 #   $  sh etc/prettify-cpp.sh /tmp/t.cpp | grep -A 30 '^ty\$gmm_knossos_gmm_objective '
 # Will produce something like
-#   ty$gmm_knossos_gmm_objective gmm_knossos_gmm_objective(ks::allocator * alloc, tensor<1, tensor<1, double>> x, tensor<1, double> alphas, tensor<1, tensor<1, double>> means, tensor<1, tensor<1, double>> qs, tensor<1, tensor<1, double>> ls, tuple<double,int> wishart) {
+#   ty$gmm_knossos_gmm_objective gmm_knossos_gmm_objective(ks::allocator * alloc, tensor<1, tensor<1, Float>> x, tensor<1, Float> alphas, tensor<1, tensor<1, Float>> means, tensor<1, tensor<1, Float>> qs, tensor<1, tensor<1, Float>> ls, tuple<Float,int> wishart) {
 #   int c0 = size(x);
 #   int N = c0;
 #   int c1 = size(alphas);
 #   int K = c1;
-#   tensor<1, double> c2 = index(0, x);
+#   tensor<1, Float> c2 = index(0, x);
 #   ...
 
 

--- a/src/ksc/Cgen.hs
+++ b/src/ksc/Cgen.hs
@@ -205,12 +205,12 @@ allocatorUsageOfCType = \case
   LMVariant _    -> UsesAllocator
 
 -- CGenResult is (C declarations, C expression, CType)
--- e.g. (["double r; if (b) { r = 1; } else { r = 2; };"],
+-- e.g. (["ks::Float r; if (b) { r = 1; } else { r = 2; };"],
 --       "r",
---       TypeDouble)
+--       TypeFloat)
 -- e.g. ([],         -- simple constant needs no pre-declaration
 --       "1.0",      -- this is what we use at the occurrence
---       TypeDouble)
+--       TypeFloat)
 -- e.g. (["typedef LM::HCat<LM::VCat<LM::One, LM::Zero>,LM::Zero> v12_t;",
 --        "v12_t v12 = v12_t::mk(a,b);"]
 --       "v12",      -- this is what we use at the occurrence
@@ -714,7 +714,7 @@ cgenType = \case
 
 cgenTypeLang :: HasCallStack => Type -> String
 cgenTypeLang = \case
-  TypeFloat     -> "double" -- TODO: make these all ks_Float etc, and add typedefs in knossos.h
+  TypeFloat     -> "Float"
   TypeInteger   -> "int"
   TypeString    -> "std::string"
   TypeTuple ts  -> "tuple<" ++ intercalate "," (map cgenTypeLang ts) ++ ">"
@@ -785,7 +785,7 @@ ctypeofGradBuiltin f ctys = case (f, map stripTypeDef ctys) of
 cgenKonst :: Konst -> String
 cgenKonst = \case
   KInteger i -> show i
-  KFloat   f -> show f
+  KFloat   f -> "Float(" ++ show f ++ ")"
   KString  s -> show s
   KBool    b -> if b then "true" else "false"
 

--- a/src/python/ksc/compile.py
+++ b/src/python/ksc/compile.py
@@ -184,8 +184,8 @@ PYBIND11_MODULE("""
     m.def("allocator_peak", []{ return g_alloc.peak();});
     m.def("logging", &ks_logging);
 
-    declare_tensor_1<double>(m, "Tensor_1_Float");
-    declare_tensor_2<double>(m, "Tensor_2_Float");
+    declare_tensor_1<ks::Float>(m, "Tensor_1_Float");
+    declare_tensor_2<ks::Float>(m, "Tensor_2_Float");
     declare_tensor_2<int>(m, "Tensor_2_Integer");
 
 """

--- a/src/python/ksc/rewrites.py
+++ b/src/python/ksc/rewrites.py
@@ -291,7 +291,7 @@ class ParsedRuleMatcher(RuleMatcher):
             (add (mul a b) (mul b c)) ;; replacement
         )
     or, the inverse a*b+a*c-> a*(b+c)
-        (rule "add_two_muls.double"
+        (rule "add_two_muls.Float"
             ((a : Float) (b : Float)) ;; template_vars
             (add (mul a b) (mul a c)) ;; template --- note a occurs in multiple places, these must be identical
             (mul a (add b c)) ;; replacement

--- a/src/runtime/knossos-lm.h
+++ b/src/runtime/knossos-lm.h
@@ -48,11 +48,11 @@ namespace ks
 		// ---------------- Scale  ------------------
 		struct Scale
 		{
-			typedef double scale_t;
+			typedef Float scale_t;
 			scale_t val;
 
-			typedef double To;
-			typedef double From;
+			typedef Float To;
+			typedef Float From;
 
 			static Scale mk(scale_t val) { return Scale{ val }; }
 
@@ -71,12 +71,12 @@ namespace ks
 		{
 			T val;
 
-			typedef double To;
-			typedef double From;
+			typedef Float To;
+			typedef Float From;
 
 			static ScaleR mk(allocator *, T val) { return ScaleR{ val }; }
 
-			T Apply(allocator *, double rhs) const { return rhs * val; }
+			T Apply(allocator *, Float rhs) const { return rhs * val; }
 		};
 
 		template <class T>
@@ -518,14 +518,14 @@ namespace ks
 		return LM::HCat<LM::Scale, LM::Scale>::mk(LM::Scale::mk(t2), LM::Scale::mk(t1));
 	}
 */
-	inline auto D$abs$af(allocator *, double d) { return LM::Scale::mk(d > 0 ? 1.0 : -1.0); }
+	inline auto D$abs$af(allocator *, Float d) { return LM::Scale::mk(d > 0 ? 1.0 : -1.0); }
 
-	inline auto D$max$aff(allocator *, double a, double b) {
-		double s = a > b ? 1.0 : 0.0;
+	inline auto D$max$aff(allocator *, Float a, Float b) {
+		Float s = a > b ? 1.0 : 0.0;
 		return LM::HCat<LM::Scale, LM::Scale>::mk(LM::Scale::mk(s), LM::Scale::mk(1.0 - s));
 	}
 
-	inline auto D$ts_neg(allocator *, double d) { return LM::Scale::mk(-1.0); }
+	inline auto D$ts_neg(allocator *, Float d) { return LM::Scale::mk(-1.0); }
 
 	inline auto D$to_integer(int d) { return LM::Zero<int, int>(); }
 
@@ -540,8 +540,8 @@ namespace ks
 		{
 			typedef typename Vec::value_type T;
 			auto di = LM::Zero<I, T>::mk();
-			auto delta = [i](I ii) { return LM::Scale<T,T,double>::mk(T{}, T{}, ii == i ? 1.0 : 0.0); };
-			auto df = LM::Build<std::function<LM::Scale<T,T,double>(I)>>::mk(delta);
+			auto delta = [i](I ii) { return LM::Scale<T,T,Float>::mk(T{}, T{}, ii == i ? 1.0 : 0.0); };
+			auto df = LM::Build<std::function<LM::Scale<T,T,Float>(I)>>::mk(delta);
 			return D_t$index<I, Vec>::mk(di, df);
 		}
 

--- a/src/runtime/knossos-prelude-lm.h
+++ b/src/runtime/knossos-prelude-lm.h
@@ -1,20 +1,20 @@
 
 namespace ks {
 
-inline auto D$sub$aff(allocator *, double, double)
+inline auto D$sub$aff(allocator *, Float, Float)
 {
 	typedef LM::Scale M1;
 	typedef LM::Scale M2;
-	return LM::HCat<M1, M2>::mk(M1::mk(1.0), M2::mk(-1.0));
+	return LM::HCat<M1, M2>::mk(M1::mk(1.0f), M2::mk(-1.0f));
 }
 
-inline auto D$div$aff(allocator *, double t1, double t2)
+inline auto D$div$aff(allocator *, Float t1, Float t2)
 {
 	return LM::HCat<LM::Scale, LM::Scale>::mk(LM::Scale::mk(1.0 / t2), LM::Scale::mk(-1.0 / (t1*t1)));
 }
 
-inline auto D$to_float$ai(allocator *, int d) { return LM::Zero<int, double>(); }
-inline auto D$to_float(allocator *, int d) { return LM::Zero<int, double>(); }
+inline auto D$to_float$ai(allocator *, int d) { return LM::Zero<int, Float>(); }
+inline auto D$to_float(allocator *, int d) { return LM::Zero<int, Float>(); }
 
 }
 

--- a/src/runtime/knossos-prelude.h
+++ b/src/runtime/knossos-prelude.h
@@ -6,44 +6,44 @@ namespace ks {
 // We should probably come up with a better story for the
 // tests but at the time of writing I didn't want to hold back
 // edef support any longer.
-double edef_example$af(allocator *, double x) { return x; }
-double fwd$edef_example$af(allocator *, double x, double dx) { return dx; }
-double rev$edef_example$af(allocator *, double x, double ddr) { return ddr; }
-ks::tuple<double,ks::tuple<>> suffwdpass$edef_example$af(allocator *, double x) { return ks::make_tuple(x, ks::make_tuple()); }
-double sufrevpass$edef_example$af(allocator *, double ddr, ks::tuple<>) { return ddr; }
+Float edef_example$af(allocator *, Float x) { return x; }
+Float fwd$edef_example$af(allocator *, Float x, Float dx) { return dx; }
+Float rev$edef_example$af(allocator *, Float x, Float ddr) { return ddr; }
+ks::tuple<Float,ks::tuple<>> suffwdpass$edef_example$af(allocator *, Float x) { return ks::make_tuple(x, ks::make_tuple()); }
+Float sufrevpass$edef_example$af(allocator *, Float ddr, ks::tuple<>) { return ddr; }
 
-double dot$aT1fT1f(allocator *, vec<double> const& a, vec<double> const& b)
+Float dot$aT1fT1f(allocator *, vec<Float> const& a, vec<Float> const& b)
 {
 	return ts_dot(a,b);
 }
 
-vec<double>
-mul$aT2fT1f(allocator * alloc, tensor<2, double> const& M, vec<double> const& v)
+vec<Float>
+mul$aT2fT1f(allocator * alloc, tensor<2, Float> const& M, vec<Float> const& v)
 {
 	int r = M.outer_dimension();
-	vec<double> ret(alloc, r);
+	vec<Float> ret(alloc, r);
 	for(int i = 0; i < r; ++i)
 		ret[i] = ts_dot(M[i], v);
 	return ret;
 }
 
-tuple<tensor<2, double>,vec<double>>
-rev$mul$aT2fT1f(allocator * alloc, tuple<tensor<2, double>, vec<double>> const& M_v, vec<double> const& dr)
+tuple<tensor<2, Float>,vec<Float>>
+rev$mul$aT2fT1f(allocator * alloc, tuple<tensor<2, Float>, vec<Float>> const& M_v, vec<Float> const& dr)
 {
 	auto [M, v] = M_v;
 	int r = M.outer_dimension();
 	int c = size(v);
-	tensor<2, double> retM(alloc, size(M));
+	tensor<2, Float> retM(alloc, size(M));
 	for(int i = 0; i < r; ++i) {
 		// Inlined retM[i].assign(ts_scale(dr[i], v))
-		vec<double> retrow = retM[i];
+		vec<Float> retrow = retM[i];
 		for (int j = 0; j < c; ++j)
 			retrow[j] = dr[i] * v[j];
 	}
 
-	vec<double> retv(alloc, c);
+	vec<Float> retv(alloc, c);
 	for(int i = 0; i < c; ++i) {
-		double retvi = 0;
+		Float retvi = 0;
 		for(int j = 0; j < r; ++j)
 			retvi += M.index(ks::make_tuple(j, i)) * dr[j];
 		retv[i] = retvi;
@@ -52,11 +52,11 @@ rev$mul$aT2fT1f(allocator * alloc, tuple<tensor<2, double>, vec<double>> const& 
 	return ks::make_tuple(retM,retv);
 }
 
-size_t imax$aT1f(allocator *, vec<double> const &v)
+size_t imax$aT1f(allocator *, vec<Float> const &v)
 {
     KS_ASSERT(size(v) > 0);
     size_t imax = 0;
-    double vmax = v[imax];
+    Float vmax = v[imax];
     for (int i = 1; i < size(v); ++i)
         if (v[i] > vmax)
         {
@@ -66,17 +66,17 @@ size_t imax$aT1f(allocator *, vec<double> const &v)
     return imax;
 }
 
-double max$aT1f(allocator * alloc, vec<double> const& v)
+Float max$aT1f(allocator * alloc, vec<Float> const& v)
 {
     return v[imax$aT1f(alloc, v)];
 }
 
-double rev$lgamma$af(allocator *, double x, double dr)
+Float rev$lgamma$af(allocator *, Float x, Float dr)
 {
 	std::cerr << "rev$lgamma unimp!\n" << std::endl;
 	throw "rev$gamma unimp!\n";
 }
-double fwd$lgamma$af(allocator *, double x, double dx)
+Float fwd$lgamma$af(allocator *, Float x, Float dx)
 {
   if (dx == 0.0) {
     return 0.0;
@@ -86,23 +86,23 @@ double fwd$lgamma$af(allocator *, double x, double dx)
   }
 }
 
-double pow$afi(allocator *, double x, int e)
+Float pow$afi(allocator *, Float x, int e)
 {
     return std::pow(x,e);
 }
 
-tuple<> fwd$gt(allocator *, double a,double b,double d$a,double d$b)
+tuple<> fwd$gt(allocator *, Float a,Float b,Float d$a,Float d$b)
 {
     return tuple<>();
 }
 
-tuple<double,double> rev$gt(allocator *, double a,double b, tuple<> d$r)
+tuple<Float,Float> rev$gt(allocator *, Float a,Float b, tuple<> d$r)
 {
 	std::cerr << "rev$gt unimp!\n" << std::endl;
 	throw "rev$gt unimp!\n";
 }
 
-inline double sub$aff(allocator *, double t1, double t2)
+inline Float sub$aff(allocator *, Float t1, Float t2)
 {
 	return t1 - t2;
 }
@@ -112,7 +112,7 @@ inline int sub$aii(allocator *, int t1, int t2)
 	return t1 - t2;
 }
 
-inline double div$aff(allocator *, double t1, double t2)
+inline Float div$aff(allocator *, Float t1, Float t2)
 {
 	return t1 / t2;
 }
@@ -122,7 +122,7 @@ inline int div$aii(allocator *, int t1, int t2)
 	return t1 / t2;
 }
 
-inline double neg$af(allocator *, double t)
+inline Float neg$af(allocator *, Float t)
 {
 	return -t;
 }
@@ -132,17 +132,17 @@ inline int neg$ai(allocator *, int t)
 	return -t;
 }
 
-inline double exp$af(allocator *, double d) { return exp(d); }
-inline double log$af(allocator *, double d) { return log(d); }
-inline double sin$af(allocator *, double d) { return sin(d); }
-inline double cos$af(allocator *, double d) { return cos(d); }
-inline double cosh$af(allocator *, double d) { return cosh(d); }
-inline double tanh$af(allocator *, double d) { return tanh(d); }
-inline double lgamma$af(allocator *, double d) { return lgamma(d); }
-inline double erf$af(allocator *, double d) { return erf(d); }
-inline double sqrt$af(allocator *, double d) { return sqrt(d); }
+inline Float exp$af(allocator *, Float d) { return exp(d); }
+inline Float log$af(allocator *, Float d) { return log(d); }
+inline Float sin$af(allocator *, Float d) { return sin(d); }
+inline Float cos$af(allocator *, Float d) { return cos(d); }
+inline Float cosh$af(allocator *, Float d) { return cosh(d); }
+inline Float tanh$af(allocator *, Float d) { return tanh(d); }
+inline Float lgamma$af(allocator *, Float d) { return lgamma(d); }
+inline Float erf$af(allocator *, Float d) { return erf(d); }
+inline Float sqrt$af(allocator *, Float d) { return sqrt(d); }
 
-inline double to_float$ai(allocator *, int d) { return d; }
+inline Float to_float$ai(allocator *, int d) { return d; }
 
 inline bool or$abb(allocator *, int b1, int b2)  { return b1 || b2; }
 inline bool and$abb(allocator *, int b1, int b2) { return b1 && b2; }

--- a/src/runtime/knossos.h
+++ b/src/runtime/knossos.h
@@ -62,6 +62,9 @@ namespace ks {
 #define KS_NOTE { KS_LOG("note " << (KS_FIND ? (void*)this : (void*)0), log_indent); }
 #define KS_LEAVE { KS_LOG("dtor " << KS_FIND, --log_indent);  objects.erase(this); }
 
+	// ===============================  Core types  ==================================
+	typedef double Float;
+
 	// ===============================  Tuple  ==================================
 
 	// Trivially-copyable tuple type. For n <= 4, an n-tuple is just a struct with n public members
@@ -159,6 +162,12 @@ namespace ks {
 	struct type_to_string<double>
 	{
 		static std::string name() { return "double"; }
+	};
+
+	template <>
+	struct type_to_string<float>
+	{
+		static std::string name() { return "float"; }
 	};
 
 	// Specialize for some types we use
@@ -653,7 +662,7 @@ namespace ks {
 
 	tuple<> shape(allocator_base *, bool const&) { return {}; }
 	tuple<> shape(allocator_base *, int const&) { return {}; }
-	tuple<> shape(allocator_base *, double const&) { return {}; }
+	tuple<> shape(allocator_base *, Float const&) { return {}; }
 	tuple<> shape(allocator_base *, std::string const&) { return {}; }
 
 	template<size_t Dim, class T>
@@ -943,7 +952,7 @@ namespace ks {
 	}
 
 	template <>
-	double zero(allocator *, double const& val)
+	Float zero(allocator *, Float const& val)
 	{
 		return 0.0;
 	}
@@ -1092,13 +1101,13 @@ namespace ks {
 	}
 
 	template <class T>
-	T ts_scale(allocator *, double s, T const& t)
+	T ts_scale(allocator *, Float s, T const& t)
 	{
 		return s * t;
 	}
 
 	template <class... Us>
-	auto ts_scale(allocator * alloc, double s, tuple<Us...> const& t)
+	auto ts_scale(allocator * alloc, Float s, tuple<Us...> const& t)
 	{
 		return transform_tuple(t, [alloc, s](auto const& elem) { return ts_scale(alloc, s, elem); });
 	}
@@ -1110,7 +1119,7 @@ namespace ks {
 	}
 
 	template <size_t Dim, class T>
-	tensor<Dim, T> ts_scale(allocator * alloc, double val, tensor<Dim, T> const& t)
+	tensor<Dim, T> ts_scale(allocator * alloc, Float val, tensor<Dim, T> const& t)
 	{
 		auto ret = tensor<Dim, T>::create(alloc, t.size());
 		T* retdata = ret.data();
@@ -1122,7 +1131,7 @@ namespace ks {
 
 	inline int ts_neg(allocator *, int d) { return -d; }
 
-	inline double ts_neg(allocator *, double d) { return -d; }
+	inline Float ts_neg(allocator *, Float d) { return -d; }
 
 	template <class... Us>
 	inline tuple<Us...> ts_neg(allocator * alloc, tuple<Us...> t) {
@@ -1563,7 +1572,7 @@ namespace ks {
 		return t1 != t2;
 	}
 
-        inline bool lt$aff(allocator *, double t1, double t2)
+        inline bool lt$aff(allocator *, Float t1, Float t2)
 	{
 		return t1 < t2;
 	}
@@ -1573,7 +1582,7 @@ namespace ks {
 		return t1 < t2;
 	}
 
-	inline bool gt$aff(allocator *, double t1, double t2)
+	inline bool gt$aff(allocator *, Float t1, Float t2)
 	{
 		return t1 > t2;
 	}
@@ -1583,7 +1592,7 @@ namespace ks {
 		return t1 > t2;
 	}
 
-	inline bool lte$aff(allocator *, double t1, double t2)
+	inline bool lte$aff(allocator *, Float t1, Float t2)
 	{
 		return t1 <= t2;
 	}
@@ -1593,7 +1602,7 @@ namespace ks {
 		return t1 <= t2;
 	}
 
-	inline bool gte$aff(allocator *, double t1, double t2)
+	inline bool gte$aff(allocator *, Float t1, Float t2)
 	{
 		return t1 >= t2;
 	}
@@ -1603,7 +1612,7 @@ namespace ks {
 		return t1 >= t2;
 	}
 
-	inline double add$aff(allocator *, double t1, double t2)
+	inline Float add$aff(allocator *, Float t1, Float t2)
 	{
 		return t1 + t2;
 	}
@@ -1613,7 +1622,7 @@ namespace ks {
 		return t1 + t2;
 	}
 
-	inline double mul$aff(allocator *, double t1, double t2)
+	inline Float mul$aff(allocator *, Float t1, Float t2)
 	{
 		return t1 * t2;
 	}
@@ -1623,9 +1632,9 @@ namespace ks {
 		return t1 * t2;
 	}
 
-	inline double abs$af(allocator *, double d) { return d > 0 ? d : -d; }
+	inline Float abs$af(allocator *, Float d) { return d > 0 ? d : -d; }
 
-	inline double max$aff(allocator *, double a, double b) { return a > b ? a : b; }
+	inline Float max$aff(allocator *, Float a, Float b) { return a > b ? a : b; }
 
 	inline int to_integer(int d) { return d; }
 
@@ -1665,8 +1674,8 @@ namespace ks {
           return v;
         }
 
-        inline double $ranhashdoub$ai(allocator * alloc, int32_t v) {
-          return 5.42101086242752217E-20 * $ranhash(alloc, v);
+        inline Float $ranhashdoub$ai(allocator * alloc, int32_t v) {
+          return Float(5.42101086242752217E-20 * $ranhash(alloc, v));
         }
 
 	// ========================= Trace primitive ===============
@@ -1722,30 +1731,30 @@ namespace ks {
 																		}))
 
 	// ===============================  Dot ===========================================
-	inline double ts_dot(double t1, double t2) { return t1 * t2; }
+	inline Float ts_dot(Float t1, Float t2) { return t1 * t2; }
 
 	template <class T>
-	inline double ts_dot(T t1, tuple<> t2)
+	inline Float ts_dot(T t1, tuple<> t2)
 	{
 		return 0.0;
 	}
 
 	template <class T>
-	inline double ts_dot(T t1, tuple<T> t2)
+	inline Float ts_dot(T t1, tuple<T> t2)
 	{
 		return ts_dot(t1,ks::get<0>(t2));
 	}
 
 	template <class T0, class... Ts, class U0, class... Us>
-	inline double ts_dot(tuple<T0, Ts...> t1, tuple<U0, Us...> t2)
+	inline Float ts_dot(tuple<T0, Ts...> t1, tuple<U0, Us...> t2)
 	{
 		return ts_dot(head(t1), head(t2)) + ts_dot(tail(t1), tail(t2));
 	}
 
 	template <size_t Dim, class T1, class T2>
-	inline double ts_dot(tensor<Dim, T1> t1, tensor<Dim, T2> t2)
+	inline Float ts_dot(tensor<Dim, T1> t1, tensor<Dim, T2> t2)
 	{
-		double ret = 0;
+		Float ret = 0;
 
 		KS_ASSERT(t1.size() == t2.size());
 
@@ -1773,14 +1782,14 @@ namespace ks {
   //  i.e. what should be small (when dx is) if our
   //  reverse mode generated code is correct.
 	template <class Functor, class RevFunctor, class X, class Dx, class Df>
-        double $check(allocator * alloc, Functor f, RevFunctor rev_f, X x, Dx dx, Df df)
+        Float $check(allocator * alloc, Functor f, RevFunctor rev_f, X x, Dx dx, Df df)
 	{
 		auto f_x = applyWithAllocator(alloc, f, x);
 		auto f_x_plus_dx = applyWithAllocator(alloc, f, ts_add(alloc, x, dx));
 		auto delta_f = f_x_plus_dx - f_x;
-		double d1 = ts_dot(delta_f, df);
+		Float d1 = ts_dot(delta_f, df);
 		auto dfJ = applyWithAllocator(alloc, rev_f, ks::make_tuple(x, df));
-		double d2 = ts_dot(dfJ, dx);
+		Float d2 = ts_dot(dfJ, dx);
 
 		/*
 		std::cout << "dfJ=" << dfJ << std::endl;

--- a/src/runtime/prelude-aten.cpp
+++ b/src/runtime/prelude-aten.cpp
@@ -5,27 +5,27 @@
 
 namespace ks {
 
-tensor<1, double> 
-aten$8$8matmul$aT2fT1f(allocator * alloc, tensor<2,double> const& M, tensor<1,double> const& v)
+tensor<1, Float> 
+aten$8$8matmul$aT2fT1f(allocator * alloc, tensor<2,Float> const& M, tensor<1,Float> const& v)
 {
 	auto [r,c] = size(M);
     KS_ASSERT(c == size(v));
-	tensor<1,double> ret(alloc, r);
+	tensor<1,Float> ret(alloc, r);
 	for(int i = 0; i < r; ++i)
 		ret[i] = ts_dot(M[i], v);
 	return ret;
 }
 
-tensor<2, double> 
-aten$8$8matmul$aT2fT2f(allocator * alloc, tensor<2,double> const& A, tensor<2,double> const& B)
+tensor<2, Float> 
+aten$8$8matmul$aT2fT2f(allocator * alloc, tensor<2,Float> const& A, tensor<2,Float> const& B)
 {
 	auto [r,K] = size(A);
 	auto [K_,c] = size(B);
   KS_ASSERT(K == K_);
-	tensor<2,double> ret(alloc, make_tuple(r, c));
+	tensor<2,Float> ret(alloc, make_tuple(r, c));
 	for(int i = 0; i < r; ++i)
 		for(int j = 0; j < c; ++j) {
-			double tot = 0;
+			Float tot = 0;
 		  for(int k = 0; k < K; ++k)
 				tot += A[i][k] * B[k][j];
 			ret[i][j] = tot;
@@ -33,20 +33,20 @@ aten$8$8matmul$aT2fT2f(allocator * alloc, tensor<2,double> const& A, tensor<2,do
 	return ret;
 }
 
-tuple<tensor<2,double>,tensor<1,double>> 
-rev$aten$8$8matmul$aT2fT1f(allocator * alloc, tuple<tensor<2,double>, tensor<1,double>> const& M_v, tensor<1,double> const& dr)
+tuple<tensor<2,Float>,tensor<1,Float>> 
+rev$aten$8$8matmul$aT2fT1f(allocator * alloc, tuple<tensor<2,Float>, tensor<1,Float>> const& M_v, tensor<1,Float> const& dr)
 {
 	auto [M, v] = M_v;
 	auto [r, c] = size(M);
 	KS_ASSERT(c == size(v));
 
-	tensor<2,double> retM(alloc, size(M));
+	tensor<2,Float> retM(alloc, size(M));
 	for(int i = 0; i < r; ++i)
 		retM[i] = ts_scale(alloc, dr[i], v);
 
-	tensor<1,double> retv(alloc, c);
+	tensor<1,Float> retv(alloc, c);
 	for(int i = 0; i < c; ++i) {
-		double retvi = 0;
+		Float retvi = 0; // TODO: Accumulator types
 		for(int j = 0; j < r; ++j)
 			retvi += M[j][i] * dr[j];
 		retv[i] = retvi;
@@ -62,8 +62,8 @@ aten$8$8pow$aT2fi(allocator * alloc, tensor<Dim,T> const& a, int const& i)
 	return elementwise_map(alloc, a, [i](T const& v) { return std::pow(v, i); });
 }
 
-typedef tensor<2, double> Mat;
-typedef tensor<1, double> Vec;
+typedef tensor<2, Float> Mat;
+typedef tensor<1, Float> Vec;
 
 /*
 (edef aten::cat Mat ((Tensor 1 Mat) Integer))
@@ -198,7 +198,7 @@ rev$addA1bt$aT2fT1f(allocator * alloc, tuple<Mat, Vec> const& args, Mat const& d
 
 	Vec retdb(alloc, N);
 	for(int j = 0; j < N; ++j) {
-		double tot = 0;
+		Float tot = 0; // TODO: Accumulator types
 		for(int i = 0; i < M; ++i)
 			tot += retdA[i][j];
 		retdb[j] = tot;

--- a/src/test/knossos-test.cpp
+++ b/src/test/knossos-test.cpp
@@ -2,10 +2,10 @@
 #include "knossos.h"
 namespace ks {
 
-	double f(vec<double> s$x, vec<double> s$y) {
+	Float f(vec<Float> s$x, vec<Float> s$y) {
 		auto c$1 = lt(2, 3);
 
-		double c$0;
+		Float c$0;
 		if (c$1) {  
 			auto c$2 = index(1, s$x);
 			;
@@ -19,17 +19,17 @@ namespace ks {
 	}
 
 	auto D$f() {
-		LM::Variant<LM::BuildT<LM::One<double>>, LM::Zero<vec<double>, double>> ret;
+		LM::Variant<LM::BuildT<LM::One<Float>>, LM::Zero<vec<Float>, Float>> ret;
 
 		auto c$3 = [](int s$ii) {
-			return LM::One<double>::mk(double{});
+			return LM::One<Float>::mk(Float{});
 		};
-		auto x = LM::BuildT<LM::One<double>>::mk(7, c$3);
+		auto x = LM::BuildT<LM::One<Float>>::mk(7, c$3);
 
 		if (1)
 			ret.v = x;
 		else
-			ret.v = LM::Zero<vec<double>, double>::mk(vec<double>{}, double{});
+			ret.v = LM::Zero<vec<Float>, Float>::mk(vec<Float>{}, Float{});
 		return ret;
 	}
 

--- a/test/ksc/syntax-primer.ks
+++ b/test/ksc/syntax-primer.ks
@@ -92,7 +92,7 @@ If you prefer block comments then use pairs of #| and |#
 ; Knossos has the following types: String, Bool, Integer, Float, Tuple
 ; and Vec.
 ;
-; "Float" compiles to C++ double and "Vec" compiles to ks::vec from
+; "Float" compiles to C++ ks::Float and "Vec" compiles to ks::tensor from
 ; the Knossos C++ runtime.
 ;
 ; * Integer literals are numeric literals
@@ -119,7 +119,7 @@ If you prefer block comments then use pairs of #| and |#
 
 ; Python equivalent
 ;
-; def let_and_types(b : bool, s : str, i : int, f : double, v : List[double]) -> double:
+; def let_and_types(b : bool, s : str, i : int, f : Float, v : List[Float]) -> Float:
 ;     b2 = b or False
 ;     i2 = i + 10
 ;     f2 = f + 10.0
@@ -151,7 +151,7 @@ If you prefer block comments then use pairs of #| and |#
 
 ; Python equivalent
 ;
-; def build_example(n : int) -> List[double]:
+; def build_example(n : int) -> List[Float]:
 ;     return list(float(ni * ni) for ni in range(n))
 
 


### PR DESCRIPTION
First step of https://github.com/microsoft/knossos-ksc/issues/691 and [AB#20029](https://msrcambridge.visualstudio.com/5e4c69bb-8524-4a69-a371-1fd3d005296f/_workitems/edit/20029)

Convert uses of "double" to ks::Float, leaving the typedef as double.
