### PR TITLE
Use std::tuple instead of ks::Tuple in entry points

### DIFF
--- a/src/python/ksc/cgen.py
+++ b/src/python/ksc/cgen.py
@@ -30,7 +30,7 @@ def entry_point_cpp_type(t, use_torch):
         return scalar_type_to_cpp_map[t.kind]
     elif t.is_tuple:
         return (
-            "ks::Tuple<"
+            "std::tuple<"
             + ", ".join(
                 entry_point_cpp_type(child, use_torch) for child in t.tuple_elems()
             )

--- a/src/runtime/knossos-entry-points.h
+++ b/src/runtime/knossos-entry-points.h
@@ -42,23 +42,23 @@ struct Converter
 };
 
 template<typename ...KsElementTypes, typename ...EntryPointElementTypes>
-struct Converter<ks::Tuple<KsElementTypes...>, ks::Tuple<EntryPointElementTypes...>>
+struct Converter<ks::Tuple<KsElementTypes...>, std::tuple<EntryPointElementTypes...>>
 {
   template<size_t ...Indices>
-  static ks::Tuple<KsElementTypes...> to_ks_impl(ks::Tuple<EntryPointElementTypes...> arg, std::index_sequence<Indices...>) {
-    return ks::make_Tuple(convert_argument<KsElementTypes>(ks::get<Indices>(arg))...);
+  static ks::Tuple<KsElementTypes...> to_ks_impl(std::tuple<EntryPointElementTypes...> arg, std::index_sequence<Indices...>) {
+    return ks::make_Tuple(convert_argument<KsElementTypes>(std::get<Indices>(arg))...);
   }
 
-  static ks::Tuple<KsElementTypes...> to_ks(ks::Tuple<EntryPointElementTypes...> arg) {
+  static ks::Tuple<KsElementTypes...> to_ks(std::tuple<EntryPointElementTypes...> arg) {
     return to_ks_impl(arg, std::index_sequence_for<EntryPointElementTypes...>{});
   }
 
   template<size_t ...Indices>
-  static ks::Tuple<EntryPointElementTypes...> from_ks_impl(ks::Tuple<KsElementTypes...> ret, std::index_sequence<Indices...>) {
-    return ks::make_Tuple(convert_return_value<EntryPointElementTypes>(ks::get<Indices>(ret))...);
+  static std::tuple<EntryPointElementTypes...> from_ks_impl(ks::Tuple<KsElementTypes...> ret, std::index_sequence<Indices...>) {
+    return std::make_tuple(convert_return_value<EntryPointElementTypes>(ks::get<Indices>(ret))...);
   }
 
-  static ks::Tuple<EntryPointElementTypes...> from_ks(ks::Tuple<KsElementTypes...> ret) {
+  static std::tuple<EntryPointElementTypes...> from_ks(ks::Tuple<KsElementTypes...> ret) {
     return from_ks_impl(ret, std::index_sequence_for<KsElementTypes...>{});
   }
 };


### PR DESCRIPTION
This PR changes the entry points to use `std::tuple`, as this is supported directly by pybind11. This would mean that we could remove the specialization for `ks::Tuple` in `knossos-pybind.h`.

(Edited: The following comment was resolved by #961.)

One difficulty: we are optionally logging the entry point arguments using `operator<<`, but there is no `operator<<` defined for `std::tuple`. There are various ways we might fix this:

1. Define `operator<<` for `std::tuple`. This invasion of `std::` is technically illegal, but would probably work as long as no-one tries the same thing somewhere else.
2. Define our own `print` function to use instead of `operator<<`.
3. Log the values of the arguments _after_ converting to ks types. This would work OK as things stand, but not once we are doing elementwise operations. (We wouldn't want to log inside the loop.)
4. Just remove the logging now. As @toelli-msft pointed out on https://github.com/microsoft/knossos-ksc/pull/925#discussion_r669465277 it doesn't really make sense to have it turned on any more, unless you're debugging a small example.

Any thoughts? (@awf?)
