### PR TITLE
Generate and compile CUDA code

### DIFF
--- a/src/bench/conftest.py
+++ b/src/bench/conftest.py
@@ -12,7 +12,7 @@ from collections import namedtuple
 from contextlib import contextmanager
 from typing import Callable
 
-from ksc.torch_frontend import KscStub
+from ksc.torch_frontend import KscStub, CompileConfiguration
 from ksc.compile import VecSpec_Elementwise
 from ksc import utils
 
@@ -114,7 +114,7 @@ def functions_to_benchmark(
                 ks_compiled = fn_obj.compile(
                     torch_extension_name=torch_extension_name,
                     example_inputs=example_inputs,
-                    gpu=False,
+                    configuration=CompileConfiguration(gpu=False),
                 )
                 yield BenchmarkFunction("Knossos", ks_compiled.apply)
                 if (
@@ -126,7 +126,7 @@ def functions_to_benchmark(
                             "ksc", "ksc_cuda", 1
                         ),
                         example_inputs=example_inputs,
-                        gpu=True,
+                        configuration=CompileConfiguration(gpu=True),
                     )
                     yield BenchmarkFunction(
                         "Knossos CUDA", ks_compiled_cuda.apply, torch.device("cuda"),

--- a/src/bench/conftest.py
+++ b/src/bench/conftest.py
@@ -13,6 +13,7 @@ from contextlib import contextmanager
 from typing import Callable
 
 from ksc.torch_frontend import KscStub
+from ksc.compile import VecSpec_Elementwise
 from ksc import utils
 
 
@@ -113,8 +114,23 @@ def functions_to_benchmark(
                 ks_compiled = fn_obj.compile(
                     torch_extension_name=torch_extension_name,
                     example_inputs=example_inputs,
+                    gpu=False,
                 )
                 yield BenchmarkFunction("Knossos", ks_compiled.apply)
+                if (
+                    isinstance(fn_obj.vectorization, VecSpec_Elementwise)
+                    and torch.cuda.is_available()
+                ):
+                    ks_compiled_cuda = fn_obj.compile(
+                        torch_extension_name=torch_extension_name.replace(
+                            "ksc", "ksc_cuda", 1
+                        ),
+                        example_inputs=example_inputs,
+                        gpu=True,
+                    )
+                    yield BenchmarkFunction(
+                        "Knossos CUDA", ks_compiled_cuda.apply, torch.device("cuda"),
+                    )
             elif fn_name == benchmark_name + "_cuda_init":
                 if torch.cuda.is_available():
                     yield from function_to_manual_cuda_benchmarks(fn_obj)

--- a/src/python/ksc/cgen.py
+++ b/src/python/ksc/cgen.py
@@ -98,7 +98,7 @@ def entry_point_cpp_type(t, use_torch):
 
 
 def generate_cpp_entry_points(
-    bindings_to_generate, decls, vectorization, use_torch=False
+    bindings_to_generate, decls, vectorization, use_torch=False, gpu=False
 ):
     decls_by_name = {decl.name: decl for decl in decls}
 
@@ -114,13 +114,18 @@ def generate_cpp_entry_points(
                 lookup_decl(structured_name),
                 vectorization=vectorization,
                 use_torch=use_torch,
+                gpu=gpu,
             )
             for binding_name, structured_name in bindings_to_generate
         )
     )
 
     entry_point_header = (
-        "knossos-entry-points-torch.h" if use_torch else "knossos-entry-points.h"
+        "knossos-entry-points-torch-cuda.cuh"
+        if gpu
+        else "knossos-entry-points-torch.h"
+        if use_torch
+        else "knossos-entry-points.h"
     )
 
     return (
@@ -160,12 +165,19 @@ def arg_types_of_decl(decl):
 
 
 def generate_cpp_entry_point(
-    cpp_function_name: str, decl: Def, vectorization: VecSpec, use_torch: bool
+    cpp_function_name: str,
+    decl: Def,
+    vectorization: VecSpec,
+    use_torch: bool,
+    gpu: bool,
 ):
     if isinstance(vectorization, VecSpec_Elementwise):
         if not use_torch:
             raise ValueError("Elementwise operations only available when using torch")
-        return generate_cpp_elementwise_entry_point(cpp_function_name, decl)
+        if gpu:
+            return generate_cpp_cuda_entry_point(cpp_function_name, decl)
+        else:
+            return generate_cpp_elementwise_entry_point(cpp_function_name, decl)
     if isinstance(vectorization, VecSpec_VMap):
         if not use_torch:
             raise ValueError("VMap only available when using torch")
@@ -256,3 +268,39 @@ def generate_cpp_elementwise_entry_point(cpp_function_name, decl):
 
 def generate_cpp_vmap_entry_point(cpp_function_name, decl):
     raise NotImplementedError("vmap")
+
+
+def generate_cpp_cuda_entry_point(cpp_function_name, decl):
+    arg_types = arg_types_of_decl(decl)
+    if not all(a == Type.Float for a in arg_types):
+        raise ValueError(
+            "Elementwise operations only available for floating-point element type"
+        )
+    num_args = len(arg_types)
+    if num_args != 1 and num_args != 2:
+        raise ValueError("CUDA entry points must have 1 or 2 arguments")
+    map_function_name = "map_gpu" if num_args == 1 else "map2_gpu"
+
+    def join_args(sep, callable):
+        return sep.join(callable(i) for i in range(num_args))
+
+    ks_function_name = utils.encode_name(decl.name.mangled())
+
+    cpp_function = f"torch::Tensor {cpp_function_name}({join_args(', ', lambda i: f'torch::Tensor arg{i}')})"
+
+    cpp_declaration = f"{cpp_function};\n"
+
+    cpp = f"""
+    struct functor_{cpp_function_name}
+    {{
+        template<typename scalar_t>
+        inline __device__ scalar_t operator()({join_args(', ', lambda i: f'scalar_t arg{i}')}) {{
+            return {ks_function_name}(nullptr, {join_args(', ', lambda i: f'arg{i}')});
+        }}
+    }};
+    {cpp_function} {{
+        return {map_function_name}({join_args(', ', lambda i: f'arg{i}')}, functor_{cpp_function_name}{{}});
+    }}
+"""
+
+    return cpp_declaration, cpp

--- a/src/python/ksc/cgen.py
+++ b/src/python/ksc/cgen.py
@@ -178,6 +178,10 @@ def generate_cpp_entry_point(
             return generate_cpp_cuda_entry_point(cpp_function_name, decl)
         else:
             return generate_cpp_elementwise_entry_point(cpp_function_name, decl)
+    if gpu:
+        raise ValueError(
+            "Only elementwise operations can be compiled for GPU"
+        )  # TODO: could also support vmap
     if isinstance(vectorization, VecSpec_VMap):
         if not use_torch:
             raise ValueError("VMap only available when using torch")

--- a/src/python/ksc/compile.py
+++ b/src/python/ksc/compile.py
@@ -192,6 +192,7 @@ def generate_cpp_for_py_module_from_ks(
     vectorization: VecSpec = VecSpec_None(),
     use_aten=True,
     use_torch=False,
+    gpu=False,
 ):
     """Returns two strings of C++ code:
        The first string contains definitions of all ksc-generated functions and entry points.
@@ -218,7 +219,11 @@ def generate_cpp_for_py_module_from_ks(
         cpp_entry_point_declarations,
         cpp_entry_point_definitions,
     ) = cgen.generate_cpp_entry_points(
-        bindings_to_generate, decls, vectorization=vectorization, use_torch=use_torch
+        bindings_to_generate,
+        decls,
+        vectorization=vectorization,
+        use_torch=use_torch,
+        gpu=gpu,
     )
     cpp_pybind_module_declaration = generate_cpp_pybind_module_declaration(
         bindings, python_module_name
@@ -302,6 +307,7 @@ def build_module_using_pytorch_from_ks(
     vectorization: VecSpec = VecSpec_None(),
     use_aten=False,
     extra_cflags=[],
+    gpu=False,
 ):
     """Uses PyTorch C++ extension mechanism to build and load a module
 
@@ -322,10 +328,14 @@ def build_module_using_pytorch_from_ks(
         vectorization=vectorization,
         use_aten=use_aten,
         use_torch=True,
+        gpu=gpu,
     )
 
     return build_module_using_pytorch_from_cpp_backend(
-        [("ksc-main.cpp", cpp_definitions), ("ksc-pybind.cpp", cpp_pybind)],
+        [
+            ("ksc-main.cu" if gpu else "ks-main.cpp", cpp_definitions),
+            ("ksc-pybind.cpp", cpp_pybind),
+        ],
         torch_extension_name,
         extra_cflags,
     )
@@ -381,6 +391,7 @@ def build_module_using_pytorch_from_cpp_backend(
         sources=[source_path(filename) for filename, _ in cpp_strs],
         extra_include_paths=[ksc_runtime_dir],
         extra_cflags=extra_cflags,
+        extra_cuda_cflags=extra_cflags + ["-DKS_CUDA"],
         build_directory=build_directory,
         verbose=verbose,
     )

--- a/src/runtime/knossos-entry-points-torch-cuda.cuh
+++ b/src/runtime/knossos-entry-points-torch-cuda.cuh
@@ -1,0 +1,2 @@
+#include "knossos-entry-points-torch.h"
+#include "knossos-kernel.cuh"

--- a/src/runtime/knossos.h
+++ b/src/runtime/knossos.h
@@ -74,11 +74,15 @@ Each C++ function is annotated with one of the following macros:
 #define COMMENT(x)
 
 // KS_ASSERT
+#ifdef KS_CUDA
+#define KS_ASSERT(expr) assert(expr);
+#else
 #define KS_ASSERT(expr)                     \
     if (expr)                               \
         ;                                   \
     else                                    \
         ks::fail(__FILE__, __LINE__, #expr);
+#endif
 
 namespace ks {
 	inline void fail [[noreturn]] (char const* file, int line, char const* expr)


### PR DESCRIPTION
Completes end-to-end CUDA support for elementwise functions:
- Generate CUDA entry points
- Functions defined using `knossos.elementwise` can be compiled twice, to support both CPU and GPU.