### PR TITLE
Add #includes to generated C++

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ a `.ks` program.  This example runs `hello-world.ks`.
   --ks-source-file src/runtime/prelude.ks \
   --ks-source-file test/ksc/hello-world.ks \
   --ks-output-file obj/test/ksc/hello-world.kso \
+  --cpp-include prelude.h \
   --cpp-output-file obj/test/ksc/hello-world.cpp \
   --c++ g++ \
   --exe-output-file obj/test/ksc/hello-world.exe
@@ -148,6 +149,7 @@ or with PowerShell syntax:
   --ks-source-file src/runtime/prelude.ks `
   --ks-source-file test/ksc/hello-world.ks `
   --ks-output-file obj/test/ksc/hello-world.kso `
+  --cpp-include prelude.h `
   --cpp-output-file obj/test/ksc/hello-world.cpp `
   --c++ g++ `
   --exe-output-file obj/test/ksc/hello-world.exe
@@ -195,6 +197,7 @@ command line
   --ks-source-file src/runtime/prelude.ks \
   --ks-source-file input.ks \
   --ks-output-file output.ks \
+  --cpp-include prelude.h \
   --cpp-output-file output.cpp
 ```
 

--- a/examples/dl-activations/relu3.py
+++ b/examples/dl-activations/relu3.py
@@ -73,6 +73,7 @@ mtune_cflags = ksc.compile.CFlags.GCCOnly(["-mtune=native"])
 
 cpp_mask_bool_to_float = """
         #include "knossos.h"
+        #include "prelude.h"
 
         namespace ks{
         tensor<1, ks::Float> vrelu3(ks::allocator * $alloc, tensor<1, ks::Float> t) {

--- a/src/j2k/README.md
+++ b/src/j2k/README.md
@@ -134,6 +134,7 @@ then (in PowerShell style)
   --ks-source-file src/runtime/prelude.ks `
   --ks-source-file obj/test/j2k/j2k_test0.ks `
   --ks-output-file obj/test/j2k/j2k_test0.kso `
+  --cpp-include prelude.h `
   --cpp-output-file obj/test/j2k/j2k_test0.cpp `
   --c++ g++ `
   --exe-output-file obj/test/j2k/j2k_test0.exe

--- a/src/python/ksc/compile.py
+++ b/src/python/ksc/compile.py
@@ -80,6 +80,7 @@ def generate_cpp_from_ks(ks_str, preludes, prelude_headers):
         fks.name,
         "--ks-output-file",
         fkso.name,
+        *(opt for header in prelude_headers for opt in ("--cpp-include", header)),
         "--cpp-output-file",
         fcpp.name,
     ]
@@ -101,8 +102,6 @@ def generate_cpp_from_ks(ks_str, preludes, prelude_headers):
     with open(fcpp.name) as f:
         generated_cpp = f.read()
 
-    prelude_includes = "".join(f'#include "{header}"\n' for header in prelude_headers)
-
     # only delete these file if no error
     if not preserve_temporary_files:
 
@@ -118,7 +117,7 @@ def generate_cpp_from_ks(ks_str, preludes, prelude_headers):
             os.unlink(fcpp.name)
             os.unlink(fkso.name)
 
-    return prelude_includes + generated_cpp, decls
+    return generated_cpp, decls
 
 
 def build_py_module_from_cpp(cpp_str, profiling=False):
@@ -210,7 +209,7 @@ def generate_cpp_for_py_module_from_ks(
     ]
 
     preludes = ["prelude.ks"] + (["prelude-aten.ks"] if use_aten else [])
-    prelude_headers = ["prelude-aten.h"] if use_aten else []
+    prelude_headers = ["prelude.h"] + (["prelude-aten.h"] if use_aten else [])
     cpp_ks_functions, decls = generate_cpp_from_ks(ks_str, preludes, prelude_headers)
     (
         cpp_entry_point_declarations,

--- a/src/runtime/knossos.h
+++ b/src/runtime/knossos.h
@@ -1718,5 +1718,3 @@ namespace ks {
 } // namespace ks
 
 #include "knossos-lm.h"
-
-#include "prelude.h"

--- a/src/runtime/prelude.h
+++ b/src/runtime/prelude.h
@@ -1,6 +1,8 @@
 // Defines everything in Knossos.ks
 #pragma once
 
+#include "knossos.h"
+
 namespace ks {
 // ===============================  Test edef  ========================
 // These only exist so that we can test edef functionality.


### PR DESCRIPTION
Adds an option `--cpp-include` to ksc, to specify files to `#include` at the top of the generated code.

This makes it possible for ksc to generate a self-contained C++ file. Previously if a prelude was used which defined edefs, it was not possible to compile the resulting C++ without modifying it to add the corresponding `#include`.

I've removed the inclusion of `prelude.h` at the bottom of `knossos.h`. This means that you now have to specify `--cpp-include prelude.h` explicitly. The advantage is that it becomes possible to provide other implementations of the prelude, e.g. for CUDA support.

