### PR TITLE
Do not generate structured bindings

### DIFF
--- a/src/ksc/Cgen.hs
+++ b/src/ksc/Cgen.hs
@@ -482,7 +482,7 @@ cgenExprWithoutResettingAlloc env = \case
         cgenUntupling = case pat of
           VarPat _ -> []
           TupPat vs -> map (\(i, v) ->
-            "auto " ++ (cgenVar (tVarVar v)) ++ " = ks::get<" ++ show i ++ ">(" ++ vartuple ++ ");"
+            "auto " ++ cgenVar (tVarVar v) ++ " = ks::get<" ++ show i ++ ">(" ++ vartuple ++ ");"
             ) (zip [0..] vs)
 
     return $ CG


### PR DESCRIPTION
Replace structured bindings with explicit calls to `ks::get`. This should be exactly equivalent, and avoids compile errors when using nvcc (which incorrectly rejects lambdas which capture a structured binding).

Before:

```
ty$fwd$add$aff fwd$add$aff(ks::allocator * $alloc, ks::Tuple<ks::Float,ks::Float> xt, ks::Tuple<ks::Float,ks::Float> dxt) {
  auto [dx1, dx2] = dxt;
  ks::Float c$0 = add$aff($alloc, dx1, dx2);
  return (c$0);
}
```

After:

```
ty$fwd$add$aff fwd$add$aff(ks::allocator * $alloc, ks::Tuple<ks::Float,ks::Float> xt, ks::Tuple<ks::Float,ks::Float> dxt) {
  ks::Tuple<ks::Float,ks::Float> c$1 = dxt;
  auto dx1 = ks::get<0>(c$1);
  auto dx2 = ks::get<1>(c$1);
  ks::Float c$0 = add$aff($alloc, dx1, dx2);
  return (c$0);
}
```