### PR TITLE
Initial plumbing for vmap

### DIFF
--- a/examples/dl-activations/gelu.py
+++ b/examples/dl-activations/gelu.py
@@ -82,7 +82,7 @@ def sigmoid(x):
 
 
 # Gelu and activations
-@knossos.vmap
+@knossos.elementwise
 def vgelu(x: float) -> float:
     return 0.5 * x * (1.0 + erf(x / sqrt(2)))
 

--- a/examples/dl-activations/relu3.py
+++ b/examples/dl-activations/relu3.py
@@ -12,8 +12,6 @@ from ksc.torch_frontend import (
 )
 import ksc.torch_frontend as knossos
 
-import torch._vmap_internals
-
 # BEGINDOC
 @knossos.register(elementwise=True)
 def vrelu3(x: float) -> float:
@@ -47,6 +45,7 @@ def vrelu3_pytorch(x: torch.Tensor):
 # RuntimeError: Batching rule not implemented for aten::is_nonzero. We could not generate a fallback.
 # See https://msrcambridge.visualstudio.com/Knossos/_backlogs/backlog/Knossos%20Team/Goals/?workitem=19587
 if False:
+    import torch._vmap_internals
 
     def relu3_pytorch_nice(x: float) -> float:
         if x < 0.0:

--- a/examples/dl-activations/relu3.py
+++ b/examples/dl-activations/relu3.py
@@ -13,7 +13,7 @@ from ksc.torch_frontend import (
 import ksc.torch_frontend as knossos
 
 # BEGINDOC
-@knossos.register(elementwise=True)
+@knossos.elementwise
 def vrelu3(x: float) -> float:
     """
     Like ReLu, but smoother

--- a/examples/dl-activations/relu3.py
+++ b/examples/dl-activations/relu3.py
@@ -15,7 +15,7 @@ import ksc.torch_frontend as knossos
 import torch._vmap_internals
 
 # BEGINDOC
-@knossos.vmap
+@knossos.register(elementwise=True)
 def vrelu3(x: float) -> float:
     """
     Like ReLu, but smoother

--- a/examples/dl-capsule/sqrl.py
+++ b/examples/dl-capsule/sqrl.py
@@ -35,4 +35,18 @@ def sqrl_pytorch_nice(x: torch.Tensor):
 def sqrl_bench_configs():
     yield torch.randn((4, 4))
     yield torch.randn((16, 16))
-    # yield torch.randn((128, 64))  TODO: uncomment after fixing SUF OOM issue
+
+
+#################################
+#
+# vsqrl - vectorized sqrl
+#
+
+vsqrl = knossos.vmap(sqrl)
+
+
+# run-bench: Define a range of values at which to call the methods
+def vsqrl_bench_configs():
+    yield torch.randn((10, 4, 4))
+    yield torch.randn((1000, 4, 4))
+    yield torch.randn((1000, 16, 16))

--- a/src/python/ksc/cgen.py
+++ b/src/python/ksc/cgen.py
@@ -140,7 +140,7 @@ def generate_cpp_entry_point(cpp_function_name, decl, vectorization, use_torch):
         return generate_cpp_elementwise_entry_point(cpp_function_name, decl)
     if vectorization == Vectorization.VMAP:
         if not use_torch:
-            raise ValueError("Elementwise operations only available when using torch")
+            raise ValueError("VMap only available when using torch")
         return generate_cpp_vmap_entry_point(cpp_function_name, decl)
 
     arg_types = arg_types_of_decl(decl)

--- a/src/python/ksc/cgen.py
+++ b/src/python/ksc/cgen.py
@@ -17,7 +17,6 @@ class Vectorization(Enum):
     NONE: f is compiled to take rank 3 tensors.
     ELEMENTWISE: f is compiled to take floats (rank 0), and is computed elementwise
     VMAP: f is compiled to take rank 2 tensors, and mapped over the first dimension.
-
     """
 
     NONE = 1

--- a/src/python/ksc/cgen.py
+++ b/src/python/ksc/cgen.py
@@ -4,6 +4,22 @@ from enum import Enum
 
 
 class Vectorization(Enum):
+    """
+    Options for vectorization of knossos-registered functions.
+
+    Suppose a knossos function
+       def f(x : Tensor) -> Tensor 
+
+    is called with x a tensor of size [PxMxN].  
+    
+    The Vectorize enum decides how f is mapped over this argument as follows:
+    
+    NONE: f is compiled to take rank 3 tensors.
+    ELEMENTWISE: f is compiled to take floats (rank 0), and is computed elementwise
+    VMAP: f is compiled to take rank 2 tensors, and mapped over the first dimension.
+
+    """
+
     NONE = 1
     VMAP = 2
     ELEMENTWISE = 3

--- a/src/python/ksc/compile.py
+++ b/src/python/ksc/compile.py
@@ -189,7 +189,7 @@ def generate_cpp_for_py_module_from_ks(
     ks_str,
     bindings_to_generate,
     python_module_name,
-    vectorization: VecSpec = VecSpec_None,
+    vectorization: VecSpec = VecSpec_None(),
     use_aten=True,
     use_torch=False,
 ):
@@ -268,7 +268,7 @@ PYBIND11_MODULE("""
 def build_py_module_from_ks(
     ks_str,
     bindings_to_generate,
-    vectorization: VecSpec = VecSpec_None,
+    vectorization: VecSpec = VecSpec_None(),
     use_aten=False,
     use_torch=False,
 ):
@@ -299,7 +299,7 @@ def build_module_using_pytorch_from_ks(
     ks_str,
     bindings_to_generate,
     torch_extension_name,
-    vectorization: VecSpec = VecSpec_None,
+    vectorization: VecSpec = VecSpec_None(),
     use_aten=False,
     extra_cflags=[],
 ):

--- a/src/python/ksc/compile.py
+++ b/src/python/ksc/compile.py
@@ -189,7 +189,7 @@ def generate_cpp_for_py_module_from_ks(
     ks_str,
     bindings_to_generate,
     python_module_name,
-    vectorization=VecSpec_None,
+    vectorization: VecSpec = VecSpec_None,
     use_aten=True,
     use_torch=False,
 ):

--- a/src/python/ksc/compile.py
+++ b/src/python/ksc/compile.py
@@ -1,16 +1,19 @@
+from dataclasses import dataclass
+from typing import List
+
 import atexit
 import os
 import subprocess
 import sysconfig
 import sys
-from dataclasses import dataclass
+
 from tempfile import NamedTemporaryFile
 from tempfile import gettempdir
-from typing import List
 
 from torch.utils import cpp_extension
 
 from ksc import cgen, utils
+from ksc.cgen import Vectorization
 from ksc.parse_ks import parse_ks_filename
 
 preserve_temporary_files = False
@@ -186,7 +189,7 @@ def generate_cpp_for_py_module_from_ks(
     ks_str,
     bindings_to_generate,
     python_module_name,
-    elementwise=False,
+    vectorization=Vectorization.NONE,
     use_aten=True,
     use_torch=False,
 ):
@@ -215,7 +218,7 @@ def generate_cpp_for_py_module_from_ks(
         cpp_entry_point_declarations,
         cpp_entry_point_definitions,
     ) = cgen.generate_cpp_entry_points(
-        bindings_to_generate, decls, elementwise=elementwise, use_torch=use_torch
+        bindings_to_generate, decls, vectorization=vectorization, use_torch=use_torch
     )
     cpp_pybind_module_declaration = generate_cpp_pybind_module_declaration(
         bindings, python_module_name
@@ -263,14 +266,18 @@ PYBIND11_MODULE("""
 
 
 def build_py_module_from_ks(
-    ks_str, bindings_to_generate, elementwise=False, use_aten=False, use_torch=False
+    ks_str,
+    bindings_to_generate,
+    vectorization=Vectorization.NONE,
+    use_aten=False,
+    use_torch=False,
 ):
 
     cpp_definitions, cpp_pybind = generate_cpp_for_py_module_from_ks(
         ks_str,
         bindings_to_generate,
         "PYTHON_MODULE_NAME",
-        elementwise=elementwise,
+        vectorization=vectorization,
         use_aten=use_aten,
         use_torch=use_torch,
     )
@@ -292,7 +299,7 @@ def build_module_using_pytorch_from_ks(
     ks_str,
     bindings_to_generate,
     torch_extension_name,
-    elementwise=False,
+    vectorization=Vectorization.NONE,
     use_aten=False,
     extra_cflags=[],
 ):
@@ -312,7 +319,7 @@ def build_module_using_pytorch_from_ks(
         ks_str,
         bindings_to_generate,
         "TORCH_EXTENSION_NAME",
-        elementwise=elementwise,
+        vectorization=vectorization,
         use_aten=use_aten,
         use_torch=True,
     )

--- a/src/python/ksc/compile.py
+++ b/src/python/ksc/compile.py
@@ -13,7 +13,7 @@ from tempfile import gettempdir
 from torch.utils import cpp_extension
 
 from ksc import cgen, utils
-from ksc.cgen import Vectorization
+from ksc.cgen import VecSpec, VecSpec_None, VecSpec_Elementwise, VecSpec_VMap
 from ksc.parse_ks import parse_ks_filename
 
 preserve_temporary_files = False
@@ -189,7 +189,7 @@ def generate_cpp_for_py_module_from_ks(
     ks_str,
     bindings_to_generate,
     python_module_name,
-    vectorization=Vectorization.NONE,
+    vectorization=VecSpec_None,
     use_aten=True,
     use_torch=False,
 ):
@@ -268,7 +268,7 @@ PYBIND11_MODULE("""
 def build_py_module_from_ks(
     ks_str,
     bindings_to_generate,
-    vectorization=Vectorization.NONE,
+    vectorization: VecSpec = VecSpec_None,
     use_aten=False,
     use_torch=False,
 ):
@@ -299,7 +299,7 @@ def build_module_using_pytorch_from_ks(
     ks_str,
     bindings_to_generate,
     torch_extension_name,
-    vectorization=Vectorization.NONE,
+    vectorization: VecSpec = VecSpec_None,
     use_aten=False,
     extra_cflags=[],
 ):

--- a/src/python/ksc/torch_frontend.py
+++ b/src/python/ksc/torch_frontend.py
@@ -711,7 +711,8 @@ class KscStub:
             print(f"knossos.register: Compiling {self.raw_f.__name__}")
             torch_extension_name = (
                 "KscStub_"
-                + self.vectorization.str() + "_"
+                + self.vectorization.str()
+                + "_"
                 + ("lm_" if self.generate_lm else "")
                 + self.module.__name__
                 + "_"
@@ -864,4 +865,3 @@ def elementwise(
         generate_lm=generate_lm,
         vectorization=VecSpec_Elementwise(example_element),
     )
-

--- a/src/python/ksc/torch_frontend.py
+++ b/src/python/ksc/torch_frontend.py
@@ -755,7 +755,10 @@ def _register_core(
 # TODO: In Python 3.9, optional-argument decorators will be much simpler.
 # https://docs.python.org/3.9/reference/compound_stmts.html#function
 def register_direct(func: Callable, generate_lm=False, elementwise=False, vmap=False):
-    module = inspect.getmodule(inspect.currentframe().f_back)
+    frame = inspect.currentframe()
+    assert frame
+    module = inspect.getmodule(frame.f_back)
+    assert module
     return _register_core(
         func, module, generate_lm=generate_lm, elementwise=elementwise, vmap=vmap,
     )

--- a/src/python/ksc/torch_frontend.py
+++ b/src/python/ksc/torch_frontend.py
@@ -606,7 +606,7 @@ def ksc_string_to_autograd_function(
         ks_str,
         entry_sn,
         torch_extension_name,
-        vectorization=VecSpec_None,
+        vectorization=VecSpec_None(),
         generate_lm=generate_lm,
         extra_cflags=extra_cflags,
     )
@@ -632,7 +632,7 @@ def _tsmod2ksmod(
     torch_extension_name,
     example_inputs,
     generate_lm=True,
-    vectorization: VecSpec = VecSpec_None,
+    vectorization: VecSpec = VecSpec_None(),
 ):
     assert isinstance(example_inputs, tuple)
 

--- a/src/python/ksc/torch_frontend.py
+++ b/src/python/ksc/torch_frontend.py
@@ -606,7 +606,7 @@ def ksc_string_to_autograd_function(
         ks_str,
         entry_sn,
         torch_extension_name,
-        vectorization=False,
+        vectorization=VecSpec_None,
         generate_lm=generate_lm,
         extra_cflags=extra_cflags,
     )

--- a/src/python/ksc/torch_frontend.py
+++ b/src/python/ksc/torch_frontend.py
@@ -801,4 +801,3 @@ def vmap(f: Union[Callable, KscStub], module: ModuleType, generate_lm=False):
         return KscStub(
             f, generate_lm=generate_lm, elementwise=False, vmap=True, module=module
         )
-

--- a/test/ts2k/test_dl_activations.py
+++ b/test/ts2k/test_dl_activations.py
@@ -8,7 +8,11 @@ import importlib
 
 @pytest.mark.parametrize(
     "module_file,bench_name",
-    [("examples/dl-activations/relu3", "vrelu3"), ("examples/dl-capsule/sqrl", "sqrl")],
+    [
+        #        ("examples/dl-capsule/sqrl", "vsqrl"),
+        ("examples/dl-activations/relu3", "vrelu3"),
+        ("examples/dl-capsule/sqrl", "sqrl"),
+    ],
 )
 def test_bench(module_file, bench_name):
     """

--- a/test/ts2k/test_torch_frontend.py
+++ b/test/ts2k/test_torch_frontend.py
@@ -69,7 +69,7 @@ def relux_pt(x: float):
     return (x < 0) * (0.1 * x) + (x > 0) * (x * x)
 
 
-vrelux = knossos.vmap(relux)
+vrelux = knossos.register_direct(relux, elementwise=True)
 
 
 def test_ts2k_vrelux():


### PR DESCRIPTION
No new functionality; this PR replaces "elementwise" in most places with a new class `VecSpec`, which has derived classes `VecSpec_None`, `VecSpec_Elementwise`, `VecSpec_VMap`., with meaning as follows:

Suppose a knossos function
```
       def f(x : Tensor) -> Tensor 
```
is called with x a tensor of size [PxMxN].  

The Vectorization specification VecSpec subclass decides how f is mapped over this argument as follows:
```    
     None: f is compiled to take rank 3 tensors.
     Elementwise: f is compiled to take floats (rank 0), and is computed elementwise.
     VMap: f is compiled to take rank 2 tensors, and mapped over the first dimension.
 ```
