### PR TITLE
Don't pass an empty command line argument

### DIFF
--- a/src/python/ksc/compile.py
+++ b/src/python/ksc/compile.py
@@ -258,9 +258,7 @@ def build_module_using_pytorch_from_cpp_backend(
 ):
     __ksc_path, ksc_runtime_dir = utils.get_ksc_paths()
 
-    extra_cflags = [
-        "-DKS_INCLUDE_ATEN" if use_aten else "",
-    ]
+    extra_cflags = ["-DKS_INCLUDE_ATEN"] if use_aten else []
 
     # I don't like this assumption about Windows -> cl but it matches what PyTorch is currently doing:
     # https://github.com/pytorch/pytorch/blob/ad8d1b2aaaf2ba28c51b1cb38f86311749eff755/torch/utils/cpp_extension.py#L1374-L1378


### PR DESCRIPTION
I think this is what we actually want, don't we? It seems that the compiler ultimately ignores an command line argument that is the empty string, but if so that's just luck rather than design!