### PR TITLE
Make support for allocation optional

### DIFF
--- a/src/ksc/Cgen.hs
+++ b/src/ksc/Cgen.hs
@@ -275,13 +275,10 @@ cComment :: String -> String
 cComment s = "/* " ++ s ++ " */"
 
 markAllocator :: String -> String -> String
-markAllocator bumpmark allocVar = "ks::alloc_mark_t " ++ bumpmark ++ " = " ++ allocVar ++ "->mark();"
+markAllocator bumpmark allocVar = "KS_MARK(" ++ allocVar ++ ", " ++ bumpmark ++ ");"
 
 resetAllocator :: String -> String -> String
-resetAllocator bumpmark allocVar = allocVar ++ "->reset(" ++ bumpmark ++ ");"
-
-moveMark :: String -> String -> String
-moveMark bumpmark allocVar = bumpmark ++ " = " ++ allocVar ++ "->mark();"
+resetAllocator bumpmark allocVar = "KS_RESET(" ++ allocVar ++ ", " ++ bumpmark ++ ");"
 
 allocatorParameterName :: String
 allocatorParameterName = "$alloc"
@@ -408,7 +405,7 @@ cgenExprWithoutResettingAlloc env = \case
         (  [ cComment "Explicitly-requested copydown",
              markAllocator bumpmark allocatorParameterName ]
         ++ cdecl
-        ++ [ cgenType ctype ++ " " ++ ret ++ " = ks::copydown(" ++ allocatorParameterName ++ ", " ++ bumpmark ++ ", " ++ generateCGRE cexpr ++ ");" ]
+        ++ [ cgenType ctype ++ " " ++ ret ++ " = KS_COPYDOWN(" ++ allocatorParameterName ++ ", " ++ bumpmark ++ ", (" ++ generateCGRE cexpr ++ "));" ]
         )
         (CGREVar (Simple ret))
         ctype

--- a/src/runtime/knossos-entry-points.cpp
+++ b/src/runtime/knossos-entry-points.cpp
@@ -3,11 +3,21 @@
 namespace ks {
 namespace entry_points {
 
+#ifdef KS_ALLOCATOR
+
 ks::allocator g_alloc{ 1'000'000'000 };
 
 void reset_allocator() { g_alloc.reset(); }
 size_t allocator_top() { return g_alloc.mark(); }
 size_t allocator_peak() { return g_alloc.peak(); }
+
+#else
+
+void reset_allocator() { }
+size_t allocator_top() { }
+size_t allocator_peak() { }
+
+#endif
 
 }
 }

--- a/src/runtime/knossos-entry-points.h
+++ b/src/runtime/knossos-entry-points.h
@@ -7,19 +7,13 @@
 namespace ks {
 namespace entry_points {
 
+#ifdef KS_ALLOCATOR
 extern ks::allocator g_alloc;
+#endif
+
 void reset_allocator();
 size_t allocator_top();
 size_t allocator_peak();
-
-// Convert functor to one which takes a first argument g_alloc,
-// and optionally logs inputs and outputs to cerr
-template<typename RetType, typename... ParamTypes>
-auto with_ks_allocator(const char * tracingMessage, RetType(*f)(ks::allocator*, ParamTypes...)) {
-  return [f, tracingMessage](ParamTypes... params) {
-    return f(&g_alloc, params...);
-  };
-}
 
 template<typename KSType, typename EntryPointType>
 KSType convert_argument(EntryPointType arg);


### PR DESCRIPTION
This PR modifies `knososs.h` to support scenarios where we want to prohibit any allocation taking place, e.g. for a basic version of GPU support.

When allocation is disabled you get a _runtime_ assertion failure if `tensor::create` is called.

I would have much preferred to make this a compile-time failure. However, this would have meant that `prelude.ks` could not be compiled. (`prelude.ks` contains several `build` calls, including some generated by gdefs.)

My initial plan was to provide a separate `prelude-cuda.ks`, removing the functions that do allocation. But although this works, I found some problems:
- Maintaining `prelude.ks` and `prelude-cuda.ks` separately would result in a huge amount of duplication. We could split `prelude.ks` up into the parts that require allocation and the parts that do not; but that destroys the logical structure of the file. (For example, `max` does not require allocation, but `[rev max]` does.) Also if we split `prelude.ks` up then most users will need to specify both sections of the prelude in the ksc command line, which is awkward. (We don't have any mechanism to include one `.ks` file from another.)
- The initial version of CUDA support won't support allocation, but we might plan to implement that in future. If we created `prelude-cuda.ks` now, and changed all the callers to use the correct preludes, we'd end up undoing all this work if we implement allocation later.

An alternative would be for ksc to strip out any unused defs as the final stage of compilation. Then we could get a compile-time error if any remaining defs involved a `build` (or another allocating function). I could try implementing this if we thought it was a good idea (it might also be good for reducing code size and C++ compile times). But, nearly all of this PR would still be necessary in that case: the difference would be that uses of `tensor::create` would cause a compile-time error rather than an assertion failure.