### PR TITLE
Ensure compiled as well

### DIFF
--- a/src/python/ksc/torch_frontend.py
+++ b/src/python/ksc/torch_frontend.py
@@ -674,6 +674,7 @@ class KscStub:
         Does not wrap torch tensors, or reset memory allocator.
         For test use only
         """
+        self.ensure_compiled(args)
         assert self.compiled  # TODO: infer call args from vjp args
         return self.compiled.py_mod.entry_vjp(*args)
 


### PR DESCRIPTION
The tests have an ordering dependency, as some parts assume compilation has happened. Try ensuring it here. Any performance implication?

To reproduce the issue:

`pytest test/ts2k/test_torch_frontend.py -k "test_ts2k_relux_grad"`