### PR TITLE
(python) Capture Avoiding Substitution preserves type

### DIFF
--- a/src/python/ksc/cav_subst.py
+++ b/src/python/ksc/cav_subst.py
@@ -144,7 +144,9 @@ class CAvSubst(ExprTransformer):
         )  # ExprTransformer ensures.
         arg, substs = self._rename_if_needed(e.arg, e.expr, reqs, substs)
         return Lam(
-            Var(arg.name, type=arg.type_, decl=True), self.visit(e.body, reqs, substs)
+            Var(arg.name, type=arg.type_, decl=True),
+            self.visit(e.body, reqs, substs),
+            type=e.type_,
         )
 
     def visit_let(self, e: Union[Let, ExprWithPath], reqs, substs):
@@ -167,4 +169,5 @@ class CAvSubst(ExprTransformer):
             new_vars,
             self.visit(e.rhs, reqs, substs),
             self.visit(e.body, reqs, body_substs),
+            type=e.type_,
         )


### PR DESCRIPTION
This is nearly trivial - but where ExprTransformer preserves the type of things it copies: https://github.com/microsoft/knossos-ksc/blob/333c2ec4ed53f2818810a902aea52b57b8f94ce3/src/python/ksc/visitors.py#L95

The capture-avoiding substitution code overrides that and drops the type. Hence, add it back in.

I haven't added a test, as it seems that this would largely just repeat the lines added. But it might be useful as a regression check, so happy to add one if anyone feels I should.