### PR TITLE
Remove infix pretty printer

### DIFF
--- a/src/ksc/Ksc/AD.hs
+++ b/src/ksc/Ksc/AD.hs
@@ -12,6 +12,7 @@ import qualified Ksc.OptLet
 import GHC.Stack
 
 import Data.Maybe (mapMaybe)
+import Text.PrettyPrint (render)
 
 {- Note [Automatic differentiation documentation]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/ksc/Ksc/ANF.hs
+++ b/src/ksc/Ksc/ANF.hs
@@ -11,6 +11,7 @@ import Ksc.Lang
 import Ksc.OptLet( Subst, mkEmptySubst, substBndr, substVar )
 import Ksc.KMonad
 import Control.Monad( ap )
+import Text.PrettyPrint ((<+>), text, char)
 
 -- anfDefs :: (GenBndr p) => [DefX p] -> KM [DefX p]
 anfDefs :: Monad m => [TDef] -> KMT m [TDef]

--- a/src/ksc/Ksc/Annotate.hs
+++ b/src/ksc/Ksc/Annotate.hs
@@ -19,6 +19,7 @@ import GHC.Stack
 import Control.Monad( ap )
 import Data.List( intersperse )
 import qualified Text.EditDistance as E
+import Text.PrettyPrint (($$), (<+>), text,  hang,  empty, render, vcat, nest)
 
 configEditDistanceThreshold :: Int
 configEditDistanceThreshold = 5

--- a/src/ksc/Ksc/CatLang.hs
+++ b/src/ksc/Ksc/CatLang.hs
@@ -12,6 +12,8 @@ import Ksc.LangUtils
 import Ksc.Prim
 import qualified Data.Set as S
 import Data.Maybe( mapMaybe )
+import Text.PrettyPrint (($$), (<+>), (<>), punctuate, comma,
+                         text, vcat, hang, parens, nest, sep, char, cat, int)
 
 data CLExpr
   = CLId

--- a/src/ksc/Ksc/Cgen.hs
+++ b/src/ksc/Ksc/Cgen.hs
@@ -19,8 +19,9 @@ import qualified System.Directory
 import qualified System.FilePath
 import qualified System.Process
 import           System.Exit                    ( ExitCode(ExitSuccess) )
+import           Text.PrettyPrint        (render)
 
-import           Ksc.Lang                hiding ( (<>) )
+import           Ksc.Lang
 import qualified Ksc.OptLet
 
 import Debug.Trace

--- a/src/ksc/Ksc/Cgen.hs
+++ b/src/ksc/Ksc/Cgen.hs
@@ -831,7 +831,7 @@ isMainFunction Def{ def_fun = Fun JustFun f, def_res_ty = TypeInteger }
 isMainFunction _ = False
 
 ksoGen :: [TDef] -> String
-ksoGen = unlines . map (renderSexp . ppr)
+ksoGen = unlines . map (render . ppr)
 
 cppGenWithFiles :: String -> String -> [String] -> [TDef] -> IO (String, String)
 cppGenWithFiles ksofile cppfile cppincludefiles defs = do

--- a/src/ksc/Ksc/Futhark.hs
+++ b/src/ksc/Ksc/Futhark.hs
@@ -7,12 +7,13 @@ module Ksc.Futhark (toFuthark, Def) where
 import           Data.Int
 import           Data.List
 import           Prelude                 hiding ( (<>) )
+import           Text.PrettyPrint (($$), (<+>), (<>),  fsep, punctuate, comma,
+                                  text,  hang,  fsep, empty, integer, brackets,
+                                  parens, sep, double, render)
 
 import qualified Ksc.Cgen
 import qualified Ksc.Lang                as L
-import Ksc.Lang (Pretty(..), text, render, empty, parensIf,
-             (<>), (<+>), ($$), parens, brackets, punctuate, sep,
-             integer, double, comma, PrimFun(..))
+import Ksc.Lang (Pretty(..), PrimFun(..), parensIf)
 import qualified Ksc.LangUtils           as LU
 
 --------------------------
@@ -102,10 +103,10 @@ instance Pretty Param where
 
 instance Pretty Def where
   ppr (DefFun entry fname tparams params ret rhs) =
-    L.hang (let' entry <+> text fname <+>
-            L.fsep (map ppr tparams) <+>
-            L.fsep (map ppr params) <+>
-            maybe empty ((text ":" <+>) . ppr) ret <+> text "=")
+    hang (let' entry <+> text fname <+>
+          fsep (map ppr tparams) <+>
+          fsep (map ppr params) <+>
+          maybe empty ((text ":" <+>) . ppr) ret <+> text "=")
     2 (ppr rhs)
     where let' Entry = text "entry"
           let' NotEntry = text "let"
@@ -172,7 +173,7 @@ instance Pretty Exp where
     parensIf p 10 $
     ppr f <+> sep (map (pprPrec 10) args)
   pprPrec _ (Lambda params body) =
-    parens $ text "\\" <> L.hang (sep (map ppr params) <+> text "->")
+    parens $ text "\\" <> hang (sep (map ppr params) <+> text "->")
     2 (ppr body)
   pprPrec _ (Project e field) =
     e' <> text "." <> text field

--- a/src/ksc/Ksc/Lang.hs
+++ b/src/ksc/Ksc/Lang.hs
@@ -17,7 +17,6 @@ import           Prelude                 hiding ( (<>) )
 
 import qualified Ksc.Traversal                  as T
 
-import qualified Text.PrettyPrint              as PP
 import           Text.PrettyPrint
 import           Data.List                      ( intersperse )
 import           Ksc.KMonad
@@ -722,9 +721,6 @@ type SDoc = Doc
 
 default_display_style :: ()
 default_display_style = ()
-
-renderSexp :: SDoc -> String
-renderSexp = PP.render
 
 -----------------------------------------------
 --     Pretty printer for the KS language

--- a/src/ksc/Ksc/Lang.hs
+++ b/src/ksc/Ksc/Lang.hs
@@ -718,49 +718,49 @@ traceWhenTypesUnequal = traceWhenUnequal
 --     SDoc abstraction over expression display style
 -----------------------------------------------
 
-newtype SDoc = SDoc(() -> Doc) -- True = S-expressions, False = infix style
+newtype SDoc = SDoc Doc
 
 (<>) :: SDoc -> SDoc -> SDoc
-SDoc d1 <> SDoc d2 = SDoc (\s -> d1 s PP.<> d2 s)
+SDoc d1 <> SDoc d2 = SDoc (d1 PP.<> d2)
 
 (<+>) :: SDoc -> SDoc -> SDoc
-SDoc d1 <+> SDoc d2 = SDoc (\s -> d1 s PP.<+> d2 s)
+SDoc d1 <+> SDoc d2 = SDoc (d1 PP.<+> d2)
 
 ($$) :: SDoc -> SDoc -> SDoc
-SDoc d1 $$ SDoc d2 = SDoc (\s -> d1 s PP.$$ d2 s)
+SDoc d1 $$ SDoc d2 = SDoc (d1 PP.$$ d2)
 
 text :: String -> SDoc
-text s = SDoc (\_ -> PP.text s)
+text s = SDoc (PP.text s)
 
 char :: Char -> SDoc
-char c = SDoc (\_ -> PP.char c)
+char c = SDoc (PP.char c)
 
 int :: Int -> SDoc
-int i = SDoc (\_ -> PP.int i)
+int i = SDoc (PP.int i)
 
 integer :: Integer -> SDoc
-integer i = SDoc (\_ -> PP.integer i)
+integer i = SDoc (PP.integer i)
 
 double :: Double -> SDoc
-double d = SDoc (\_ -> PP.double d)
+double d = SDoc (PP.double d)
 
 parens :: SDoc -> SDoc
-parens (SDoc d) = SDoc (PP.parens . d)
+parens (SDoc d) = SDoc (PP.parens d)
 
 cat :: [SDoc] -> SDoc
 cat ss = SDoc
-  (\m -> PP.cat $ map
+  (PP.cat $ map
     (\case
-      SDoc s -> s m
+      SDoc s -> s
     )
     ss
   )
 
 sep :: [SDoc] -> SDoc
 sep ss = SDoc
-  (\m -> PP.sep $ map
+  (PP.sep $ map
     (\case
-      SDoc s -> s m
+      SDoc s -> s
     )
     ss
   )
@@ -771,69 +771,69 @@ mode :: SDoc  -- How to print in s-expression style
 mode (SDoc se) _ = SDoc se
 
 nest :: Int -> SDoc -> SDoc
-nest i (SDoc d) = SDoc (PP.nest i . d)
+nest i (SDoc d) = SDoc (PP.nest i d)
 
 vcat :: [SDoc] -> SDoc
 vcat ss = SDoc
-  (\m -> PP.vcat $ map
+  (PP.vcat $ map
     (\case
-      SDoc s -> s m
+      SDoc s -> s
     )
     ss
   )
 
 hang :: SDoc -> Int -> SDoc -> SDoc
-hang (SDoc d1) i (SDoc d2) = SDoc (\m -> PP.hang (d1 m) i (d2 m))
+hang (SDoc d1) i (SDoc d2) = SDoc (PP.hang d1 i d2)
 
 braces :: SDoc -> SDoc
-braces (SDoc d) = SDoc (PP.braces . d)
+braces (SDoc d) = SDoc (PP.braces d)
 
 brackets :: SDoc -> SDoc
-brackets (SDoc d) = SDoc (PP.brackets . d)
+brackets (SDoc d) = SDoc (PP.brackets d)
 
 doubleQuotes :: SDoc -> SDoc
-doubleQuotes (SDoc d) = SDoc (PP.doubleQuotes . d)
+doubleQuotes (SDoc d) = SDoc (PP.doubleQuotes d)
 
 fsep :: [SDoc] -> SDoc
 fsep ss = SDoc
-  (\m -> PP.fsep $ map
+  (PP.fsep $ map
     (\case
-      SDoc s -> s m
+      SDoc s -> s
     )
     ss
   )
 
 punctuate :: SDoc -> [SDoc] -> [SDoc]
 punctuate (SDoc p) ss =
-  let ts = PP.punctuate (p ()) $ map
+  let ts = PP.punctuate p $ map
         (\case
-          SDoc s -> s ()
+          SDoc s -> s
         )
         ss
-      fs = PP.punctuate (p ()) $ map
+      fs = PP.punctuate p $ map
         (\case
-          SDoc s -> s ()
+          SDoc s -> s
         )
         ss
-  in  map (\(t, f) -> SDoc (\() -> if True then t else f)) (zip ts fs)
+  in  map (\(t, f) -> SDoc (if True then t else f)) (zip ts fs)
 
 comma :: SDoc
 comma = text ","
 
 empty :: SDoc
-empty = SDoc (\_ -> PP.empty)
+empty = SDoc (PP.empty)
 
 default_display_style :: ()
 default_display_style = ()
 
 render :: SDoc -> String
-render (SDoc s) = PP.render (s default_display_style)
+render (SDoc s) = PP.render s
 
 renderSexp :: SDoc -> String
-renderSexp (SDoc s) = PP.render (s ())
+renderSexp (SDoc s) = PP.render s
 
 instance Show SDoc where
-  show (SDoc s) = show (s default_display_style)
+  show (SDoc s) = show s
 
 -----------------------------------------------
 --     Pretty printer for the KS language

--- a/src/ksc/Ksc/Lang.hs
+++ b/src/ksc/Ksc/Lang.hs
@@ -1073,7 +1073,7 @@ pprExpr :: forall phase. InPhase phase => Prec -> ExprX phase -> SDoc
 pprExpr _ (Var   v ) = pprVar @phase v
 pprExpr _ (Dummy ty) = parens $ text "$dummy" <+> pprParendType ty
 pprExpr p (Konst k ) = pprPrec p k
-pprExpr p (Call f e) = pprCall p f e
+pprExpr _ (Call f e) = pprCall f e
 pprExpr _ (Tuple es) = parens $ text "tuple" <+> rest
   where rest = pprList ppr es
 pprExpr _ (Lam v e) =  parens $ text "lam" <+> parens (pprTVar v) <+> ppr e
@@ -1086,8 +1086,8 @@ pprExpr _ (App e1 e2) =
   parens (text "App" <+> sep [pprParendExpr e1, pprParendExpr e2])
     -- We aren't expecting Apps, so I'm making them very visible
 
-pprCall :: forall p. InPhase p => Prec -> FunX p -> ExprX p -> SDoc
-pprCall _ f e = parens $ pprFunOcc @p f <+> pp_args_tuple
+pprCall :: forall p. InPhase p => FunX p -> ExprX p -> SDoc
+pprCall f e = parens $ pprFunOcc @p f <+> pp_args_tuple
  where
   pp_args = ppr e
 

--- a/src/ksc/Ksc/Lang.hs
+++ b/src/ksc/Ksc/Lang.hs
@@ -18,7 +18,7 @@ import           Prelude                 hiding ( (<>) )
 import qualified Ksc.Traversal                  as T
 
 import qualified Text.PrettyPrint              as PP
-import           Text.PrettyPrint               ( Doc )
+import           Text.PrettyPrint
 import           Data.List                      ( intersperse )
 import           Ksc.KMonad
 
@@ -718,117 +718,13 @@ traceWhenTypesUnequal = traceWhenUnequal
 --     SDoc abstraction over expression display style
 -----------------------------------------------
 
-newtype SDoc = SDoc Doc
-
-(<>) :: SDoc -> SDoc -> SDoc
-SDoc d1 <> SDoc d2 = SDoc (d1 PP.<> d2)
-
-(<+>) :: SDoc -> SDoc -> SDoc
-SDoc d1 <+> SDoc d2 = SDoc (d1 PP.<+> d2)
-
-($$) :: SDoc -> SDoc -> SDoc
-SDoc d1 $$ SDoc d2 = SDoc (d1 PP.$$ d2)
-
-text :: String -> SDoc
-text s = SDoc (PP.text s)
-
-char :: Char -> SDoc
-char c = SDoc (PP.char c)
-
-int :: Int -> SDoc
-int i = SDoc (PP.int i)
-
-integer :: Integer -> SDoc
-integer i = SDoc (PP.integer i)
-
-double :: Double -> SDoc
-double d = SDoc (PP.double d)
-
-parens :: SDoc -> SDoc
-parens (SDoc d) = SDoc (PP.parens d)
-
-cat :: [SDoc] -> SDoc
-cat ss = SDoc
-  (PP.cat $ map
-    (\case
-      SDoc s -> s
-    )
-    ss
-  )
-
-sep :: [SDoc] -> SDoc
-sep ss = SDoc
-  (PP.sep $ map
-    (\case
-      SDoc s -> s
-    )
-    ss
-  )
-
-nest :: Int -> SDoc -> SDoc
-nest i (SDoc d) = SDoc (PP.nest i d)
-
-vcat :: [SDoc] -> SDoc
-vcat ss = SDoc
-  (PP.vcat $ map
-    (\case
-      SDoc s -> s
-    )
-    ss
-  )
-
-hang :: SDoc -> Int -> SDoc -> SDoc
-hang (SDoc d1) i (SDoc d2) = SDoc (PP.hang d1 i d2)
-
-braces :: SDoc -> SDoc
-braces (SDoc d) = SDoc (PP.braces d)
-
-brackets :: SDoc -> SDoc
-brackets (SDoc d) = SDoc (PP.brackets d)
-
-doubleQuotes :: SDoc -> SDoc
-doubleQuotes (SDoc d) = SDoc (PP.doubleQuotes d)
-
-fsep :: [SDoc] -> SDoc
-fsep ss = SDoc
-  (PP.fsep $ map
-    (\case
-      SDoc s -> s
-    )
-    ss
-  )
-
-punctuate :: SDoc -> [SDoc] -> [SDoc]
-punctuate (SDoc p) ss =
-  let ts = PP.punctuate p $ map
-        (\case
-          SDoc s -> s
-        )
-        ss
-      fs = PP.punctuate p $ map
-        (\case
-          SDoc s -> s
-        )
-        ss
-  in  map (\(t, f) -> SDoc (if True then t else f)) (zip ts fs)
-
-comma :: SDoc
-comma = text ","
-
-empty :: SDoc
-empty = SDoc (PP.empty)
+type SDoc = Doc
 
 default_display_style :: ()
 default_display_style = ()
 
-render :: SDoc -> String
-render (SDoc s) = PP.render s
-
 renderSexp :: SDoc -> String
-renderSexp (SDoc s) = PP.render s
-
-instance Show SDoc where
-  show (SDoc s) = show s
+renderSexp = PP.render
 
 -----------------------------------------------
 --     Pretty printer for the KS language

--- a/src/ksc/Ksc/LangUtils.hs
+++ b/src/ksc/Ksc/LangUtils.hs
@@ -40,6 +40,8 @@ import qualified Data.Set as S
 import Data.Char( isDigit )
 import Data.List( mapAccumL )
 import Test.Hspec
+import Text.PrettyPrint (($$), (<+>), braces, fsep, punctuate, comma,
+                         text, vcat, hang)
 
 -----------------------------------------------
 --     Functions over expressions

--- a/src/ksc/Ksc/Opt.hs
+++ b/src/ksc/Ksc/Opt.hs
@@ -27,6 +27,7 @@ import Test.Hspec
 import Data.List( mapAccumR )
 import Data.Sequence( mapWithIndex, fromList )
 import Data.Foldable( toList )
+import Text.PrettyPrint ((<+>), text, parens, render, vcat)
 
 optTrace :: String -> a -> a
 optTrace _msg t = t

--- a/src/ksc/Ksc/Parse.hs
+++ b/src/ksc/Ksc/Parse.hs
@@ -97,12 +97,13 @@ Notes:
 -}
 
 
-import Ksc.Lang hiding (parens, brackets)
+import Ksc.Lang
 import Ksc.Traversal ( over )
 
 import Text.Parsec( (<|>), try, many, parse, eof, manyTill, ParseError, unexpected )
 import Text.Parsec.Char
 import Text.Parsec.String (Parser)
+import Text.PrettyPrint (render)
 
 import qualified Text.Parsec.Token as Tok
 

--- a/src/ksc/Ksc/Pipeline.hs
+++ b/src/ksc/Ksc/Pipeline.hs
@@ -17,7 +17,7 @@ import Ksc.Traversal (mapAccumLM)
 import Ksc.Lang (Decl, DeclX(DefDecl), DerivedFun(Fun), Derivations(JustFun),
              TDef, Pretty,
              def_fun, displayN, partitionDecls,
-             ppr, renderSexp, (<+>))
+             ppr, renderSexp,)
 import qualified Ksc.Lang as L
 import Ksc.LangUtils (GblSymTab, emptyGblST, extendGblST, stInsertFun)
 import qualified Ksc.Prune
@@ -34,6 +34,8 @@ import Data.List (intercalate)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import GHC.Stack (HasCallStack)
+import Text.PrettyPrint ((<+>))
+import qualified Text.PrettyPrint as L
 
 -------------------------------------
 --  The demo driver

--- a/src/ksc/Ksc/Pipeline.hs
+++ b/src/ksc/Ksc/Pipeline.hs
@@ -17,7 +17,7 @@ import Ksc.Traversal (mapAccumLM)
 import Ksc.Lang (Decl, DeclX(DefDecl), DerivedFun(Fun), Derivations(JustFun),
              TDef, Pretty,
              def_fun, displayN, partitionDecls,
-             ppr, renderSexp,)
+             ppr)
 import qualified Ksc.Lang as L
 import Ksc.LangUtils (GblSymTab, emptyGblST, extendGblST, stInsertFun)
 import qualified Ksc.Prune
@@ -294,5 +294,5 @@ genFuthark files file = do
   putStrLn $ "ksc: Writing to " ++ futfile
   Ksc.Cgen.createDirectoryWriteFile futfile $
     intercalate "\n\n" $
-    prelude : map (renderSexp . ppr . Ksc.Futhark.toFuthark) defs
+    prelude : map (L.render . ppr . Ksc.Futhark.toFuthark) defs
   where futfile = "obj/" ++ file ++ ".fut"

--- a/src/ksc/Ksc/Prim.hs
+++ b/src/ksc/Ksc/Prim.hs
@@ -12,6 +12,7 @@ import Ksc.LangUtils (isTrivial)
 import GHC.Stack (HasCallStack)
 import Data.Maybe (isJust)
 import Control.Monad (zipWithM)
+import Text.PrettyPrint (($$), (<+>), text, vcat)
 
 --------------------------------------------
 --  Simple call construction

--- a/src/ksc/Ksc/Prune.hs
+++ b/src/ksc/Ksc/Prune.hs
@@ -9,7 +9,7 @@
 
 module Ksc.Prune where
 
-import Ksc.Lang hiding ((<>), empty)
+import Ksc.Lang
 import Data.Maybe (mapMaybe)
 import Data.Set
 import Data.Map (fromList, lookup, Map)

--- a/src/ksc/Ksc/SUF.hs
+++ b/src/ksc/Ksc/SUF.hs
@@ -10,7 +10,7 @@
 
 module Ksc.SUF where
 
-import           Ksc.Lang hiding ((<>))
+import           Ksc.Lang
 import           Ksc.LangUtils (notInScopeTV)
 import           Ksc.Prim
 

--- a/src/ksc/Ksc/SUF/AD.hs
+++ b/src/ksc/Ksc/SUF/AD.hs
@@ -20,6 +20,8 @@ import qualified Data.Set as S
 import           Data.Maybe (mapMaybe)
 import           Data.Traversable (mapAccumL)
 
+import Text.PrettyPrint ((<+>), text)
+
 type SUFFwdRevPass =
   GblSymTab
   -- ^ Global symbol table, only used for looking up the

--- a/src/ksc/Ksc/Test.hs
+++ b/src/ksc/Ksc/Test.hs
@@ -14,6 +14,7 @@ import qualified System.Directory
 import qualified System.FilePath
 import Test.Hspec (Spec)
 import Test.Hspec.Runner (isSuccess, runSpec, defaultConfig)
+import Text.PrettyPrint (render)
 
 import Control.Monad (when)
 
@@ -79,7 +80,7 @@ testRoundTrip ksFiles = do
     original <- readFile ksFile
 
     let render :: InPhase p => [DeclX p] -> String
-        render = unlines . map (renderSexp . ppr)
+        render = unlines . map (Text.PrettyPrint.render . ppr)
 
         parsedE = parseE original
 


### PR DESCRIPTION
Perhaps somewhat controversial, but we don't use the infix ks syntax except for occasional diagnostic messages.  There's no parser for it. I think it's much less confusing to just maintain a single pretty printer.

(based on https://github.com/microsoft/knossos-ksc/pull/1053)
