### PR TITLE
Bump jaxlib

### DIFF
--- a/test/builds/build_and_test_mnistcnn.sh
+++ b/test/builds/build_and_test_mnistcnn.sh
@@ -11,7 +11,7 @@ build_pybind11_module $KNOSSOS $PYBIND11 $MODULE_NAME $CPP_FILE
 
 echo Installing JAX...
 
-python3 -m pip install jax==0.1.57 jaxlib==0.1.41
+python3 -m pip install jax==0.1.57 jaxlib==0.1.60
 
 KSCPY=$KNOSSOS/src/python
 PYTHONPATH=$OBJ:$KSCPY python3 -m ksc.mnist.test

--- a/test/builds/test_pytest.sh
+++ b/test/builds/test_pytest.sh
@@ -2,7 +2,7 @@ set -e
 
 echo Installing dependencies...
 python3 -m pip install -r src/python/requirements.txt -f https://download.pytorch.org/whl/torch_stable.html
-python3 -m pip install pytest numpy torch==1.9.0+cu111 jax==0.1.57 jaxlib==0.1.41 -f https://download.pytorch.org/whl/torch_stable.html
+python3 -m pip install pytest numpy torch==1.9.0+cu111 jax==0.1.57 jaxlib==0.1.60 -f https://download.pytorch.org/whl/torch_stable.html
 
 echo Running pytest '(+ doctest)'
 python3 -m pytest test/python --doctest-modules src/python/ksc/path.py

--- a/test/builds/test_resnet50.sh
+++ b/test/builds/test_resnet50.sh
@@ -4,7 +4,7 @@ set -e
 
 echo Installing dependencies...
 
-python3 -m pip install -U Pillow jax==0.1.57 jaxlib==0.1.41
+python3 -m pip install -U Pillow jax==0.1.57 jaxlib==0.1.60
 
 export PYTHONPATH="./src/python"
 


### PR DESCRIPTION
because 0.1.60 is now the oldest version that is available on PyPI

(same as in https://github.com/microsoft/knossos-ksc/pull/1008)