### PR TITLE
gelu upper bounds (vectorised erf)

### DIFF
--- a/examples/dl-activations/gelu.py
+++ b/examples/dl-activations/gelu.py
@@ -44,11 +44,12 @@ cpp_inlined_map = """
             auto ret = tensor<1, ks::Float>::create($alloc, t.size());
             auto retdata = ret.data();
             auto sqrt_2_div_pi = sqrt(2.0 / 3.14159);
+            auto sqrt_2 = sqrt(2.0);
             for (int i = 0, ne = t.num_elements(); i != ne; ++i) {
                 ks::Float c$1;
                 ks::Float x = tdata[i];
                 ks::Float dreti = dretdata[i];
-                c$1 = 0.5 * (1.0 + erf(x / sqrt(2.0)) + x * sqrt_2_div_pi * exp(-x*x/2.0));
+                c$1 = 0.5 * (1.0 + erf(x / sqrt_2) + x * sqrt_2_div_pi * exp(-x*x/2.0));
                 retdata[i] = c$1 * dreti;
             }
             return ret;

--- a/examples/dl-activations/gelu.py
+++ b/examples/dl-activations/gelu.py
@@ -113,6 +113,23 @@ def vgelu_embedded_cpp_inlined_map_flags_extra():
     )
 
 
+def vgelu_embedded_cpp_aten():
+    return cpp_string_to_autograd_function(
+        """
+    torch::Tensor entry(torch::Tensor x) {
+        return 0.5 * x * (1.0 + erf(x / sqrt(2.0)));
+    }
+
+    torch::Tensor entry_vjp(torch::Tensor x, torch::Tensor dret) {
+        auto sqrt_2_div_pi = sqrt(2.0 / 3.14159);
+        return 0.5 * (1.0 + erf(x / sqrt(2.0)) + x * sqrt_2_div_pi * exp(-x*x/2.0)) * dret;
+    }
+    """,
+        "ksc_dl_activations__manual__vgelu_embedded_cpp_aten",
+        extra_cflags=embedded_cflags_opts + embedded_cflags,
+    )
+
+
 def gelu_approx_sigmoid(x: float) -> float:
     # From https://github.com/hendrycks/GELUs: fast but somewhat inaccurate
     return sigmoid(1.702 * x) * x


### PR DESCRIPTION
@dcrc2 and I managed to vectorise erf (we presume) by writing an embedded C++ function using aten. It is still about 50% slower than PyTorch on the largest problem size. We hypothesise that PyTorch is faster because it takes advantage of a BOG whereas our embedded C++, embedded ks, and ts2ks functions can't take advantage of a BOG. In fact `forward_template` stores only the arguments to the function (in other words, it "checkpoints" the function call). Contrary to my earlier expectation it seems that we can (and must) benefit from a BOG in these kernels so we will need https://github.com/microsoft/knossos-ksc/issues/818.

https://github.com/microsoft/knossos-ksc/blob/e0fe83263828ad9080f78aec3fff78ee8cd87b46/src/python/ksc/torch_frontend.py#L448-L459

![image](https://user-images.githubusercontent.com/51626669/127140371-d1e61d7b-f06b-4cd3-b96c-3741cd9c46f3.png)

![image](https://user-images.githubusercontent.com/51626669/127140421-f3b23c4f-e32e-4988-bc49-56d7ea6945b6.png)

![image](https://user-images.githubusercontent.com/51626669/127140479-323b91dd-6052-4f39-b22c-e011ff16f424.png)

(generated from 2c1799327759f7c220ac5c010ea5da2e1489d0bd)

How we discovered the BOG on PyTorch objects:

```
>>> import torch
>>> import torch.autograd
>>> inputs = torch.randn(10)
>>> inputs.requires_grad = True
>>> x = torch.erf(inputs)
>>> x.grad_fn._saved_self
tensor([ 0.2379,  0.9197, -0.4796,  0.8679,  0.2679,  1.2065, -0.2523, -0.9073,
         0.1340, -1.2081], requires_grad=True)
```
