### PR TITLE
Remove src/bench from pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,4 +2,4 @@
 addopts = --strict-markers
 testpaths =
     test
-    src/bench
+#    src/bench remove until fast enough at discovery time


### PR DESCRIPTION
I added src/bench to pytest.ini, but it compiles a bunch of stuff in its discovery phase so slows down vs code horribly.  TBD to delay compilation in discovery.