### PR TITLE
Build the PDF every week because it expires after 90 days

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -6,6 +6,10 @@ on:
     
   workflow_dispatch:
     
+  schedule:
+    # Run at 11pm (23 0) every Sunday (0)
+    - cron:  '23 0 * * 0'
+
 jobs:
   build_latex:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The original attempt at keeping the PDF fresh (https://github.com/microsoft/knossos-ksc/pull/775) didn't work because the retention limit is so low.  In this commit we follow the suggestion in
https://github.com/microsoft/knossos-ksc/pull/775#pullrequestreview-657916524.

Related: https://github.com/microsoft/knossos-ksc/issues/1036