### PR TITLE
Move all top-level modules to submodules of Ksc

### DIFF
--- a/knossos.cabal
+++ b/knossos.cabal
@@ -6,28 +6,28 @@ cabal-version:   >= 1.18
 executable ksc
   default-language: Haskell2010
   main-is: Main.hs
-  other-modules: AD
-                 ANF
-                 Annotate
-                 CSE
-                 Cgen
-                 KMonad
+  other-modules: Ksc.AD
+                 Ksc.ANF
+                 Ksc.Annotate
                  Ksc.CatLang
+                 Ksc.CSE
+                 Ksc.Cgen
                  Ksc.Futhark
+                 Ksc.KMonad
+                 Ksc.Lang
+                 Ksc.LangUtils
+                 Ksc.Opt
                  Ksc.Opt.Shape
+                 Ksc.OptLet
                  Ksc.Pipeline
+                 Ksc.Parse
+                 Ksc.Prim
+                 Ksc.Rules
+                 Ksc.Shapes
                  Ksc.SUF
                  Ksc.SUF.AD
                  Ksc.SUF.Rewrite
                  Ksc.Traversal
-                 Lang
-                 LangUtils
-                 Opt
-                 OptLet
-                 Parse
-                 Prim
-                 Rules
-                 Shapes
   hs-source-dirs: src/ksc
   build-depends: base >= 4.9,
                  pretty >= 1.1,

--- a/src/ksc/Ksc/AD.hs
+++ b/src/ksc/Ksc/AD.hs
@@ -3,12 +3,12 @@
 
 {-# LANGUAGE DataKinds #-}
 
-module AD where
+module Ksc.AD where
 
-import Lang
-import LangUtils
-import Prim
-import qualified OptLet
+import Ksc.Lang
+import Ksc.LangUtils
+import Ksc.Prim
+import qualified Ksc.OptLet
 import GHC.Stack
 
 import Data.Maybe (mapMaybe, fromMaybe)
@@ -71,7 +71,7 @@ gradDefInner adp
     s_ty = typeof s
 
     -- See Note: [Shadowing after grad]
-    rhs' = OptLet.ensureDon'tReuseParams [params] rhs
+    rhs' = Ksc.OptLet.ensureDon'tReuseParams [params] rhs
 
     lets = [ (gradTVar adp s params,
               mkGradTuple adp (Var params) (lmOne (typeof params)))

--- a/src/ksc/Ksc/ANF.hs
+++ b/src/ksc/Ksc/ANF.hs
@@ -4,12 +4,12 @@
              PatternSynonyms,
 	     ScopedTypeVariables, TypeApplications #-}
 
-module ANF where
+module Ksc.ANF where
 
 import Ksc.Traversal( traverseState )
-import Lang
-import OptLet( Subst, mkEmptySubst, substBndr, substVar )
-import KMonad
+import Ksc.Lang
+import Ksc.OptLet( Subst, mkEmptySubst, substBndr, substVar )
+import Ksc.KMonad
 import Control.Monad( ap )
 
 -- anfDefs :: (GenBndr p) => [DefX p] -> KM [DefX p]

--- a/src/ksc/Ksc/Annotate.hs
+++ b/src/ksc/Ksc/Annotate.hs
@@ -5,15 +5,15 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
 
-module Annotate (
+module Ksc.Annotate (
   annotDecls, lintDefs
   ) where
 
-import Lang
-import LangUtils
-import KMonad
+import Ksc.Lang
+import Ksc.LangUtils
+import Ksc.KMonad
 import Ksc.Traversal ( traverseOf )
-import Prim
+import Ksc.Prim
 import qualified Data.Map   as Map
 import GHC.Stack
 import Control.Monad( ap )

--- a/src/ksc/Ksc/CSE.hs
+++ b/src/ksc/Ksc/CSE.hs
@@ -1,16 +1,16 @@
 -- Copyright (c) Microsoft Corporation.
 -- Licensed under the MIT license.
-module CSE where
+module Ksc.CSE where
 
 import Ksc.Traversal( traverseState )
-import Lang
-import Prim
-import OptLet( Subst, substBndr, lookupSubst, mkEmptySubst, extendSubstMap )
-import LangUtils( GblSymTab )
-import Rules
-import ANF
-import Opt
-import KMonad
+import Ksc.Lang
+import Ksc.Prim
+import Ksc.OptLet( Subst, substBndr, lookupSubst, mkEmptySubst, extendSubstMap )
+import Ksc.LangUtils( GblSymTab )
+import Ksc.Rules
+import Ksc.ANF
+import Ksc.Opt
+import Ksc.KMonad
 import qualified Data.Map as M
 
 {- Note [CSE for bindings]

--- a/src/ksc/Ksc/CatLang.hs
+++ b/src/ksc/Ksc/CatLang.hs
@@ -4,9 +4,9 @@
 module Ksc.CatLang( CLDef, toCLDefs, fromCLDefs, toCLDef_maybe, fromCLDef ) where
 
 import Prelude hiding( (<>) )
-import Lang
-import LangUtils
-import Prim
+import Ksc.Lang
+import Ksc.LangUtils
+import Ksc.Prim
 import qualified Data.Set as S
 import Data.Maybe( mapMaybe )
 

--- a/src/ksc/Ksc/Cgen.hs
+++ b/src/ksc/Ksc/Cgen.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE LambdaCase, FlexibleInstances, PatternSynonyms  #-}
 {-# LANGUAGE DataKinds  #-}
 
-module Cgen where
+module Ksc.Cgen where
 
 import           GHC.Stack
 import           Prelude                 hiding ( lines
@@ -20,8 +20,8 @@ import qualified System.FilePath
 import qualified System.Process
 import           System.Exit                    ( ExitCode(ExitSuccess) )
 
-import           Lang                    hiding ( (<>) )
-import qualified OptLet
+import           Ksc.Lang                hiding ( (<>) )
+import qualified Ksc.OptLet
 
 import Debug.Trace
 
@@ -340,7 +340,7 @@ params_withPackedParams param = case typeof param of
         mkParam i ty = TVar ty (Simple name)
           where name = nameOfVar (tVarVar param) ++ "arg" ++ show i
         packParams = mkLet param (Tuple (map Var params))
-    in (params, OptLet.ensureDon'tReuseParams params . packParams)
+    in (params, Ksc.OptLet.ensureDon'tReuseParams params . packParams)
   _             -> ([param], id)
 
 mkCTypedVar :: TVar -> String

--- a/src/ksc/Ksc/Futhark.hs
+++ b/src/ksc/Ksc/Futhark.hs
@@ -8,12 +8,12 @@ import           Data.Int
 import           Data.List
 import           Prelude                 hiding ( (<>) )
 
-import qualified Cgen
-import qualified Lang                    as L
-import Lang (Pretty(..), text, render, empty, parensIf,
+import qualified Ksc.Cgen
+import qualified Ksc.Lang                as L
+import Ksc.Lang (Pretty(..), text, render, empty, parensIf,
              (<>), (<+>), ($$), parens, brackets, punctuate, sep,
              integer, double, comma, PrimFun(..))
-import qualified LangUtils               as LU
+import qualified Ksc.LangUtils           as LU
 
 --------------------------
 -- Futhark AST definition
@@ -225,7 +225,7 @@ toTypedName = toTypedNameString . render . ppr
 -- TypeInteger] would give "ii" instead of "<ii>".
 toTypedNameString :: String -> L.TypeX -> Name
 toTypedNameString x ty =
-  escape (Cgen.mangleFun (x ++ "@" ++ Cgen.mangleType ty))
+  escape (Ksc.Cgen.mangleFun (x ++ "@" ++ Ksc.Cgen.mangleType ty))
 
 toFutharkType :: L.Type -> Type
 toFutharkType L.TypeInteger    = I32

--- a/src/ksc/Ksc/KMonad.hs
+++ b/src/ksc/Ksc/KMonad.hs
@@ -1,7 +1,7 @@
 -- Copyright (c) Microsoft Corporation.
 -- Licensed under the MIT license.
 
-module KMonad where
+module Ksc.KMonad where
 
 import Control.Monad.State hiding (liftIO)
 import qualified Control.Monad.State

--- a/src/ksc/Ksc/Lang.hs
+++ b/src/ksc/Ksc/Lang.hs
@@ -11,7 +11,7 @@
 {-# OPTIONS_GHC -Wwarn=incomplete-patterns #-}
 -- Pattern match exhaustiveness checker seems to be broken on synonyms
 
-module Lang where
+module Ksc.Lang where
 
 import           Prelude                 hiding ( (<>) )
 
@@ -20,7 +20,7 @@ import qualified Ksc.Traversal                  as T
 import qualified Text.PrettyPrint              as PP
 import           Text.PrettyPrint               ( Doc )
 import           Data.List                      ( intersperse )
-import           KMonad
+import           Ksc.KMonad
 
 import           Data.Either                    ( partitionEithers )
 import qualified Data.Map as M
@@ -1283,7 +1283,7 @@ hspec = do
     it "doesn't truncate" (eqType (TypeTuple []) (TypeTuple [TypeFloat]) `shouldBe` False)
 
 test_Pretty :: IO ()
-test_Pretty = Test.Hspec.hspec Lang.hspec
+test_Pretty = Test.Hspec.hspec Ksc.Lang.hspec
 
 -----------------------------------------------
 --     Equality modulo alpha

--- a/src/ksc/Ksc/LangUtils.hs
+++ b/src/ksc/Ksc/LangUtils.hs
@@ -7,7 +7,7 @@
 	     ScopedTypeVariables #-}
 {-# LANGUAGE LambdaCase #-}
 
-module LangUtils (
+module Ksc.LangUtils (
   -- Functions over expressions
   isTrivial, splitTuple,
 
@@ -23,7 +23,7 @@ module LangUtils (
   notFreeIn, newVarNotIn, freeVarsOf,
 
   -- Tests
-  LangUtils.hspec, test_FreeIn,
+  Ksc.LangUtils.hspec, test_FreeIn,
 
   -- Symbol table
   GblSymTab, extendGblST, lookupGblST, emptyGblST, modifyGblST,
@@ -37,7 +37,7 @@ module LangUtils (
 
   ) where
 
-import Lang
+import Ksc.Lang
 import qualified Data.Map as M
 import qualified Data.Set as S
 import Data.Char( isDigit )
@@ -165,7 +165,7 @@ hspec = do
         newVarNotIn TypeFloat e2 `shouldBe` (var "_t2")
 
 test_FreeIn :: IO ()
-test_FreeIn = Test.Hspec.hspec LangUtils.hspec
+test_FreeIn = Test.Hspec.hspec Ksc.LangUtils.hspec
 
 
 -----------------------------------------------

--- a/src/ksc/Ksc/Opt.hs
+++ b/src/ksc/Ksc/Opt.hs
@@ -8,15 +8,15 @@
              PatternSynonyms,
 	     ScopedTypeVariables #-}
 
-module Opt( optLets, optDef, optDefs, optE, Opt.hspec, simplify, test_opt ) where
+module Ksc.Opt( optLets, optDef, optDefs, optE, Ksc.Opt.hspec, simplify, test_opt ) where
 
-import Lang
-import LangUtils
-import ANF
-import Prim
-import Rules
-import OptLet
-import KMonad
+import Ksc.Lang
+import Ksc.LangUtils
+import Ksc.ANF
+import Ksc.Prim
+import Ksc.Rules
+import Ksc.OptLet
+import Ksc.KMonad
 import Ksc.Opt.Shape ( optShape )
 import qualified Ksc.SUF.Rewrite as SUF
 import Ksc.Traversal( traverseState, mapAccumLM )
@@ -1055,4 +1055,4 @@ hspec = do
             lmHCat [lmAdd l1 l2, lmScale TypeFloat f4]
 
 test_opt:: IO ()
-test_opt = Test.Hspec.hspec Opt.hspec
+test_opt = Test.Hspec.hspec Ksc.Opt.hspec

--- a/src/ksc/Ksc/Opt/Shape.hs
+++ b/src/ksc/Ksc/Opt/Shape.hs
@@ -1,7 +1,7 @@
 module Ksc.Opt.Shape where
 
-import Lang
-import Prim
+import Ksc.Lang
+import Ksc.Prim
 
 -- See Note [Compressed shape types]
 

--- a/src/ksc/Ksc/OptLet.hs
+++ b/src/ksc/Ksc/OptLet.hs
@@ -4,7 +4,7 @@
              PatternSynonyms,
 	     ScopedTypeVariables #-}
 
-module OptLet( optLets
+module Ksc.OptLet( optLets
              , Subst
              , mkEmptySubst, lookupSubst
              , substInScope, extendInScopeSet
@@ -13,9 +13,9 @@ module OptLet( optLets
              , ensureDon'tReuseParams )
              where
 
-import Lang
-import LangUtils
-import Prim
+import Ksc.Lang
+import Ksc.LangUtils
+import Ksc.Prim
 import Ksc.Traversal (traverseState)
 import           Data.List (foldl')
 import qualified Data.Map as M

--- a/src/ksc/Ksc/Parse.hs
+++ b/src/ksc/Ksc/Parse.hs
@@ -4,7 +4,7 @@
              PatternSynonyms,
 	     ScopedTypeVariables #-}
 
-module Parse  where
+module Ksc.Parse  where
 
 {- The language we parse
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -97,7 +97,7 @@ Notes:
 -}
 
 
-import Lang hiding (parens, brackets)
+import Ksc.Lang hiding (parens, brackets)
 import Ksc.Traversal ( over )
 
 import Text.Parsec( (<|>), try, many, parse, eof, manyTill, ParseError, unexpected )

--- a/src/ksc/Ksc/Pipeline.hs
+++ b/src/ksc/Ksc/Pipeline.hs
@@ -6,24 +6,24 @@
 
 module Ksc.Pipeline where
 
-import Annotate (annotDecls, lintDefs)
-import AD (gradDef, applyDef)
-import qualified Cgen
-import CSE (cseDefs)
-import KMonad (KM, KMT, runKM,  banner)
+import Ksc.Annotate (annotDecls, lintDefs)
+import Ksc.AD (gradDef, applyDef)
+import qualified Ksc.Cgen
+import Ksc.CSE (cseDefs)
+import Ksc.KMonad (KM, KMT, runKM,  banner)
 import Ksc.CatLang
 import Ksc.Traversal (mapAccumLM)
-import Lang (Decl, DeclX(DefDecl), DerivedFun(Fun), Derivations(JustFun),
+import Ksc.Lang (Decl, DeclX(DefDecl), DerivedFun(Fun), Derivations(JustFun),
              TDef, Pretty,
              def_fun, displayN, partitionDecls,
              ppr, renderSexp, (<+>))
-import qualified Lang as L
-import LangUtils (GblSymTab, emptyGblST, extendGblST, stInsertFun)
+import qualified Ksc.Lang as L
+import Ksc.LangUtils (GblSymTab, emptyGblST, extendGblST, stInsertFun)
 import qualified Ksc.Futhark
-import Parse (parseF)
-import Rules (mkRuleBase)
-import Opt (optDefs)
-import Shapes (shapeDefs)
+import Ksc.Parse (parseF)
+import Ksc.Rules (mkRuleBase)
+import Ksc.Opt (optDefs)
+import Ksc.Shapes (shapeDefs)
 import Ksc.SUF (sufDef)
 import Ksc.SUF.AD (sufFwdRevPassDef, sufRevDef)
 
@@ -55,7 +55,7 @@ displayCppGen verbosity cppincludefiles ksFiles ksofile cppfile =
   ; decls0 <- fmap concat (mapM parseF ksFiles)
   ; putStrLn "ksc: read decls"
   ; defs <- pipelineIO verbosity decls0
-  ; Cgen.cppGenWithFiles ksofile cppfile cppincludefiles defs
+  ; Ksc.Cgen.cppGenWithFiles ksofile cppfile cppincludefiles defs
   }
 
 displayCppGenAndCompile
@@ -90,8 +90,8 @@ displayCppGenCompileAndRun :: HasCallStack
                            -> IO (String, (String, String))
 displayCppGenCompileAndRun compilername verbosity cppincludefiles files file = do
   { (exefile, cpp_kso) <- displayCppGenAndCompile
-                          (Cgen.compile compilername) ".exe" verbosity cppincludefiles files file
-  ; output <- Cgen.runExe exefile
+                          (Ksc.Cgen.compile compilername) ".exe" verbosity cppincludefiles files file
+  ; output <- Ksc.Cgen.runExe exefile
   ; pure (output, cpp_kso)
   }
 
@@ -280,7 +280,7 @@ genFuthark files file = do
   prelude <- readFile "src/runtime/knossos.fut"
   defs <- futharkPipeline (files ++ [file])
   putStrLn $ "ksc: Writing to " ++ futfile
-  Cgen.createDirectoryWriteFile futfile $
+  Ksc.Cgen.createDirectoryWriteFile futfile $
     intercalate "\n\n" $
     prelude : map (renderSexp . ppr . Ksc.Futhark.toFuthark) defs
   where futfile = "obj/" ++ file ++ ".fut"

--- a/src/ksc/Ksc/Prim.hs
+++ b/src/ksc/Ksc/Prim.hs
@@ -5,10 +5,10 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 
-module Prim where
+module Ksc.Prim where
 
-import Lang
-import LangUtils (isTrivial)
+import Ksc.Lang
+import Ksc.LangUtils (isTrivial)
 import GHC.Stack (HasCallStack)
 import Data.Maybe (isJust)
 import Control.Monad (zipWithM)

--- a/src/ksc/Ksc/Rules.hs
+++ b/src/ksc/Ksc/Rules.hs
@@ -1,10 +1,10 @@
 -- Copyright (c) Microsoft Corporation.
 -- Licensed under the MIT license.
 {-# OPTIONS_GHC -Wno-unused-matches #-}
-module Rules( RuleBase, tryRules, mkRuleBase ) where
+module Ksc.Rules( RuleBase, tryRules, mkRuleBase ) where
 
-import Lang
-import LangUtils ()
+import Ksc.Lang
+import Ksc.LangUtils ()
 import Control.Monad( guard )
 import Data.Map as M
 

--- a/src/ksc/Ksc/SUF.hs
+++ b/src/ksc/Ksc/SUF.hs
@@ -7,9 +7,9 @@
 
 module Ksc.SUF where
 
-import           Lang hiding ((<>))
-import           LangUtils (notInScopeTV)
-import           Prim
+import           Ksc.Lang hiding ((<>))
+import           Ksc.LangUtils (notInScopeTV)
+import           Ksc.Prim
 
 import qualified Data.Foldable as F
 import qualified Data.Set as S

--- a/src/ksc/Ksc/SUF/AD.hs
+++ b/src/ksc/Ksc/SUF/AD.hs
@@ -7,11 +7,11 @@ module Ksc.SUF.AD where
 
 import           Ksc.SUF (L2(L2), L3(L3), L4(L4), L8(L8))
 
-import           Lang
-import           LangUtils (notInScopeTVs, stInsertFun, GblSymTab,
+import           Ksc.Lang
+import           Ksc.LangUtils (notInScopeTVs, stInsertFun, GblSymTab,
                             freeVarsOf, lookupGblST, InScopeSet, mkInScopeSet,
                             extendInScopeSet)
-import           Prim
+import           Ksc.Prim
 
 import qualified Data.Set as S
 import           Data.Maybe (mapMaybe, catMaybes)

--- a/src/ksc/Ksc/SUF/Rewrite.hs
+++ b/src/ksc/Ksc/SUF/Rewrite.hs
@@ -7,8 +7,8 @@
 
 module Ksc.SUF.Rewrite (rewriteSUFFwdPass, rewriteSUFRevPass) where
 
-import Lang
-import Prim
+import Ksc.Lang
+import Ksc.Prim
 
 rewriteSUFFwdPass :: PrimFun -> TExpr -> Maybe TExpr
 rewriteSUFFwdPass (P_SelFun i n) arg

--- a/src/ksc/Ksc/Shapes.hs
+++ b/src/ksc/Ksc/Shapes.hs
@@ -20,10 +20,10 @@ shape$f may itself involve allocating memory in the heap.
 
 {-# LANGUAGE DataKinds #-}
 
-module Shapes where
+module Ksc.Shapes where
 
-import Lang
-import Prim
+import Ksc.Lang
+import Ksc.Prim
 import GHC.Stack
 import Data.Maybe(mapMaybe)
 

--- a/src/ksc/Main.hs
+++ b/src/ksc/Main.hs
@@ -4,13 +4,13 @@
 
 module Main where
 
-import Lang
-import LangUtils
-import Parse (parseE)
-import Opt
+import Ksc.Lang
+import Ksc.LangUtils
+import Ksc.Parse (parseE)
+import Ksc.Opt
 import Ksc.Pipeline (displayCppGenAndCompile, genFuthark)
 import qualified Ksc.Pipeline
-import qualified Cgen
+import qualified Ksc.Cgen
 import qualified Control.Exception
 import qualified Data.Maybe
 import Data.List( intercalate )
@@ -28,9 +28,9 @@ import Text.Parsec hiding (option)
 
 hspec :: Spec
 hspec = do
-    Opt.hspec
-    Lang.hspec
-    LangUtils.hspec
+    Ksc.Opt.hspec
+    Ksc.Lang.hspec
+    Ksc.LangUtils.hspec
 
 -- | 'main' is the entry point of this module. It allows compiling
 -- @.ks@ files, running tests and profiling.
@@ -103,8 +103,8 @@ compileAndRun = parseErr p
 
           return $ do
             Ksc.Pipeline.displayCppGen Nothing cppincludefiles inputs ksout cppout
-            Cgen.compile compiler cppout exeout
-            output <- Cgen.runExe exeout
+            Ksc.Cgen.compile compiler cppout exeout
+            output <- Ksc.Cgen.runExe exeout
             putStrLn output
 
 satisfyS :: Monad m => (String -> Bool) -> ParsecT [String] u m String
@@ -238,7 +238,7 @@ futharkCompileKscPrograms ksFiles = do
                         ++ " because it is known not to work with Futhark")
          else do
             genFuthark ["src/runtime/prelude"] ksTest
-            Cgen.readProcessPrintStderrOnFail
+            Ksc.Cgen.readProcessPrintStderrOnFail
               "futhark-0.11.2-linux-x86_64/bin/futhark"
               ["check", "obj/" ++ ksTest ++ ".fut"]
             return ()
@@ -311,8 +311,8 @@ profileArgs :: String -> FilePath -> FilePath -> FilePath -> IO ()
 profileArgs source proffile proffunctions proflines = do
   let compiler = "g++-7"
 
-  (exe, _) <- displayCppGenAndCompile (Cgen.compileWithProfiling compiler) ".exe" Nothing ["prelude.h"] ["src/runtime/prelude"] source
-  Cgen.readProcessEnvPrintStderr exe [] (Just [("CPUPROFILE", proffile)])
+  (exe, _) <- displayCppGenAndCompile (Ksc.Cgen.compileWithProfiling compiler) ".exe" Nothing ["prelude.h"] ["src/runtime/prelude"] source
+  Ksc.Cgen.readProcessEnvPrintStderr exe [] (Just [("CPUPROFILE", proffile)])
   withOutputFileStream proflines $ \std_out -> createProcess
     (proc "google-pprof" ["--text", "--lines", exe, proffile]) { std_out = std_out
                                                                }


### PR DESCRIPTION
For a public release we probably shouldn't have top-level modules. It's more comprehensible to organise them below a `Ksc` module.