### PR TITLE
Use sum in sqrl instead of mean

### DIFF
--- a/examples/dl-capsule/sqrl.py
+++ b/examples/dl-capsule/sqrl.py
@@ -9,7 +9,7 @@ def sqrl(x: torch.Tensor):
     Typically x is a 4x4 tensor, possibly
     packed in a 4n x 4m array
     """
-    y = torch.mean(x)
+    y = torch.sum(x)
     if y < 0.0:
         t = -0.125 * x
     else:

--- a/src/runtime/prelude-aten.ks
+++ b/src/runtime/prelude-aten.ks
@@ -338,6 +338,15 @@
 (gdef sufrevpass [aten::prod (Tuple Integer Integer)])
 (gdef sufrev [aten::prod (Tuple Integer Integer)])
 
+(def aten::sum Float ((a : Tensor 2 Float) (opt_dtype : Tuple))
+    (sumbuild (size a) (lam (ij : Tuple Integer Integer)
+            (index ij a))))
+(gdef rev [aten::sum (Tuple (Tensor 2 Float) (Tuple))])
+(gdef fwd [aten::sum (Tuple (Tensor 2 Float) (Tuple))])
+(gdef suffwdpass [aten::sum (Tuple (Tensor 2 Float) (Tuple))])
+(gdef sufrevpass [aten::sum (Tuple (Tensor 2 Float) (Tuple))])
+(gdef sufrev [aten::sum (Tuple (Tensor 2 Float) (Tuple))])
+
 (def aten::sum Float (a : Tensor 2 Float)
     (sumbuild (size a) (lam (ij : Tuple Integer Integer)
             (index ij a))))


### PR DESCRIPTION
in a place where the two have the same effect but sum is likely to be
faster.  There is a lot of noise in the benchmarks so it's not
completely obvious it *is* faster.

Fixes https://github.com/microsoft/knossos-ksc/issues/967

I don't understand why a version of `aten::sum` with an extra `(Tuple)` argument is required.