### PR TITLE
Remove ksc publish

### DIFF
--- a/test/builds/build_and_test.yml
+++ b/test/builds/build_and_test.yml
@@ -80,9 +80,9 @@ jobs:
     displayName: 'Twine Authenticate'
     inputs:
       artifactFeed: Knossos/Knossos # <Project Name>/<Feed Name>
-  - script: |
-      python -m twine upload -r "Knossos" --skip-existing --config-file $(PYPIRC_PATH) ./src/python/dist/*.whl --verbose
-    displayName: Publishing ksc python package
+# - script: |
+#     python -m twine upload -r "Knossos" --skip-existing --config-file $(PYPIRC_PATH) ./src/python/dist/*.whl --verbose
+#   displayName: Publishing ksc python package
 
   - script: rm -rf *
     displayName: 'Clean'


### PR DESCRIPTION
Don't publish ksc on all PRs.  
We don't even pip install it on most builds.