### PR TITLE
Update .NET Core minor version

### DIFF
--- a/test/builds/build_and_test.yml
+++ b/test/builds/build_and_test.yml
@@ -20,7 +20,7 @@ jobs:
 
   - task: UseDotNet@2
     inputs:
-      version: 3.1.100
+      version: 3.1.411
 
   - script: sh ./test/builds/mkdirs.sh
     displayName: 'Make directories [userInstall]'
@@ -104,7 +104,7 @@ jobs:
 
   - task: UseDotNet@2
     inputs:
-      version: 3.1.100
+      version: 3.1.411
 
   - task: PowerShell@2
     inputs:


### PR DESCRIPTION
We're on a very old version which is now breaking unrelated builds.

I've done a quick check and it seems to work fine.