### PR TITLE
Typing rewrites.py 3/n

### DIFF
--- a/src/python/ksc/rewrites.py
+++ b/src/python/ksc/rewrites.py
@@ -215,13 +215,13 @@ class inline_var(RuleMatcher):
 
 @singleton
 class inline_call(RuleMatcher):
-    possible_filter_terms: FrozenSet[typing.Type[Any]] = frozenset()
+    possible_filter_terms: FrozenSet[typing.Type[Expr]] = frozenset()
     may_match_any_call = True
 
     def matches_for_possible_expr(
         self, ewp: ExprWithPath, env: Environment
     ) -> Iterator[Match]:
-        assert isinstance(ewp.expr, Call)  # TODO: Check this is correct
+        assert isinstance(ewp.expr, Call)
         if ewp.expr.name not in env.defs:
             return
         func_def: Def = env.defs[ewp.expr.name]


### PR DESCRIPTION
I've made it so you have to fully qualify `typing.Type` or `ksc.type.Type` as it leads to confusion.

@acl33 I've put in a `assert isinstance(ewp.expr, Call)` in `inline_call` which I'm not certain is correct. It passes tests but perhaps there are other types that should flow in here too?

Still a few classes of type error, particularly around the visitors and inheritance but we're getting there.