### PR TITLE
Correct order of arguments in vrelu3 aten implementation

### DIFF
--- a/examples/dl-activations/relu3.py
+++ b/examples/dl-activations/relu3.py
@@ -370,7 +370,7 @@ torch::Tensor entry(torch::Tensor x) {
   return mask0_1 * val_0_1 + mask1_inf * val_1_inf;
 }
 
-torch::Tensor entry_vjp(torch::Tensor grad, torch::Tensor x) {
+torch::Tensor entry_vjp(torch::Tensor x, torch::Tensor grad) {
   torch::Tensor mask1_inf = x > 1.0;
   torch::Tensor mask0_1 = (x > 0.0) & ~mask1_inf;
   torch::Tensor val_0_1 = x * x;


### PR DESCRIPTION
Fixes a bug in #1001.

The PyTorch example code passes the arguments to `backward` in the opposite order to that used in Knossos. I forgot to switch the arguments when changing the benchmark to use the Knossos wrapper.

I should have picked this up in manual testing, sorry. The bug is not found by CI because we have some benchmarks which are _expected_ to give incorrect results (the `embedded_INCORRECT` benchmarks). Maybe we should disable those benchmarks in CI so that we can fail the build if another example breaks?