### PR TITLE
RLO: make train_over_expressions.py runnable

### DIFF
--- a/rlo/.gitmodules
+++ b/rlo/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "knossos-ksc"]
-	path = knossos-ksc
-	url = https://github.com/microsoft/knossos-ksc

--- a/rlo/src/rlo/__init__.py
+++ b/rlo/src/rlo/__init__.py
@@ -3,6 +3,6 @@ import os
 
 sys.path.append(
     os.path.join(
-        os.path.dirname(__file__), os.pardir, os.pardir, "knossos-ksc", "src", "python"
+        os.path.dirname(__file__), os.pardir, os.pardir, os.pardir, "src", "python"
     )
 )


### PR DESCRIPTION
rm rlo/.gitmodules
fix sys.path

do we want to add to CI? (I haven't tried this - not sure how much package setup, authentication/etc. might be required)