### PR TITLE
Rename revmap to map2

### DIFF
--- a/examples/dl-activations/vrelu3_cuda_kernel.cu
+++ b/examples/dl-activations/vrelu3_cuda_kernel.cu
@@ -45,6 +45,6 @@ torch::Tensor vrelu3_cuda_forward(torch::Tensor input) {
 torch::Tensor vrelu3_cuda_backward(
     torch::Tensor grad,
     torch::Tensor x) {
-  return revmap_gpu(grad, x, Relu3_backward{});
+  return map2_gpu(grad, x, Relu3_backward{});
 }
 

--- a/src/runtime/knossos-kernel.cuh
+++ b/src/runtime/knossos-kernel.cuh
@@ -17,8 +17,8 @@ template<typename scalar_t> using tensor_accessor_2 =
 
 template <typename scalar_t, typename F>
 __global__ void map_kernel_1(
-    const tensor_accessor_1<scalar_t> input,
     tensor_accessor_1<scalar_t> output,
+    const tensor_accessor_1<scalar_t> input,
     F f) {
   const int i = blockIdx.x * blockDim.x + threadIdx.x;
   if (i < input.size(0))
@@ -27,8 +27,8 @@ __global__ void map_kernel_1(
 
 template <typename scalar_t, typename F>
 __global__ void map_kernel_2(
-    const tensor_accessor_2<scalar_t> input,
     tensor_accessor_2<scalar_t> output,
+    const tensor_accessor_2<scalar_t> input,
     F f) {
   const int n = blockIdx.y;
   const int i = blockIdx.x * blockDim.x + threadIdx.x;
@@ -53,8 +53,8 @@ torch::Tensor map_gpu(
       const int blocks = (input_size + threads - 1) / threads;
 
       map_kernel_1<ks_float><<<blocks, threads>>>(
-          input.packed_accessor32<ks_float,1,torch::RestrictPtrTraits>(),
           output.packed_accessor32<ks_float,1,torch::RestrictPtrTraits>(),
+          input.packed_accessor32<ks_float,1,torch::RestrictPtrTraits>(),
           f);
       break;
     }
@@ -66,8 +66,8 @@ torch::Tensor map_gpu(
       const dim3 blocks((input_size_1 + threads - 1) / threads, input_size_0);
 
       map_kernel_2<ks_float><<<blocks, threads>>>(
-          input.packed_accessor32<ks_float,2,torch::RestrictPtrTraits>(),
           output.packed_accessor32<ks_float,2,torch::RestrictPtrTraits>(),
+          input.packed_accessor32<ks_float,2,torch::RestrictPtrTraits>(),
           f);
       break;
     }
@@ -77,69 +77,69 @@ torch::Tensor map_gpu(
   return output;
 }
 
-template <typename scalar_t, typename RevF>
-__global__ void revmap_kernel_1(
-    tensor_accessor_1<scalar_t> d_x,
-    const tensor_accessor_1<scalar_t> grad,
-    const tensor_accessor_1<scalar_t> x,
-    RevF rev_f) {
+template <typename scalar_t, typename F>
+__global__ void map2_kernel_1(
+    tensor_accessor_1<scalar_t> output,
+    const tensor_accessor_1<scalar_t> input1,
+    const tensor_accessor_1<scalar_t> input2,
+    F f) {
   const int i = blockIdx.x * blockDim.x + threadIdx.x;
-  if (i < x.size(0))
-    d_x[i] = rev_f(grad[i], x[i]);
+  if (i < input1.size(0))
+    output[i] = f(input1[i], input2[i]);
 }
 
-template <typename scalar_t, typename RevF>
-__global__ void revmap_kernel_2(
-    tensor_accessor_2<scalar_t> d_x,
-    const tensor_accessor_2<scalar_t> grad,
-    const tensor_accessor_2<scalar_t> x,
-    RevF rev_f) {
+template <typename scalar_t, typename F>
+__global__ void map2_kernel_2(
+    tensor_accessor_2<scalar_t> output,
+    const tensor_accessor_2<scalar_t> input1,
+    const tensor_accessor_2<scalar_t> input2,
+    F f) {
   const int n = blockIdx.y;
   const int i = blockIdx.x * blockDim.x + threadIdx.x;
-  if (i < x.size(1))
-    d_x[n][i] = rev_f(grad[n][i], x[n][i]);
+  if (i < input1.size(1))
+    output[n][i] = f(input1[n][i], input2[n][i]);
 }
 
-template<typename RevF>
-torch::Tensor revmap_gpu(
-    torch::Tensor grad,
-    torch::Tensor x,
-    RevF rev_f) {
-  CHECK_INPUT(grad);
-  CHECK_INPUT(x);
+template<typename F>
+torch::Tensor map2_gpu(
+    torch::Tensor input1,
+    torch::Tensor input2,
+    F f) {
+  CHECK_INPUT(input1);
+  CHECK_INPUT(input2);
 
-  auto d_x = torch::zeros_like(x);
-  switch (x.sizes().size()) {
+  auto output = torch::zeros_like(input1);
+  switch (input1.sizes().size()) {
     case 1: {
-      auto x_size = x.size(0);
+      auto input_size = input1.size(0);
 
       // TODO: find out how PyTorch chooses these parameters
       const int threads = 1024;
-      const int blocks = (x_size + threads - 1) / threads;
+      const int blocks = (input_size + threads - 1) / threads;
 
-      revmap_kernel_1<ks_float><<<blocks, threads>>>(
-          d_x.packed_accessor32<ks_float,1,torch::RestrictPtrTraits>(),
-          grad.packed_accessor32<ks_float,1,torch::RestrictPtrTraits>(),
-          x.packed_accessor32<ks_float,1,torch::RestrictPtrTraits>(),
-          rev_f);
+      map2_kernel_1<ks_float><<<blocks, threads>>>(
+          output.packed_accessor32<ks_float,1,torch::RestrictPtrTraits>(),
+          input1.packed_accessor32<ks_float,1,torch::RestrictPtrTraits>(),
+          input2.packed_accessor32<ks_float,1,torch::RestrictPtrTraits>(),
+          f);
       break;
     }
     case 2: {
-      auto x_size_0 = x.size(0);
-      auto x_size_1 = x.size(1);
+      auto input_size_0 = input1.size(0);
+      auto input_size_1 = input1.size(1);
 
       const int threads = 1024;
-      const dim3 blocks((x_size_1 + threads - 1) / threads, x_size_0);
+      const dim3 blocks((input_size_1 + threads - 1) / threads, input_size_0);
 
-      revmap_kernel_2<ks_float><<<blocks, threads>>>(
-          d_x.packed_accessor32<ks_float,2,torch::RestrictPtrTraits>(),
-          grad.packed_accessor32<ks_float,2,torch::RestrictPtrTraits>(),
-          x.packed_accessor32<ks_float,2,torch::RestrictPtrTraits>(),
-          rev_f);
+      map2_kernel_2<ks_float><<<blocks, threads>>>(
+          output.packed_accessor32<ks_float,2,torch::RestrictPtrTraits>(),
+          input1.packed_accessor32<ks_float,2,torch::RestrictPtrTraits>(),
+          input2.packed_accessor32<ks_float,2,torch::RestrictPtrTraits>(),
+          f);
       break;
     }
     default:
       TORCH_CHECK(false, "Unsupported tensor rank");
   }
-  return d_x;
+  return output;
 }


### PR DESCRIPTION
Renames `revmap_gpu` to `map2_gpu` in `knossos-kernel.cuh`.

This function will be called by the generated entry point for any elementwise function which takes two arguments. The code-generator doesn't "know" that it's actually implementing a derivative, so the more generic name seems to make more sense.