### PR TITLE
Remove unused definition of to_integer

### DIFF
--- a/SYNTAX.md
+++ b/SYNTAX.md
@@ -284,7 +284,7 @@ separate into four categories:
  * **Arithmetic**: `add, sub, mul, div, neg`, for both `Float` and `Integer`.
  * **Comparison**: `eq, ne, gt, lt, gte, lte`, for both `Float` and `Integer`.
  * **Maths**: `log, exp, sin, cos, max, min, abs` for `Float`
- * **Type Conversion**: `to_float` for `Integer` and `to_integer` for `Float`
+ * **Type Conversion**: `to_float` for `Integer`
 
 Compilers will also generate their auto derivative, appending `D$` or `Dt$` to
 their names, but those should be used by the compiler only during

--- a/doc/sphinx/SYNTAX.md
+++ b/doc/sphinx/SYNTAX.md
@@ -284,7 +284,7 @@ separate into four categories:
  * **Arithmetic**: `add, sub, mul, div, neg`, for both `Float` and `Integer`.
  * **Comparison**: `eq, ne, gt, lt, gte, lte`, for both `Float` and `Integer`.
  * **Maths**: `log, exp, sin, cos, max, min, abs` for `Float`
- * **Type Conversion**: `to_float` for `Integer` and `to_integer` for `Float`
+ * **Type Conversion**: `to_float` for `Integer`
 
 Compilers will also generate their auto derivative, appending `D$` or `Dt$` to
 their names, but those should be used by the compiler only during

--- a/src/runtime/knossos-lm.h
+++ b/src/runtime/knossos-lm.h
@@ -527,8 +527,6 @@ namespace ks
 
 	inline auto D$ts_neg(allocator *, Float d) { return LM::Scale::mk(-1.0); }
 
-	inline auto D$to_integer(int d) { return LM::Zero<int, int>(); }
-
 	/*
 		template <class I, class Vec>
 		using D_t$index = LM::HCat<LM::Zero<I, typename Vec::value_type>,

--- a/src/runtime/knossos.h
+++ b/src/runtime/knossos.h
@@ -1603,8 +1603,6 @@ namespace ks {
 		return t1 != t2;
 	}
 
-	inline Integer to_integer(Integer d) { return d; }
-
 	template<size_t I, size_t Dim, typename TupleType>
 	auto unzip_element(allocator * alloc, tensor<Dim, TupleType> const& t)
 	{


### PR DESCRIPTION
The function `to_integer` is defined in knossos.h, but there is no such function in the prelude. It also doesn't have the correct mangling, even if an edef was added to the prelude. So we should either fix it or remove it: this PR would remove it.