### PR TITLE
Improve error reporting for failed ksc call

### DIFF
--- a/src/python/ksc/compile.py
+++ b/src/python/ksc/compile.py
@@ -91,12 +91,22 @@ def generate_cpp_from_ks(ks_str, preludes, prelude_headers):
         print(e.stderr.decode("ascii"))
         decls = list(parse_ks_filename(fkso.name))
     except subprocess.CalledProcessError as e:
-        print(f"Command failed:\n{' '.join(ksc_command)}")
-        print(f"files {fks.name} {fkso.name} {fcpp.name}")
+        ksc_command_str = " ".join(ksc_command)
+        print(f"Command failed:\n{ksc_command_str}")
+        print(f"KSC files {fks.name} {fkso.name} {fcpp.name}")
         print(f"ks_str=\n{ks_str}")
+        print("KSC output:\n")
         print(e.output.decode("ascii"))
-        print(e.stderr.decode("ascii"))
-        raise
+        ksc_stderr = e.stderr.decode("ascii")
+        ksc_stderr_filtered = "> " + "\n> ".join(ksc_stderr.split("\n")[:-1])
+        print(ksc_stderr_filtered + "\n")
+        raise Exception(
+            f"Command failed:\n"
+            f"{ksc_command_str}\n"
+            f"KSC output:\n"
+            f"{ksc_stderr_filtered}\n"
+            f"See additional information in stdout"
+        ) from e
 
     # Read from CPP back to string
     with open(fcpp.name) as f:


### PR DESCRIPTION
Before, pytest errors on a failed call to ksc looked like this:
![image](https://user-images.githubusercontent.com/128119/129007371-961a22f9-0537-4529-9fb2-8f49f3cda787.png)

After:
![image](https://user-images.githubusercontent.com/128119/129007179-a1145da7-96ff-44de-81a7-6807e845e048.png)
