### PR TITLE
Remove unused ts2mod

### DIFF
--- a/src/python/ksc/torch_frontend.py
+++ b/src/python/ksc/torch_frontend.py
@@ -652,19 +652,6 @@ def _tsmod2ksmod(
     )
 
 
-def ts2mod(function, example_inputs, torch_extension_name, generate_lm=True):
-    fn = torch.jit.script(function)
-    visitor = TorchScriptVisitor()
-    ksc_def = visitor.generate_def(False, fn.name, fn.graph, example_inputs)
-    return ksc_defs_to_autograd_function(
-        [ksc_def],
-        ksc_def,
-        torch_extension_name,
-        elementwise=False,
-        generate_lm=generate_lm,
-    )
-
-
 @dataclass
 class KscStub:
     raw_f: Callable

--- a/test/ts2k/test_torch_frontend.py
+++ b/test/ts2k/test_torch_frontend.py
@@ -5,7 +5,6 @@ import torch
 import numpy
 
 import ksc.torch_frontend as knossos
-from ksc.torch_frontend import ts2mod
 from ksc.torch_utils import elementwise_apply
 
 
@@ -200,10 +199,3 @@ def test_relu3(generate_lm):
         ks_ans = ks_relu3._entry_vjp(x, 1.0)
 
         assert pytest.approx(ks_ans, 1e-6) == py_ans
-
-
-# def test_Vec_init():
-#     def f(x : float):
-#         return torch.tensor([x, 2.2])
-
-#     ts2mod(f, [Type.Float], Type.Vec(Type.Float))


### PR DESCRIPTION
`ts2mod` is unused (which we can deduce because it calls `TorchScriptVisitor.generate_def` with four arguments instead of the three it should). It is mentioned in [some @awf personal code](https://github.com/microsoft/knossos-ksc/blob/cb108c9df6c63dca9b30f13476cbed6da99f550c/users/awf/torch_frontend_timing.py), but it is unused in the live codebase.

Can we remove it?
