### PR TITLE
Rename, add comments, per #1023

### DIFF
--- a/examples/dl-activations/gelu.py
+++ b/examples/dl-activations/gelu.py
@@ -63,17 +63,17 @@ embedded_cpp_entry_points = """
 
 torch::Tensor entry(torch::Tensor t) {
     using namespace ks::entry_points;
-    auto ks_t = convert_argument<ks::tensor<1, ks::Float>>(t);
+    auto ks_t = convert_to_ks_viewing_tensordata<ks::tensor<1, ks::Float>>(t);
     auto ks_ret = ks::vgelu(&g_alloc, ks_t);
-    return convert_return_value<torch::Tensor>(ks_ret);
+    return convert_from_ks<torch::Tensor>(ks_ret);
 }
 
 torch::Tensor entry_vjp(torch::Tensor t, torch::Tensor dret) {
     using namespace ks::entry_points;
-    auto ks_t = convert_argument<ks::tensor<1, ks::Float>>(t);
-    auto ks_dret = convert_argument<ks::tensor<1, ks::Float>>(dret);
+    auto ks_t = convert_to_ks_viewing_tensordata<ks::tensor<1, ks::Float>>(t);
+    auto ks_dret = convert_to_ks_viewing_tensordata<ks::tensor<1, ks::Float>>(dret);
     auto ks_ret = ks::sufrev_vgelu(&g_alloc, ks_t, ks_dret);
-    return convert_return_value<torch::Tensor>(ks_ret);
+    return convert_from_ks<torch::Tensor>(ks_ret);
 }
 """
 

--- a/examples/dl-activations/relu3.py
+++ b/examples/dl-activations/relu3.py
@@ -281,17 +281,17 @@ embedded_cpp_entry_points = """
 
 torch::Tensor entry(torch::Tensor t) {
     using namespace ks::entry_points;
-    auto ks_t = convert_argument<ks::tensor<1, ks::Float>>(t);
+    auto ks_t = convert_to_ks_viewing_tensordata<ks::tensor<1, ks::Float>>(t);
     auto ks_ret = ks::vrelu3(&g_alloc, ks_t);
-    return convert_return_value<torch::Tensor>(ks_ret);
+    return convert_from_ks<torch::Tensor>(ks_ret);
 }
 
 torch::Tensor entry_vjp(torch::Tensor t, torch::Tensor dret) {
     using namespace ks::entry_points;
-    auto ks_t = convert_argument<ks::tensor<1, ks::Float>>(t);
-    auto ks_dret = convert_argument<ks::tensor<1, ks::Float>>(dret);
+    auto ks_t = convert_to_ks_viewing_tensordata<ks::tensor<1, ks::Float>>(t);
+    auto ks_dret = convert_to_ks_viewing_tensordata<ks::tensor<1, ks::Float>>(dret);
     auto ks_ret = ks::sufrev_vrelu3(&g_alloc, ks_t, ks_dret);
-    return convert_return_value<torch::Tensor>(ks_ret);
+    return convert_from_ks<torch::Tensor>(ks_ret);
 }
 """
 

--- a/src/python/ksc/cgen.py
+++ b/src/python/ksc/cgen.py
@@ -207,11 +207,11 @@ def generate_cpp_entry_point(
 {cpp_function} {{
 """
 
-    # auto ks_arg0 = convert_argument<ks::tensor<Dim, Float>>(arg0);
+    # auto ks_arg0 = convert_to_ks_viewing_tensordata<ks::tensor<Dim, Float>>(arg0);
     # ...
-    # auto ks_arg7 = convert_argument<ks::tensor<Dim, Float>>(arg7);
+    # auto ks_arg7 = convert_to_ks_viewing_tensordata<ks::tensor<Dim, Float>>(arg7);
     for i in range(num_args):
-        cpp += f"    auto ks_arg{i} = convert_argument<{ks_cpp_type(arg_types[i])}>(arg{i});\n"
+        cpp += f"    auto ks_arg{i} = convert_to_ks_viewing_tensordata<{ks_cpp_type(arg_types[i])}>(arg{i});\n"
 
     # auto ks_ret = ks::my_kernel(&g_alloc, ks_arg0, ..., ks_arg7);
     cpp += f"""
@@ -220,7 +220,7 @@ def generate_cpp_entry_point(
 
     # convert return value and return
     cpp += f"""
-    return convert_return_value<{cpp_return_type}>(ks_ret);
+    return convert_from_ks<{cpp_return_type}>(ks_ret);
 }}
 """
     return cpp_declaration, cpp
@@ -343,16 +343,16 @@ torch::Tensor {cpp_function_name}({join_args(lambda k: f'torch::Tensor arg{k}')}
     int64_t n = arg0.size(0);
 """
 
-    # auto ks_arg0 = convert_argument<ks::tensor<2,float>>(arg0)
+    # auto ks_arg0 = convert_to_ks_viewing_tensordata<ks::tensor<2,float>>(arg0)
     # ...
-    # auto ks_arg7 = convert_argument<ks::tensor<1,int>>(arg7)
+    # auto ks_arg7 = convert_to_ks_viewing_tensordata<ks::tensor<1,int>>(arg7)
     for k in range(num_args):
         cpp += f"""
     KS_ASSERT(arg{k}.is_contiguous());
     KS_ASSERT(arg{k}.scalar_type() == scalar_type_of_Float);
     KS_ASSERT(arg{k}.size(0) == n);
 
-    auto ks_arg{k} = convert_argument<{ks_types[k]}>(arg{k});
+    auto ks_arg{k} = convert_to_ks_viewing_tensordata<{ks_types[k]}>(arg{k});
 """
 
     # Difficulty: depending on the rank of ks_ret, ks_ret[i] returns either
@@ -390,8 +390,8 @@ torch::Tensor {cpp_function_name}({join_args(lambda k: f'torch::Tensor arg{k}')}
     auto [{ks_sizes}] = ret0.size();
     // TODO: use torch::empty here, and copydown below.
     auto ret = torch::zeros({{n, {ks_sizes}}});
-    // And wrap it in ks - this is a view of the torch data, so convert_argument, not convert_return_value
-    auto ks_ret = convert_argument<ks::tensor<{ks_return_dim}, Float>>(ret);
+    // And view it as a ks tensor
+    auto ks_ret = convert_to_ks_viewing_tensordata<ks::tensor<{ks_return_dim}, Float>>(ret);
 
     // Place 0th value in the output
     auto ks_ret0 = ks_ret[0];

--- a/src/runtime/knossos-entry-points-python.h
+++ b/src/runtime/knossos-entry-points-python.h
@@ -11,7 +11,7 @@ struct Converter<ks::tensor<1, KsElementType>, std::vector<EntryPointElementType
   static ks::tensor<1, KsElementType> to_ks(std::vector<EntryPointElementType> const& arg) {
     auto ks_arg = ks::tensor<1, KsElementType>::create(&g_alloc, arg.size());
     for (int i = 0; i != ks_arg.size(); ++i) {
-      ks_arg[i] = convert_argument<KsElementType>(arg[i]);
+      ks_arg[i] = convert_to_ks_viewing_tensordata<KsElementType>(arg[i]);
     }
     return ks_arg;
   }
@@ -19,7 +19,7 @@ struct Converter<ks::tensor<1, KsElementType>, std::vector<EntryPointElementType
   static std::vector<EntryPointElementType> from_ks(ks::tensor<1, KsElementType> const& ks_ret) {
     std::vector<EntryPointElementType> ret;
     for (int i = 0; i != ks_ret.size(); ++i) {
-      ret.push_back(convert_return_value<EntryPointElementType>(ks_ret[i]));
+      ret.push_back(convert_from_ks<EntryPointElementType>(ks_ret[i]));
     }
     return ret;
   }
@@ -46,8 +46,8 @@ struct PurePythonEntryPointType<ks::tensor<1, KsElementType>>
 template<typename RetType, typename... ParamTypes>
 auto python_entry_point(RetType(*f)(ks::allocator*, ParamTypes...)) {
   return [f](typename PurePythonEntryPointType<ParamTypes>::type ...params) {
-    return convert_return_value<typename PurePythonEntryPointType<RetType>::type>(
-      f(&g_alloc, convert_argument<ParamTypes>(params)...)
+    return convert_from_ks<typename PurePythonEntryPointType<RetType>::type>(
+      f(&g_alloc, convert_to_ks_viewing_tensordata<ParamTypes>(params)...)
     );
   };
 }

--- a/src/runtime/knossos-entry-points.h
+++ b/src/runtime/knossos-entry-points.h
@@ -16,20 +16,25 @@ size_t allocator_top();
 size_t allocator_peak();
 
 template<typename KSType, typename EntryPointType>
-KSType convert_argument(EntryPointType arg);
+KSType convert_to_ks_viewing_tensordata(EntryPointType arg);
 
 template<typename EntryPointType, typename KSType>
-EntryPointType convert_return_value(KSType ret);
+EntryPointType convert_from_ks(KSType ret);
 
 template<typename KSType, typename EntryPointType>
 struct Converter
 {
   static_assert(std::is_same<KSType, EntryPointType>::value, "Entry point type is not supported");
 
+  // Convert arg to ks type.
+  // Scalars and tuples will copy, tensors will be viewed.
   static KSType to_ks(EntryPointType arg) {
     return arg;
   }
 
+  // Convert ks type to caller's type.  
+  // Scalars and tuples will copy, tensors may be copied, or may view the Knossos heap.
+  // TODO: bool parameter/template parameter which clarifies whether copy or view.
   static EntryPointType from_ks(KSType ret) {
     return ret;
   }
@@ -40,7 +45,7 @@ struct Converter<ks::Tuple<KsElementTypes...>, std::tuple<EntryPointElementTypes
 {
   template<size_t ...Indices>
   static ks::Tuple<KsElementTypes...> to_ks_impl(std::tuple<EntryPointElementTypes...> arg, std::index_sequence<Indices...>) {
-    return ks::make_Tuple(convert_argument<KsElementTypes>(std::get<Indices>(arg))...);
+    return ks::make_Tuple(convert_to_ks_viewing_tensordata<KsElementTypes>(std::get<Indices>(arg))...);
   }
 
   static ks::Tuple<KsElementTypes...> to_ks(std::tuple<EntryPointElementTypes...> arg) {
@@ -49,7 +54,7 @@ struct Converter<ks::Tuple<KsElementTypes...>, std::tuple<EntryPointElementTypes
 
   template<size_t ...Indices>
   static std::tuple<EntryPointElementTypes...> from_ks_impl(ks::Tuple<KsElementTypes...> ret, std::index_sequence<Indices...>) {
-    return std::make_tuple(convert_return_value<EntryPointElementTypes>(ks::get<Indices>(ret))...);
+    return std::make_tuple(convert_from_ks<EntryPointElementTypes>(ks::get<Indices>(ret))...);
   }
 
   static std::tuple<EntryPointElementTypes...> from_ks(ks::Tuple<KsElementTypes...> ret) {
@@ -58,12 +63,12 @@ struct Converter<ks::Tuple<KsElementTypes...>, std::tuple<EntryPointElementTypes
 };
 
 template<typename KSType, typename EntryPointType>
-KSType convert_argument(EntryPointType arg) {
+KSType convert_to_ks_viewing_tensordata(EntryPointType arg) {
   return Converter<KSType, EntryPointType>::to_ks(arg);
 }
 
 template<typename EntryPointType, typename KSType>
-EntryPointType convert_return_value(KSType ret) {
+EntryPointType convert_from_ks(KSType ret) {
   return Converter<KSType, EntryPointType>::from_ks(ret);
 }
 


### PR DESCRIPTION
Resolves #1023

In src/runtime/knossos-entry-points.h, we chose poor names for the functions convert_argument and convert_return_value, as the names reflect what the functions were originally used for, not what they actually do.

Rename to `convert_to_ks_viewing_tensordata` and `convert_from_ks`.

Update comments.