### PR TITLE
Fix printing of bindings in ksc-mlir

### DIFF
--- a/mlir/lib/Parser/AST.cpp
+++ b/mlir/lib/Parser/AST.cpp
@@ -104,7 +104,6 @@ std::ostream& Binding::dump(std::ostream& s, size_t tab) const {
   } else {
     s << string(tab + 2, ' ') << "name [" << var->getName() << "]" << endl;
   }
-  var->Expr::dump(s, tab + 2);
   init->dump(s, tab + 2);
   return s;
 }


### PR DESCRIPTION
Previous version repeated information unnecessarily and would crash on tupled lets.