### PR TITLE
Remove special case for inclusion of prelude-aten in knossos.h

### DIFF
--- a/src/python/ksc/torch_frontend.py
+++ b/src/python/ksc/torch_frontend.py
@@ -579,11 +579,7 @@ def cpp_string_to_module(
         ("entry_vjp", entry_vjp_name),
     ]
     return build_module_using_pytorch_from_cpp(
-        cpp_str,
-        bindings_to_generate,
-        torch_extension_name,
-        use_aten=True,
-        extra_cflags=extra_cflags,
+        cpp_str, bindings_to_generate, torch_extension_name, extra_cflags=extra_cflags,
     )
 
 

--- a/src/runtime/knossos.h
+++ b/src/runtime/knossos.h
@@ -1749,7 +1749,3 @@ namespace ks {
 #include "knossos-lm.h"
 
 #include "knossos-prelude.h"
-
-#ifdef KS_INCLUDE_ATEN
-#include "prelude-aten.cpp"
-#endif


### PR DESCRIPTION
This PR removes the macro `KS_INLCUDE_ATEN` which controlled whether the file `prelude-aten.cpp` was included at the bottom of `knossos.h`. The immediate reason for doing this is that we're going to want a different version of the ATen prelude when compiling code for the GPU.

Ideally, when the ATen prelude was used, the ksc-generated C++ would `#include "prelude-aten.cpp"` at the top of the file, immediately after `#include "knossos.h"`.

This PR achieves this by modifying the C++ immediately after it has been generated by ksc. (Actually it ends up writing `#include "prelude-aten.cpp"` _before_ `#include "knossos.h"`, but that's OK because `prelude-aten.cpp` starts by including `knossos.h` anyway.)

An alternative would be to add an option to ksc to insert the correct #include for each prelude that was used. This might be cleaner because it would mean that the C++ generated by ksc was self-contained. But since we're modifying ksc's generated code anyway (adding entry point definitions and the pybind module), it seems OK to add the #include here as well.
