### PR TITLE
Fix sqrl compile failure

### DIFF
--- a/.github/workflows/benchmark.sh
+++ b/.github/workflows/benchmark.sh
@@ -1,7 +1,9 @@
+set -e
+
 echo Installing dependencies...
 python3 -m pip install \
     -r src/python/requirements.txt \
     -r src/bench/requirements.txt \
     -f https://download.pytorch.org/whl/torch_stable.html
 
-sh ./src/bench/run-all-pytest-bench.sh
+sh -e ./src/bench/run-all-pytest-bench.sh

--- a/src/python/ksc/cgen.py
+++ b/src/python/ksc/cgen.py
@@ -391,7 +391,7 @@ torch::Tensor {cpp_function_name}({join_args(lambda k: f'torch::Tensor arg{k}')}
     auto [{ks_sizes}] = ret0.size();
     auto ret = torch::empty({{n, {ks_sizes}}});
     
-    // And wrap it in ks - this is a view of the torch data, so convert_argument, not convert_return_value
+    // And wrap it in ks - this is a view of the torch data
     auto ks_ret = convert_to_ks_viewing_tensordata<ks::tensor<{ks_return_dim}, Float>>(ret);
 
     // Place 0th value in the output


### PR DESCRIPTION
At #968, sqrl was failing tests because of a compilation failure, which wasn't caught because the shell script running multiple calls to pytest did not fail when one call failed.  This PR
1. Makes github workflow benchmarks fail when one fails
2. Fixes the compilation issue
