### PR TITLE
Prune unused defs

### DIFF
--- a/knossos.cabal
+++ b/knossos.cabal
@@ -22,6 +22,7 @@ executable ksc
                  Ksc.Pipeline
                  Ksc.Parse
                  Ksc.Prim
+                 Ksc.Prune
                  Ksc.Rules
                  Ksc.Shapes
                  Ksc.SUF

--- a/rlo/src/rlo/ksc/release/gelu.kso
+++ b/rlo/src/rlo/ksc/release/gelu.kso
@@ -1,5 +1,5 @@
 ; Hand-munged from running
-; ./build/bin/ksc --generate-cpp --ks-source-file src/runtime/prelude.ks --ks-source-file gelu.ks --ks-output-file obj/test/gelu.kso --cpp-output-file obj/test/gelu.cpp
+; ./build/bin/ksc --generate-cpp --ks-source-file src/runtime/prelude.ks --ks-source-file gelu.ks --ks-output-file obj/test/gelu.kso --cpp-output-file obj/test/gelu.cpp --all-defs
 ; Where gelu.ks contained '(def gelu ...)' exactly as below, plus '(gdef rev [gelu Float])'
 ; This file was then manually converted from gelu.kso by extracting only the relevant defs and mangling the names.
 

--- a/src/ksc/Ksc/Parse.hs
+++ b/src/ksc/Ksc/Parse.hs
@@ -391,7 +391,7 @@ pBaseFun :: Parser (BaseFun Parsed)
 pBaseFun = pPrimFun
        <|> pBaseUserFun
 
-pFunG :: forall p. Parser (BaseFun p) -> Parser (Fun p)
+pFunG :: forall p n. Parser (BaseFunId n p) -> Parser (DerivedFun n p)
 pFunG pBase = try (brackets $
             ((pDerivation "D" GradFun)
          <|> (pDerivation "fwd" (DrvFun Fwd))

--- a/src/ksc/Ksc/Parse.hs
+++ b/src/ksc/Ksc/Parse.hs
@@ -404,6 +404,9 @@ pFunG pBase = try (brackets $
    <|> Fun JustFun <$> pBase
   where pDerivation s d = pReserved s >> Fun d <$> pBase
 
+pUserFunTyped  :: Parser (UserFun Typed)
+pUserFunTyped = pFunG (pBaseUserFunWithType id)
+
 pFunTyped :: Parser (Fun Typed)
 pFunTyped = pFunG (over baseFunName BaseUserFunName <$> pBaseUserFunWithType id)
 

--- a/src/ksc/Ksc/Parse.hs
+++ b/src/ksc/Ksc/Parse.hs
@@ -407,9 +407,6 @@ pFunG pBase = try (brackets $
 pUserFunTyped  :: Parser (UserFun Typed)
 pUserFunTyped = pFunG (pBaseUserFunWithType id)
 
-pFunTyped :: Parser (Fun Typed)
-pFunTyped = userFunToFun <$> pUserFunTyped
-
 pFun :: Parser (Fun Parsed)
 pFun = pFunG pBaseFun
 
@@ -464,9 +461,8 @@ pDerivation =
 pGDef :: Parser GDefX
 pGDef = do { pReserved "gdef"
            ; d <- pDerivation
-           ; f <- pFunTyped
-           ; mk_fun_f <- pIsUserFun f
-           ; pure (GDef d mk_fun_f)
+           ; f <- pUserFunTyped
+           ; pure (GDef d f)
            }
 
 

--- a/src/ksc/Ksc/Parse.hs
+++ b/src/ksc/Ksc/Parse.hs
@@ -408,7 +408,7 @@ pUserFunTyped  :: Parser (UserFun Typed)
 pUserFunTyped = pFunG (pBaseUserFunWithType id)
 
 pFunTyped :: Parser (Fun Typed)
-pFunTyped = pFunG (over baseFunName BaseUserFunName <$> pBaseUserFunWithType id)
+pFunTyped = userFunToFun <$> pUserFunTyped
 
 pFun :: Parser (Fun Parsed)
 pFun = pFunG pBaseFun

--- a/src/ksc/Ksc/Prune.hs
+++ b/src/ksc/Ksc/Prune.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE DataKinds #-}
+
+module Ksc.Prune where
+
+import Ksc.Lang hiding ((<>), empty)
+import Data.Maybe (mapMaybe)
+import Data.Set
+import Data.Map (fromList, lookup, Map)
+
+prune :: [TDef] -> Set (UserFun Typed) -> [TDef]
+prune defs roots = mapMaybe keep defs
+  where needed = prune' children Data.Set.empty roots
+        keep def = if def_fun def `elem` needed
+                   then Just def
+                   else Nothing
+
+        children :: UserFun Typed -> Set (UserFun Typed)
+        children next = case Data.Map.lookup next defsMap of
+          Nothing  -> Data.Set.empty
+          Just def -> case def_rhs def of
+            StubRhs   -> Data.Set.empty
+            EDefRhs   -> Data.Set.empty
+            UserRhs e -> userFunsCalled e
+
+        defsMap :: Map (UserFun Typed) TDef
+        defsMap = Data.Map.fromList (fmap (\def -> (def_fun def, def)) defs)
+
+prune' :: Ord a
+       => (a -> Set a)
+       -- ^ Children of a node
+       -> Set a
+       -- ^ Descendants that have already been found
+       -> Set a
+       -- ^ Yet to be explored
+       -> Set a
+       -- ^ Transitive descendants
+prune' children = recurse
+  where recurse done needed =
+          case pop needed of
+            Nothing -> done
+            Just (next, needed') ->
+              if next `elem` done
+              then recurse done needed'
+              else recurse (insert next done) (needed' <> children next)
+
+        pop = maxView
+
+userFunsCalled :: TExpr -> Set (UserFun Typed)
+userFunsCalled = \case
+  Konst _  -> empty
+  Var _    -> empty
+  Call f e -> singletonIfUserFun f <> userFunsCalled e
+  Tuple es -> foldMap userFunsCalled es
+  Lam _ e  -> userFunsCalled e
+  Dummy _  -> empty
+  App e1 e2    -> foldMap userFunsCalled [e1, e2]
+  Let _ e1 e2  -> foldMap userFunsCalled [e1, e2]
+  If e e1 e2   -> foldMap userFunsCalled [e, e1, e2]
+  Assert e1 e2 -> foldMap userFunsCalled [e1, e2]
+
+singletonIfUserFun :: TFun t -> Set (UserFun t)
+singletonIfUserFun (TFun _ f) = case maybeUserFun f of
+  Nothing -> empty
+  Just u  -> singleton u

--- a/src/python/ksc/compile.py
+++ b/src/python/ksc/compile.py
@@ -86,6 +86,7 @@ def generate_cpp_from_ks(ks_str, preludes, prelude_headers):
         *(opt for header in prelude_headers for opt in ("--cpp-include", header)),
         "--cpp-output-file",
         fcpp.name,
+        "--all-defs",
     ]
 
     try:


### PR DESCRIPTION
For example, the following only emits defs which are needed (transitively) by `main ()` (you can also provide multiple roots):

```
ksc --compile-and-run \
    --ks-source-file src/runtime/prelude.ks \
    --ks-source-file test/ksc/$SOURCE.ks \
    --ks-output-file obj/test/ksc/$SOURCE.kso \
    --cpp-include prelude.h \
    --cpp-output-file obj/test/ksc/$SOURCE.cpp \
    --remove-unused --used '[main (Tuple)]' \
    --c++ g++ \
    --exe-output-file obj/test/ksc/$SOURCE.exe 2>&1 | tee /tmp/out
```

To get the old behaviour use `all-defs`

```
ksc --compile-and-run \
    --ks-source-file src/runtime/prelude.ks \
    --ks-source-file test/ksc/$SOURCE.ks \
    --ks-output-file obj/test/ksc/$SOURCE.kso \
    --cpp-include prelude.h \
    --cpp-output-file obj/test/ksc/$SOURCE.cpp \
    --all-defs \
    --c++ g++ \
    --exe-output-file obj/test/ksc/$SOURCE.exe 2>&1 | tee /tmp/out
```