### PR TITLE
gelu upper bounds

### DIFF
--- a/examples/dl-activations/gelu.py
+++ b/examples/dl-activations/gelu.py
@@ -10,7 +10,12 @@ embedded_cflags = ksc.compile.default_cflags
 
 
 embedded_cflags_opts = ksc.compile.CFlags.GCCOnly(
-    ["-march=native", "-funroll-loops", "-ffast-math", "-mprefer-vector-width=512",]
+    ["-march=native", "-funroll-loops", "-ffast-math", "-mprefer-vector-width=512"]
+)
+
+
+embedded_cflags_opts_extra = ksc.compile.CFlags.GCCOnly(
+    ["-ffp-contract=fast", "-flto", "-fno-semantic-interposition"]
 )
 
 
@@ -93,6 +98,16 @@ def vgelu_embedded_cpp_inlined_map_flags():
         cpp_inlined_map + embedded_cpp_entry_points,
         "ksc_dl_activations__manual__vgelu_embedded_cpp_inlined_map_flags",
         extra_cflags=embedded_cflags + embedded_cflags_opts,
+    )
+
+
+def vgelu_embedded_cpp_inlined_map_flags_extra():
+    return cpp_string_to_autograd_function(
+        cpp_inlined_map + embedded_cpp_entry_points,
+        "ksc_dl_activations__manual__vgelu_embedded_cpp_inlined_map_flags_extra",
+        extra_cflags=embedded_cflags
+        + embedded_cflags_opts
+        + embedded_cflags_opts_extra,
     )
 
 


### PR DESCRIPTION
Adding some benchmarks for gelu, along the same lines as relu3.

### Duplication

There is duplication between the `embedded_cpp_entry_points` and flags here and in `relu3.py` but my inclination is to merge this first and then tidy up the duplication later. The `embedded_cpp_entry_points` in particular will need @dcrc2's help to fix I think.

### Results

Sadly not as much luck with gelu as with relu3. The same approach (simple loop with compiler flags) is 8.9x slower than PyTorch on size 1M and 5.9x slower than PyTorch on size 65k (although 1.8x *faster* on size 16).

I don't have a good intuition for why we get these numbers. Any ideas for improvements @awf @dcrc2? I will play around a bit, particularly with flags.

![image](https://user-images.githubusercontent.com/51626669/126193764-8aa393f4-c209-42f5-99a1-41b8bc668634.png)
