### PR TITLE
relu3 upper bounds with compiler flags (benchmark combinations report)

### DIFF
--- a/src/python/ksc/torch_frontend.py
+++ b/src/python/ksc/torch_frontend.py
@@ -13,6 +13,7 @@ from ksc.parse_ks import parse_ks_filename
 from ksc.compile import (
     build_module_using_pytorch_from_ks,
     build_module_using_pytorch_from_cpp,
+    default_cflags,
 )
 
 from ksc.type import Type
@@ -502,12 +503,7 @@ def ksc_defs_to_module(ksc_defs, entry_def, torch_extension_name, generate_lm):
         entry_def.name,
         torch_extension_name,
         generate_lm,
-        extra_cflags=[
-            "-std=c++17",
-            "-g",
-            "-O3",
-            # "-DKS_BOUNDS_CHECK",
-        ],
+        extra_cflags=default_cflags,
     )
 
 
@@ -552,7 +548,11 @@ def ksc_defs_to_autograd_function(
 
 
 def ksc_string_to_autograd_function(
-    ks_str, entry_sn, torch_extension_name, generate_lm=True, extra_cflags=[]
+    ks_str,
+    entry_sn,
+    torch_extension_name,
+    generate_lm=True,
+    extra_cflags=default_cflags,
 ):
     mod = ksc_string_to_module(
         ks_str, entry_sn, torch_extension_name, generate_lm, extra_cflags
@@ -565,7 +565,7 @@ def cpp_string_to_autograd_function(
     torch_extension_name,
     entry_name="entry",
     entry_vjp_name="entry_vjp",
-    extra_cflags=[],
+    extra_cflags=default_cflags,
 ):
     mod = cpp_string_to_module(
         cpp_str, torch_extension_name, entry_name, entry_vjp_name, extra_cflags


### PR DESCRIPTION
This allows to set compiler flags for the compilation of embedded C++ and KS benchmarks. See https://github.com/microsoft/knossos-ksc/pull/942#issuecomment-880665282 for up-to-date benchmark numbers. **Most important feature of benchmark**: with the right compiler flags `if` is as fast as masking (and they're both a bit faster than PyTorch)!

This PR introduces the `CFlags` class for bundling together compiler flags we might feed to `gcc` or `cl`. It's a bit hokey but seems to strike a good balance between simplicity and robustness. An alternative could be to pass around flags for both compilers separately, but that's rather messy and not robust to adding a new compiler in the future.

### Old

As of 207d412f6b8885dfa8a9272443d6929eff1f6c91 we get a 10%-30% improvement by using compiler flags (`-march=native- -funroll-loops -ffast-math -mprefer-vector-width=512`. I don't (yet) know which specific flags here make the difference.).

![image](https://user-images.githubusercontent.com/51626669/125296697-77996e00-e31e-11eb-963d-362562e303d5.png)

![image](https://user-images.githubusercontent.com/51626669/125296796-8e3fc500-e31e-11eb-850f-25c30518612c.png)

![image](https://user-images.githubusercontent.com/51626669/125296740-82ec9980-e31e-11eb-9b6d-e66a62ff11dc.png)
