### PR TITLE
Publish Sphinx to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,5 +27,7 @@ jobs:
         python -m pip install -r doc/requirements.txt
 
     - name: 'Build docs'
-      run: sh ./doc/make.sh
+      run:
+        cd ./doc
+        sh ./make.sh
       

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
         python -m pip install -r doc/requirements.txt
 
     - name: 'Build docs'
-      run:
+      run: >
         cd ./doc
         sh ./make.sh
       

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
         python -m pip install -r doc/requirements.txt
 
     - name: 'Build docs'
-      run: >
+      run: |
         cd ./doc
         sh ./make.sh
       

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install -r doc/requirements-dev.txt
+        python -m pip install -r doc/requirements.txt
 
     - name: 'Build docs'
       run: sh ./doc/make.sh

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,31 @@
+name: Documentation (Sphinx)
+
+on:
+  push:
+    branches:
+      - master
+      - cogravil/docs_ghpages
+  workflow_dispatch:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -r doc/requirements-dev.txt
+
+    - name: 'Build docs'
+      run: sh ./doc/make.sh
+      

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,3 +31,8 @@ jobs:
         cd ./doc
         sh ./make.sh
       
+    - name: Deploy docs
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./build/doc

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - cogravil/docs_ghpages
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The docs are already live at:
https://microsoft.github.io/knossos-ksc/index.html
(it's unclear why https://microsoft.github.io/knossos-ksc/ isn't working right now, it may be when you read it. Some people claim it's a delay, others you need a few deployments)

There's some repository configuration which you do via the GitHub UI, to point to a specific branch. I used "gh-pages" which is a common default.