### PR TITLE
Fixes for KS_NO_ALLOCATOR

### DIFF
--- a/src/runtime/knossos-entry-points.cpp
+++ b/src/runtime/knossos-entry-points.cpp
@@ -14,8 +14,8 @@ size_t allocator_peak() { return g_alloc.peak(); }
 #else
 
 void reset_allocator() { }
-size_t allocator_top() { }
-size_t allocator_peak() { }
+size_t allocator_top() { return 0u; }
+size_t allocator_peak() { return 0u; }
 
 #endif
 

--- a/src/runtime/knossos.h
+++ b/src/runtime/knossos.h
@@ -729,6 +729,9 @@ namespace ks {
 		return ret;
 	}
 
+	// ===============================  Copydown  ==================================
+
+#ifdef KS_ALLOCATOR
 	// The number of bytes that would be required from the
 	// allocator to store an inflated copy of the given object
 	template<class T>
@@ -754,9 +757,6 @@ namespace ks {
 		return ret;
 	}
 
-	// ===============================  Copydown  ==================================
-
-#ifdef KS_ALLOCATOR
 	// Tests if any of the memory referred to by val overlaps the
 	// range [start, end)
 	template<class T>


### PR DESCRIPTION
Fix potential build errors when `KS_NO_ALLOCATOR` is defined. (This is used in #976, where we can actually get away with the current version of the code, but it's clearly incorrect.)